### PR TITLE
Implement image preview in Image Selector in desktop resolution #129

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/image/ImageContentComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/ImageContentComboBox.ts
@@ -5,6 +5,7 @@ module api.content.image {
     import ContentTypeName = api.schema.content.ContentTypeName;
     import OptionDataHelper = api.ui.selector.OptionDataHelper;
     import ComboBox = api.ui.selector.combobox.ComboBox;
+    import ElementHelper = api.dom.ElementHelper;
 
     export class ImageContentComboBox
         extends ContentComboBox<ImageTreeSelectorItem> {
@@ -18,7 +19,28 @@ module api.content.image {
 
             super(builder);
 
-            this.addClass('image-combo-box');
+            this.addClass('image-combobox');
+
+            this.initImagePreview();
+        }
+
+        private initImagePreview() {
+            const preview = new ImageContentPreview();
+
+            this.onMouseOver((e: MouseEvent) => {
+                const helper = new ElementHelper((<HTMLElement>e.target));
+                if (this.isThumbnailImage(helper)) {
+                    preview.showFor(helper);
+                }
+            });
+
+            preview.onSelected((id: string) => {
+                this.selectOptionByValue(id);
+            });
+        }
+
+        private isThumbnailImage(helper: ElementHelper): boolean {
+            return helper.getTagName().toLowerCase() == 'img' && helper.hasAttribute('data-contentid');
         }
 
         getContent(contentId: ContentId): ContentSummary {

--- a/src/main/resources/assets/admin/common/js/content/image/ImageContentPreview.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/ImageContentPreview.ts
@@ -1,0 +1,151 @@
+module api.content.image {
+
+    import Element = api.dom.Element;
+    import ElementHelper = api.dom.ElementHelper;
+    import ImgEl = api.dom.ImgEl;
+    import ContentImageUrlResolver = api.content.util.ContentImageUrlResolver;
+    import LoadMask = api.ui.mask.LoadMask;
+
+    export class ImageContentPreview
+        extends api.dom.DivEl {
+
+        private static PADDING: number = 20;
+        private static TIMEOUT: number = 300;
+
+        public static debug: boolean = true;
+
+        private image: ImgEl;
+
+        private thumb: ElementHelper;
+
+        private mask: LoadMask;
+
+        private resolver: api.content.util.ContentImageUrlResolver;
+
+        private timeout: number;
+
+        private selectListeners: { (id: string): void }[] = [];
+
+        constructor() {
+            super('image-content-preview');
+            this.resolver = new ContentImageUrlResolver();
+            this.image = new ImgEl();
+            this.image.onLoaded(() => {
+                this.mask.hide();
+                if (!this.image.isPlaceholder()) {
+                    this.positionFor(this.thumb);
+                }
+            });
+            this.mask = new LoadMask(this);
+            this.appendChildren<Element>(this.image, this.mask);
+
+            this.onMouseOver((e: MouseEvent) => this.clearTimeout());
+            this.onMouseOut((e: MouseEvent) => this.delayHide());
+            this.onClicked((e: MouseEvent) => {
+                this.notifySelected(this.thumb.getAttribute('data-contentid'));
+                this.hide();
+            });
+        }
+
+        private notifySelected(id: string) {
+            this.selectListeners.forEach(listener => listener(id));
+        }
+
+        onSelected(listener: (id: string) => void) {
+            this.selectListeners.push(listener);
+        }
+
+        unSelected(listener: (id: string) => void) {
+            this.selectListeners = this.selectListeners.filter(item => item !== listener);
+        }
+
+        showFor(img: ElementHelper) {
+            if (ImageContentPreview.debug) {
+                console.debug('ImageContentPreview.showFor:', img);
+            }
+            this.clearTimeout();
+
+            if (!this.isVisible()) {
+                api.dom.Body.get().appendChild(this);
+            }
+
+            const imageId = img.getAttribute('data-contentid');
+
+            this.thumb = img;
+            const maxWidth = this.positionFor(img);
+            const biggestSize = this.getBiggestSize(img, maxWidth);
+            this.addClass('shown');
+            const imageUrl = this.resolver.setContentId(new ContentId(imageId)).setSize(biggestSize).resolve();
+            this.image.setSrc(imageUrl);
+            this.mask.show();
+
+            const leaveListener = (outE: MouseEvent) => {
+                img.removeEventListener('mouseout', leaveListener);
+                this.delayHide();
+            };
+
+            img.addEventListener('mouseout', leaveListener);
+        }
+
+        private delayHide() {
+            this.timeout = setTimeout(() => {
+                this.hide();
+                this.timeout = undefined;
+            }, ImageContentPreview.TIMEOUT);
+        }
+
+        private clearTimeout() {
+            if (this.timeout) {
+                clearTimeout(this.timeout);
+                this.timeout = undefined;
+            }
+        }
+
+        private getBiggestSize(img: ElementHelper, maxWidth: number): number {
+            const imgDims = img.getDimensions();
+            // multiply width by height/width ratio if it's bigger than 1
+            const ratio = imgDims.height / imgDims.width;
+            return ratio > 1 ? Math.floor(maxWidth * ratio) : maxWidth;
+        }
+
+        private positionFor(img: ElementHelper) {
+            if (ImageContentPreview.debug) {
+                console.debug('ImageContentPreview.positionFor:', img);
+            }
+
+            const imgDims = img.getDimensions();
+            const bodyDims = api.dom.Body.get().getEl().getDimensions();
+            const el = this.getEl();
+            const previewDims = el.getDimensions();
+
+            const leftSpace = imgDims.left - ImageContentPreview.PADDING;
+            const leftSide = Math.max(leftSpace - previewDims.width, 0);
+            const rightSide = Math.min(imgDims.left + imgDims.width + ImageContentPreview.PADDING, bodyDims.width - previewDims.width);
+            const rightSpace = bodyDims.width - rightSide;
+
+            const topSpace = imgDims.top - ImageContentPreview.PADDING;
+            const topSide = topSpace - (previewDims.height - imgDims.height) / 2;
+
+            el.setLeftPx(leftSpace > rightSpace ? leftSide : rightSide).setTopPx(Math.max(topSide, 0));
+            return Math.max(leftSpace, rightSpace);
+        }
+
+        hide() {
+            if (ImageContentPreview.debug) {
+                console.debug('ImageContentPreview.hide: starting animation', this.thumb);
+            }
+            this.removeClass('shown');
+            this.thumb = undefined;
+            setTimeout(() => {
+                if (ImageContentPreview.debug) {
+                    console.debug('ImageContentPreview.hide: animation finished, removing from dom');
+                }
+                // mouse might have returned during animation time
+                if (!this.thumb) {
+                    this.image.setSrc(ImgEl.PLACEHOLDER);
+                    api.dom.Body.get().removeChild(this);
+                }
+            }, ImageContentPreview.TIMEOUT);
+        }
+    }
+}

--- a/src/main/resources/assets/admin/common/js/content/image/ImageSelectorViewer.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/ImageSelectorViewer.ts
@@ -7,6 +7,12 @@ module api.content.image {
             super();
         }
 
+        doLayout(object: api.content.image.ImageTreeSelectorItem): any {
+            super.doLayout(object);
+
+            this.getNamesAndIconView().getIconImageEl().getEl().setAttribute('data-contentid', object.getContentId().toString());
+        }
+
         resolveDisplayName(object: ImageTreeSelectorItem): string {
             return object.getDisplayName();
         }

--- a/src/main/resources/assets/admin/common/js/content/image/_module.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/_module.ts
@@ -4,6 +4,7 @@
 ///<reference path='ImageSelectorDisplayValue.ts' />
 ///<reference path='ImageContentComboBox.ts' />
 ///<reference path='ImageSelectorViewer.ts' />
+///<reference path='ImageContentPreview.ts' />
 ///<reference path='ImageSelectorSelectedOptionsView.ts' />
 ///<reference path='ImageSelectorSelectedOptionView.ts' />
 ///<reference path='SelectionToolbar.ts' />

--- a/src/main/resources/assets/admin/common/js/dom/FormEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/FormEl.ts
@@ -21,10 +21,10 @@ module api.dom {
         }
 
         static getNextFocusable(input: Element, focusableSelector?: string, ignoreTabIndex?: boolean): Element {
-            let focusableElements: NodeList = document.querySelectorAll(focusableSelector ? focusableSelector : 'input, button, select');
+            const focusableElements: NodeList = document.querySelectorAll(focusableSelector ? focusableSelector : 'input, button, select');
 
             // find index of current input
-            let index = FormEl.getIndexOfInput(focusableElements, input);
+            const index = FormEl.getIndexOfInput(focusableElements, input);
 
             if (index < 0) {
                 return;
@@ -53,11 +53,12 @@ module api.dom {
             }
         }
 
-        static moveFocusToPrevFocusable(input: Element, focusableSelector?: string) {
-            let focusableElements: NodeList = document.querySelectorAll(focusableSelector ? focusableSelector : 'input, button, select');
+        static getPrevFocusable(input: Element, focusableSelector?: string, ignoreTabIndex?: boolean): Element {
+            const focusableElements: NodeList = document.querySelectorAll(focusableSelector ? focusableSelector : 'input, button, select');
 
             // find index of current input
             let index = FormEl.getIndexOfInput(focusableElements, input);
+
             let nextFocusable: api.dom.Element;
 
             do {
@@ -66,8 +67,16 @@ module api.dom {
                     nextFocusable = api.dom.Element.fromHtmlElement(<HTMLElement>focusableElements.item(index));
                 }
             } while (nextFocusable.getEl().getTabIndex() && nextFocusable.getEl().getTabIndex() < 0);
-            nextFocusable.giveFocus();
-            return;
+
+            return nextFocusable;
+        }
+
+        static moveFocusToPrevFocusable(input: Element, focusableSelector?: string) {
+            const prevFocusable = FormEl.getPrevFocusable(input, focusableSelector);
+
+            if (prevFocusable) {
+                prevFocusable.giveFocus();
+            }
         }
 
         private static getIndexOfInput(elements: NodeList, el: Element) {

--- a/src/main/resources/assets/admin/common/js/ui/Action.ts
+++ b/src/main/resources/assets/admin/common/js/ui/Action.ts
@@ -127,12 +127,13 @@ module api.ui {
             return this.visible;
         }
 
-        setVisible(value: boolean) {
+        setVisible(value: boolean): Action {
 
             if (value !== this.visible) {
                 this.visible = value;
                 this.notifyPropertyChanged();
             }
+            return this;
         }
 
         getIconClass(): string {

--- a/src/main/resources/assets/admin/common/js/ui/menu/TreeMenuItem.ts
+++ b/src/main/resources/assets/admin/common/js/ui/menu/TreeMenuItem.ts
@@ -23,6 +23,7 @@ module api.ui.menu {
                 }
             });
             this.setEnabled(action.isEnabled());
+            this.setVisible(action.isVisible());
 
             action.onPropertyChanged((changedAction: api.ui.Action) => {
                 this.setEnabled(changedAction.isEnabled());
@@ -45,14 +46,15 @@ module api.ui.menu {
             return this.action;
         }
 
+        setVisible(value: boolean) {
+            this.toggleClass('expanded', value);
+            return this;
+        }
+
         setEnabled(value: boolean) {
-            let el = this.getEl();
-            el.setDisabled(!value);
-            if (value) {
-                el.removeClass('disabled');
-            } else {
-                el.addClass('disabled');
-            }
+            this.getEl()
+                .setDisabled(!value)
+                .toggleClass('disabled', !value);
         }
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/selector/OptionsFactory.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/OptionsFactory.ts
@@ -18,9 +18,14 @@ module api.ui.selector {
         }
 
         createOptions(data: OPTION_DISPLAY_VALUE[]): wemQ.Promise<Option<OPTION_DISPLAY_VALUE>[]> {
-            return this.loader.checkReadonly(data).then((readonlyIds: string[]) => {
-                return data.map((item) => this.createOption(item, this.isOptionReadonly(item, readonlyIds)));
-            });
+            if (this.readonlyChecker) {
+                return this.loader.checkReadonly(data).then((readonlyIds: string[]) => {
+                    return data.map((item) => this.createOption(item, this.isOptionReadonly(item, readonlyIds)));
+                });
+            } else {
+                return wemQ(data.map((item) => this.createOption(item)));
+            }
+
         }
 
         createOption(data: OPTION_DISPLAY_VALUE, isReadonly: boolean = false): Option<OPTION_DISPLAY_VALUE> {

--- a/src/main/resources/assets/admin/common/styles/api/content/image/image-content-preview.less
+++ b/src/main/resources/assets/admin/common/styles/api/content/image/image-content-preview.less
@@ -1,0 +1,21 @@
+.image-content-preview {
+  position: absolute;
+  z-index: @z-index-context-window;
+  background: #eee;
+  opacity: 0;
+  transition: transform .3s ease-out, opacity .3s ease-out;
+  transform: translateY(10%);
+
+  &.shown {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+
+  img {
+    min-width: 200px;
+    min-height: 200px;
+
+    transition-duration: .3s;
+    transition-property: all;
+  }
+}

--- a/src/main/resources/assets/admin/common/styles/api/content/image/image-content-preview.less
+++ b/src/main/resources/assets/admin/common/styles/api/content/image/image-content-preview.less
@@ -3,8 +3,9 @@
   z-index: @z-index-context-window;
   background: #eee;
   opacity: 0;
-  transition: transform .3s ease-out, opacity .3s ease-out;
+  transition: all .3s ease-out;
   transform: translateY(10%);
+  overflow: auto;
 
   &.shown {
     opacity: 1;
@@ -12,10 +13,8 @@
   }
 
   img {
-    min-width: 200px;
-    min-height: 200px;
-
-    transition-duration: .3s;
-    transition-property: all;
+    min-width: 500px;
+    margin: 0;
+    border: 0 none;
   }
 }

--- a/src/main/resources/assets/admin/common/styles/api/ui/menu/context-menu.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/menu/context-menu.less
@@ -3,20 +3,29 @@
   z-index: @z-index-context-menu;
   position: absolute;
 
-  dt.collapsible {
-    &:after {
-      content: "";
-      position: absolute;
-      left: 90%;
-      border-left: 4px solid transparent;
-      border-right: 4px solid transparent;
-      margin-top: 5px;
-      border-top: 7px solid @admin-dark-gray;
+  dt {
+    &:not(.collapsible) {
+      display: none;
+      &.expanded {
+        display: block;
+      }
     }
 
-    &.expanded:after {
-      border-top: none;
-      border-bottom: 7px solid @admin-dark-gray;
+    &.collapsible {
+      &:after {
+        content: "";
+        position: absolute;
+        left: 90%;
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        margin-top: 5px;
+        border-top: 7px solid @admin-dark-gray;
+      }
+
+      &.expanded:after {
+        border-top: none;
+        border-bottom: 7px solid @admin-dark-gray;
+      }
     }
   }
 

--- a/src/main/resources/assets/admin/common/styles/styles.less
+++ b/src/main/resources/assets/admin/common/styles/styles.less
@@ -128,6 +128,7 @@
 @import "api/content/file-uploader";
 @import "api/content/media-uploader";
 @import "api/content/attachment-item";
+@import "api/content/image/image-content-preview";
 
 // api application
 @import "api/application/inputtype/siteconfigurator/site-configurator";


### PR DESCRIPTION
- automatically choses side of the picture with which has more space
- preview scales to occupy all available size as long as there are more than 500px available
- preview doesn't shrink less than 500px and overlays the thumb in that case
- it also doesn't go beyond page boundaries and shows scrollbars in that case