### PR TITLE
Enable discarding new unsaved content #138

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
@@ -839,6 +839,10 @@ module api.app.wizard {
         isValid() {
             return this.validityManager.isAllValid();
         }
+
+        isNew(): boolean {
+            return this.formState.isNew();
+        }
     }
 
     export class FormState {

--- a/src/main/resources/assets/admin/common/js/dom/Element.ts
+++ b/src/main/resources/assets/admin/common/js/dom/Element.ts
@@ -547,7 +547,9 @@ module api.dom {
             api.util.assertNotNull(child, 'Child element to remove cannot be null');
 
             child.getEl().remove();
-            this.removeChildElement(child);
+            if (this.hasChild(child)) {
+                this.removeChildElement(child);
+            }
 
             return this;
         }

--- a/src/main/resources/assets/admin/common/js/notify/MessageBus.ts
+++ b/src/main/resources/assets/admin/common/js/notify/MessageBus.ts
@@ -1,19 +1,23 @@
 module api.notify {
 
-    export function showSuccess(message: string, autoHide: boolean = true) {
-        NotifyManager.get().showSuccess(message, autoHide);
+    export function showSuccess(message: string, autoHide: boolean = true, instant?: boolean): string {
+        return NotifyManager.get().showSuccess(message, autoHide, instant);
     }
 
-    export function showFeedback(message: string, autoHide: boolean = true) {
-        NotifyManager.get().showFeedback(message, autoHide);
+    export function showFeedback(message: string, autoHide: boolean = true, instant?: boolean): string {
+        return NotifyManager.get().showFeedback(message, autoHide, instant);
     }
 
-    export function showError(message: string, autoHide: boolean = true) {
-        NotifyManager.get().showError(message, autoHide);
+    export function showError(message: string, autoHide: boolean = true, instant?: boolean): string {
+        return NotifyManager.get().showError(message, autoHide, instant);
     }
 
-    export function showWarning(message: string, autoHide: boolean = true) {
-        NotifyManager.get().showWarning(message, autoHide);
+    export function showWarning(message: string, autoHide: boolean = true, instant?: boolean): string {
+        return NotifyManager.get().showWarning(message, autoHide, instant);
+    }
+
+    export function hideNotification(messageId: string, instant?: boolean) {
+        NotifyManager.get().hide(messageId, instant);
     }
 
 }

--- a/src/main/resources/assets/admin/common/js/rest/JsonRequest.ts
+++ b/src/main/resources/assets/admin/common/js/rest/JsonRequest.ts
@@ -12,6 +12,8 @@ module api.rest {
 
         private timeoutMillis: number = 10000;
 
+        private async: boolean = true;
+
         setPath(value: Path): JsonRequest<RAW_JSON_TYPE> {
             this.path = value;
             return this;
@@ -29,6 +31,11 @@ module api.rest {
 
         setTimeout(timeoutMillis: number): JsonRequest<RAW_JSON_TYPE> {
             this.timeoutMillis = timeoutMillis;
+            return this;
+        }
+
+        setAsync(async: boolean): JsonRequest<RAW_JSON_TYPE> {
+            this.async = async;
             return this;
         }
 
@@ -74,8 +81,10 @@ module api.rest {
 
         private prepareGETRequest(request: XMLHttpRequest) {
             let uriString = UriHelper.appendUrlParams(this.path.toString(), this.params);
-            request.open(this.method, UriHelper.getUri(uriString), true);
-            request.timeout = this.timeoutMillis;
+            request.open(this.method, UriHelper.getUri(uriString), this.async);
+            if (this.async) {
+                request.timeout = this.timeoutMillis;
+            }
             request.setRequestHeader('Accept', 'application/json');
             if (api.BrowserHelper.isIE()) {
                 request.setRequestHeader('Pragma', 'no-cache');
@@ -85,8 +94,10 @@ module api.rest {
         }
 
         private preparePOSTRequest(request: XMLHttpRequest) {
-            request.open(this.method, UriHelper.getUri(this.path.toString()), true);
-            request.timeout = this.timeoutMillis;
+            request.open(this.method, UriHelper.getUri(this.path.toString()), this.async);
+            if (this.async) {
+                request.timeout = this.timeoutMillis;
+            }
             request.setRequestHeader('Accept', 'application/json');
             request.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
         }

--- a/src/main/resources/assets/admin/common/js/rest/ResourceRequest.ts
+++ b/src/main/resources/assets/admin/common/js/rest/ResourceRequest.ts
@@ -10,6 +10,8 @@ module api.rest {
 
         private timeoutMillis: number;
 
+        private async: boolean = true;
+
         constructor() {
             this.restPath = Path.fromString(api.util.UriHelper.getRestUri(''));
         }
@@ -38,6 +40,10 @@ module api.rest {
             this.heavyOperation = value;
         }
 
+        setAsync(async: boolean) {
+            this.async = async;
+        }
+
         validate() {
             // Override to ensure any validation of ResourceRequest before sending.
         }
@@ -46,10 +52,12 @@ module api.rest {
 
             this.validate();
 
-            let jsonRequest = new JsonRequest<RAW_JSON_TYPE>().
-                setMethod(this.method).setParams(this.getParams()).setPath(this.getRequestPath()).setTimeout(
-                !this.heavyOperation ? this.timeoutMillis : 0);
-            return jsonRequest.send();
+            return new JsonRequest<RAW_JSON_TYPE>().setMethod(this.method)
+                .setParams(this.getParams())
+                .setPath(this.getRequestPath())
+                .setTimeout(!this.heavyOperation ? this.timeoutMillis : 0)
+                .setAsync(this.async)
+                .send();
         }
 
         sendAndParse(): wemQ.Promise<PARSED_TYPE> {


### PR DESCRIPTION
* Added check support for the newly created content from wizard: `Wizard.isNew()`.
* Added check for element existence, when removing child element.
* Added support for the synchronous request (may be deprecated in most browsers, but still useful in Firefox).
* Added support for instant rendering of notification without animation.
* Added static method for removing notification by id.
* Updated notification `show*` methods to return the id.