### PR TITLE
Fix build problems on Concourse for lib-admin-ui. #85

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,16 @@ task gulpAll( type: GulpTask, dependsOn: npmInstall ) {
     args = ['all']
 }
 
-task copyTypeDefs( type: Copy, dependsOn: gulpAll ) {
+task copyCompiled( type: Copy, dependsOn: gulpAll ) {
+    description = 'Copy compiled js files.'
+    from( 'src/main/resources/assets' ) {
+        include '**/_all.js*'
+    }
+    into 'build/resources/main/assets'
+    includeEmptyDirs = false
+}
+
+task copyTypeDefs( type: Copy, dependsOn: copyCompiled ) {
     description = 'Copy Typescript definitions to /dev/d.ts folder.'
     from( 'src/main/resources/assets/admin/common/js' ) {
         include '**/*.d.ts'
@@ -64,18 +73,12 @@ task copySharedStyles( type: Copy, dependsOn: copyTypeDefs ) {
     into 'build/resources/main/dev'
 }
 
-task list( type: Exec ) {
-    executable "sh"
-    args "-c", "find ./build ./src -type f -name '_all*' -print"
-}
-
 jar {
     exclude 'assets/spec/**'
     exclude 'assets/**/*.ts'    // let dev/**/admin.d.ts through to be used by other apps
     exclude 'assets/**/*.less'  // let dev/**/*.less through to be used by other apps
     includeEmptyDirs = false
     dependsOn += copySharedStyles
-    dependsOn += list
 }
 
 task cleanNode( type: Delete ) {


### PR DESCRIPTION
Fixed the problem of the compiled JS not present under the build folder, since `:processResources` task executes before the `gulpAll`.

**Comments on the problem:**
_When you run `gradle clean` locally it will only remove the `build/` folder. Our compiled files are placed under the `src/main/resources/**/common/js/` folder. They won't be removed with clean build. So the problem will occur even on local machine, if you have run the `gradle build` for the first time on newly cloned repo.
And the problem is that the `:processResources` task that copies all the source resources to `build/resources` runs before the `gulpAll` task, that compiles `.ts` and libs to `_all.js` files._