### PR TITLE
Fix linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: groovy
-sudo: false
+sudo: required
 
 jdk:
-- oraclejdk8
+  - oraclejdk8
 
-script: ./gradlew build
+script: ./gradlew build --stacktrace --no-daemon
 
 cache:
   directories:

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,19 @@ ext {
     resourcesDir = file( 'src/main/resources' )
 }
 
-task gulpAll( type: GulpTask, dependsOn: npmInstall ) {
-    description = 'Build UI resources (css, etc).'
+task lint( type: GulpTask, dependsOn: npmInstall ) {
+    description = 'Lint the *.ts files.'
+    args = ['lint']
     inputs.files fileTree( dir: 'src/main/resources', exclude: '**/_all.*' )
     outputs.files fileTree( dir: 'src/main/resources', include: '**/_all.*' )
-    args = ['all']
+    outputs.upToDateWhen { false }
+}
+
+task gulpAll( type: GulpTask, dependsOn: lint ) {
+    description = 'Build UI resources (css, etc).'
+    args = ['all:no-lint']
+    inputs.files fileTree( dir: 'src/main/resources', exclude: '**/_all.*' )
+    outputs.files fileTree( dir: 'src/main/resources', include: '**/_all.*' )
 }
 
 task copyCompiled( type: Copy, dependsOn: gulpAll ) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,7 +88,7 @@ gulp.task('lint', function () {
             configuration: path.resolve('./tslint.json')
         }))
         .pipe(tsLint.report({
-            emitError: false
+            emitError: true
         }));
 });
 
@@ -114,4 +114,5 @@ gulp.task('ts', sequence('ts-admin', [/*'ts-live',*/ 'ts-spec']));
 gulp.task('combine', ['combine-js']);
 
 gulp.task('all', sequence(['less', 'combine'], 'lint', 'ts'));
+gulp.task('all:no-lint', sequence(['less', 'combine'], 'ts'));
 gulp.task('default', ['all']);


### PR DESCRIPTION
Update Gulp `lint` task to emit errors when linting fails. Previously, there were only info messages and the build still succeeds.
Splited Gulp `all` into two: with lint and without.
Added Gradle `lint` task that is never UP-TO-DATE to be able to skip it.
Set `all:no-lint` default Gulp build task.
Updated Travis CI config to be more informative.