### PR TITLE
IE11: Content Studio is blank #74

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
+++ b/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
@@ -1,6 +1,6 @@
 module api.form {
 
-    import ArrayHelper = api.util.ArrayHelper;
+
 
     export class ValidationRecording {
 
@@ -168,23 +168,14 @@ module api.form {
                 return false;
             }
 
-            const keys = mapA.keys();
-            let result: IteratorResult<string>;
+            const keys: string[] = [];
+            mapA.forEach((value: KeyBinding, key: string) => {
+                keys.push(key);
+            });
 
-            do {
-                result = keys.next();
-
-                if (!result.done) {
-                    const key: string = result.value;
-
-                    if (!mapA.get(key).equals(mapB.get(key))) {
-                        return false;
-                    }
-                }
-
-            } while (!result.done);
-
-            return true;
+            return keys.every(key => {
+                return mapA.get(key).equals(mapB.get(key));
+            });
         }
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
+++ b/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
@@ -169,7 +169,7 @@ module api.form {
             }
 
             const keys: string[] = [];
-            mapA.forEach((value: KeyBinding, key: string) => {
+            mapA.forEach((value: Equitable, key: string) => {
                 keys.push(key);
             });
 

--- a/src/main/resources/assets/admin/common/js/ui/KeyBindings.ts
+++ b/src/main/resources/assets/admin/common/js/ui/KeyBindings.ts
@@ -89,12 +89,7 @@ module api.ui {
         }
 
         public getActiveBindings(): KeyBinding[] {
-            const activeBindings: KeyBinding[] = [];
-            this.activeBindings.forEach((value: KeyBinding) => {
-                activeBindings.push(value);
-            });
-
-            return activeBindings;
+            return this.toArray(this.activeBindings);
         }
 
         /*
@@ -119,11 +114,7 @@ module api.ui {
                 });
 
                 if (curBindings.size > 0) {
-                    const curBindingsValues: KeyBinding[] = [];
-                    curBindings.forEach((value: KeyBinding) => {
-                        curBindingsValues.push(value);
-                    });
-                    this.unbindKeys(curBindingsValues);
+                    this.unbindKeys(this.toArray(curBindings));
                     this.shelves.push(curBindings);
                 }
             }
@@ -156,10 +147,7 @@ module api.ui {
                 this.activeBindings.clear();
                 Mousetrap.reset();
 
-                const previousBindings: KeyBinding[] = [];
-                previousMousetraps.forEach((value: KeyBinding) => {
-                    previousBindings.push(value);
-                });
+                const previousBindings: KeyBinding[] = this.toArray(previousMousetraps);
 
                 previousBindings.forEach((previousBinding) => {
                     this.bindKey(previousBinding);
@@ -187,10 +175,7 @@ module api.ui {
         }
 
         isActive(keyBinding: KeyBinding) {
-            const activeBindings: KeyBinding[] = [];
-            this.activeBindings.forEach((value: KeyBinding) => {
-                activeBindings.push(value);
-            });
+            const activeBindings: KeyBinding[] = this.toArray(this.activeBindings);
 
             return activeBindings.some((curBinding: KeyBinding) => {
                 return curBinding == keyBinding ? true : false;
@@ -222,6 +207,16 @@ module api.ui {
             this.helpKeyPressedListeners.forEach((listener: (event: ExtendedKeyboardEvent) => void) => {
                 listener.call(this, e);
             });
+        }
+
+        private toArray(bindings: Map<string, KeyBinding>): KeyBinding[] {
+            const result: KeyBinding[] = [];
+
+            bindings.forEach((value: KeyBinding) => {
+                result.push(value);
+            });
+
+            return result;
         }
     }
 }

--- a/src/main/resources/assets/admin/common/js/ui/KeyBindings.ts
+++ b/src/main/resources/assets/admin/common/js/ui/KeyBindings.ts
@@ -1,6 +1,6 @@
 module api.ui {
 
-    import ArrayHelper = api.util.ArrayHelper;
+
     export class KeyBindings {
 
         private static instanceCount: number = 0;
@@ -89,7 +89,12 @@ module api.ui {
         }
 
         public getActiveBindings(): KeyBinding[] {
-            return Array.from(this.activeBindings.values());
+            const activeBindings: KeyBinding[] = [];
+            this.activeBindings.forEach((value: KeyBinding) => {
+                activeBindings.push(value);
+            });
+
+            return activeBindings;
         }
 
         /*
@@ -114,7 +119,11 @@ module api.ui {
                 });
 
                 if (curBindings.size > 0) {
-                    this.unbindKeys(Array.from(curBindings.values()));
+                    const curBindingsValues: KeyBinding[] = [];
+                    curBindings.forEach((value: KeyBinding) => {
+                        curBindingsValues.push(value);
+                    });
+                    this.unbindKeys(curBindingsValues);
                     this.shelves.push(curBindings);
                 }
             }
@@ -147,7 +156,10 @@ module api.ui {
                 this.activeBindings.clear();
                 Mousetrap.reset();
 
-                const previousBindings = Array.from(previousMousetraps.values());
+                const previousBindings: KeyBinding[] = [];
+                previousMousetraps.forEach((value: KeyBinding) => {
+                    previousBindings.push(value);
+                });
 
                 previousBindings.forEach((previousBinding) => {
                     this.bindKey(previousBinding);
@@ -157,7 +169,10 @@ module api.ui {
             } else {
                 const keys = keyBindings.map(binding => this.getBindingKey(binding));
 
-                const previousKeys = Array.from(previousMousetraps.keys());
+                const previousKeys: string[] = [];
+                previousMousetraps.forEach((value: KeyBinding, key: string) => {
+                    previousKeys.push(key);
+                });
 
                 previousKeys.forEach((previousKey) => {
                     if (keys.indexOf(previousKey) >= 0) {
@@ -172,7 +187,10 @@ module api.ui {
         }
 
         isActive(keyBinding: KeyBinding) {
-            const activeBindings: KeyBinding[] = Array.from(this.activeBindings.values());
+            const activeBindings: KeyBinding[] = [];
+            this.activeBindings.forEach((value: KeyBinding) => {
+                activeBindings.push(value);
+            });
 
             return activeBindings.some((curBinding: KeyBinding) => {
                 return curBinding == keyBinding ? true : false;


### PR DESCRIPTION
-IE11 does not support iteration features of Map, in particular values() and keys() trigger errors in IE11; replaced with valid alternatives