### PR TITLE
Users App - second tabItem is getting not clickable, when the first t…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/tab/TabMenu.ts
+++ b/src/main/resources/assets/admin/common/js/ui/tab/TabMenu.ts
@@ -288,7 +288,7 @@ module api.ui.tab {
             } else if (tab.getIndex() < this.selectedTab) {
                 // if removed tab was before selected tab than decrement selected index
                 this.selectedTab--;
-            } else if (tab.getIndex() > this.getSize() - 1 && this.selectedTab !== 0) {
+            } else if (tab.getIndex() > this.getSize() - 1 && this.selectedTab > 0) {
                 // if selected index is more than tabs amount set last index as selected
                 this.selectedTab = this.getSize() - 1;
             }


### PR DESCRIPTION
…ab was closed after the deleting of user #79

Fixed `selectedTab` value update, when nothing was selected for indexes of `-1` and `0`.