### PR TITLE
The Issue List dialog is not properly centered

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -5,6 +5,7 @@ module api.ui.dialog {
     import ResponsiveRanges = api.ui.responsive.ResponsiveRanges;
     import Element = api.dom.Element;
     import ResponsiveManager = api.ui.responsive.ResponsiveManager;
+    import Body = api.dom.Body;
     import i18n = api.util.i18n;
 
     export interface ConfirmationConfig {
@@ -109,7 +110,7 @@ module api.ui.dialog {
         }
 
         private initListeners() {
-            ResponsiveManager.onAvailableSizeChanged(this, () => this.centerMyself());
+            ResponsiveManager.onAvailableSizeChanged(Body.get(), () => this.centerMyself());
 
             // Set the ResponsiveRanges on first show() call
             const firstTimeResize = () => {
@@ -282,18 +283,16 @@ module api.ui.dialog {
             const el = this.getEl();
             el.setMarginTop(`-${ el.getHeightWithBorder() / 2 }px`);
 
-            if (ResponsiveRanges._540_720.isFitOrBigger(this.getEl().getWidthWithBorder())) {
+            if (ResponsiveRanges._540_720.isFitOrBigger(Body.get().getEl().getWidthWithBorder())) {
                 this.centerHorisontally();
             } else {
                 el.setMarginLeft('0px');
-                el.removeClass('centered_horizontally');
             }
         }
 
         centerHorisontally() {
             const el = this.getEl();
             el.setMarginLeft(`-${ el.getWidthWithBorder() / 2 }px`);
-            el.addClass('centered_horizontally');
         }
 
         getButtonRow(): ButtonRow {

--- a/src/main/resources/assets/admin/common/styles/api/ui/dialog/modal-dialog.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/dialog/modal-dialog.less
@@ -151,36 +151,6 @@
     margin-left: 11px;
   }
 
-  &._0-240, &._240-360, &._360-540 {
-    box-sizing: content-box;
-  }
-
-  &._0-240, &._240-360 {
-    margin: 0;
-    padding-left: 2%;
-    padding-right: 2%;
-    width: 96%;
-  }
-
-  &._360-540 {
-    margin: 0;
-    padding-left: 3%;
-    padding-right: 3%;
-    width: 94%;
-  }
-
-  &._540-720 {
-    margin-left: 10px;
-    margin-right: 10px;
-    padding-left: 30px;
-    padding-right: 30px;
-    width: 80.185%;
-  }
-
-  &.centered_horizontally {
-    left: 50%;
-  }
-
   .input-view .edit {
     display: none;
   }
@@ -232,4 +202,35 @@ body {
       }
     }
   }
+
+  &._0-240 .@{_COMMON_PREFIX}modal-dialog, &._240-360 .@{_COMMON_PREFIX}modal-dialog {
+    margin: 0;
+    padding-left: 2%;
+    padding-right: 2%;
+    width: 96%;
+    box-sizing: content-box;
+  }
+
+  &._360-540 .@{_COMMON_PREFIX}modal-dialog {
+    margin: 0;
+    padding-left: 3%;
+    padding-right: 3%;
+    width: 94%;
+    box-sizing: content-box;
+  }
+
+  &._540-720 .@{_COMMON_PREFIX}modal-dialog {
+    margin-left: 10px;
+    margin-right: 10px;
+    padding-left: 30px;
+    padding-right: 30px;
+    width: 80.185%;
+  }
+
+  @media screen and (min-width: 541px) {
+    .@{_COMMON_PREFIX}modal-dialog {
+      left: 50%;
+    }
+  }
+
 }


### PR DESCRIPTION
-Problem is actual for ALL modal dialogs
-Issue origin: modal dialog when added to responsive manager can have different classes like _360-540, _540-720 etc; switching this classes changes modal dialog's width that immediately makes it belong to other resposive class, thus when changing viewport size you may see dialog changing it's width according to responsive class applied
-Fixed by making modal dialog styling  depend on body size