### PR TITLE
Invalid layout inside the macro dialog when a tall image is loaded in…

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/src/main/resources/assets/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -23,7 +23,6 @@ module api.content.form.inputtype.image {
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     import ContentInputTypeManagingAdd = api.content.form.inputtype.ContentInputTypeManagingAdd;
-    import SelectedOptionsView = api.ui.selector.combobox.SelectedOptionsView;
     import StringHelper = api.util.StringHelper;
     import ImageSelectorDisplayValue = api.content.image.ImageSelectorDisplayValue;
     import ImageSelectorSelectedOptionsView = api.content.image.ImageSelectorSelectedOptionsView;

--- a/src/main/resources/assets/admin/common/js/content/image/ImageSelectorSelectedOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/ImageSelectorSelectedOptionView.ts
@@ -1,6 +1,7 @@
 module api.content.image {
 
     import LoadMask = api.ui.mask.LoadMask;
+    import ResponsiveManager = api.ui.responsive.ResponsiveManager;
 
     export class ImageSelectorSelectedOptionView
         extends api.ui.selector.combobox.BaseSelectedOptionView<ImageTreeSelectorItem> {
@@ -98,6 +99,8 @@ module api.content.image {
                 if (this.getOption().displayValue.getContentSummary()) {
                     this.showResult();
                 }
+
+                ResponsiveManager.fireResizeEvent();
             });
 
             return wemQ(true);

--- a/src/main/resources/assets/admin/common/js/content/image/ImageSelectorSelectedOptionsView.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/ImageSelectorSelectedOptionsView.ts
@@ -2,7 +2,6 @@ module api.content.image {
 
     import Option = api.ui.selector.Option;
     import SelectedOption = api.ui.selector.combobox.SelectedOption;
-    import Tooltip = api.ui.Tooltip;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ImageSelectorSelectedOptionsView
@@ -125,12 +124,9 @@ module api.content.image {
                 this.notifyOptionSelected(new SelectedOptionEvent(selectedOption, keyCode));
             }
 
-            // tslint:disable-next-line:no-unused-new
-            new Tooltip(optionView, isMissingContent
+            optionView.getEl().setAttribute('title', isMissingContent
                 ? option.value
-                : option.displayValue.getPath()
-                                        ? option.displayValue.getPath().toString()
-                                        : '', 1000);
+                : option.displayValue.getPath() ? option.displayValue.getPath().toString() : '');
         }
 
         updateUploadedOption(option: Option<ImageTreeSelectorItem>) {

--- a/src/main/resources/assets/admin/common/styles/api/util/htmlarea/macro-dialog.less
+++ b/src/main/resources/assets/admin/common/styles/api/util/htmlarea/macro-dialog.less
@@ -19,6 +19,17 @@
       .@{_COMMON_PREFIX}wrapper {
         height: 41px;
       }
+
+      margin-bottom: 4.5%;
+
+      &:after {
+        padding-bottom: 0px;
+
+      }
+
+      .squared-content {
+        position: static;
+      }
     }
   }
 


### PR DESCRIPTION
…to the form #29

-Styling of ImageSelector was broken in macro modal dialog; Adjusted styling so no margin on the top and bottom, selected image remains centered horizontally;