### PR TITLE
Content wizard - Slow response when typing in the Display name field #267

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
@@ -47,7 +47,7 @@ module api.app.wizard {
             this.displayNameGenerator = builder.displayNameGenerator;
             this.displayNameProgrammaticallySet = this.displayNameGenerator != null;
 
-            const debounceNotify = (query: String) => AppHelper.debounce((event: ValueChangedEvent) => {
+            const debounceNotify = (query: string) => AppHelper.debounce((event: ValueChangedEvent) => {
                 this.notifyPropertyChanged(query, event.getOldValue(), event.getNewValue());
             }, 100);
 

--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
@@ -1,6 +1,8 @@
 module api.app.wizard {
 
     import i18n = api.util.i18n;
+    import AppHelper = api.util.AppHelper;
+    import QueryField = api.query.QueryField;
 
     export class WizardHeaderWithDisplayNameAndNameBuilder {
 
@@ -45,11 +47,13 @@ module api.app.wizard {
             this.displayNameGenerator = builder.displayNameGenerator;
             this.displayNameProgrammaticallySet = this.displayNameGenerator != null;
 
+            const debounceNotify = (query: String) => AppHelper.debounce((event: ValueChangedEvent) => {
+                this.notifyPropertyChanged(query, event.getOldValue(), event.getNewValue());
+            }, 100);
+
             this.displayNameEl = api.ui.text.AutosizeTextInput.large();
             this.displayNameEl.setPlaceholder('<' + i18n('field.displayName') + '>').setName(api.query.QueryField.DISPLAY_NAME);
-            this.displayNameEl.onValueChanged((event: api.ValueChangedEvent) => {
-                this.notifyPropertyChanged(api.query.QueryField.DISPLAY_NAME, event.getOldValue(), event.getNewValue());
-            });
+            this.displayNameEl.onValueChanged(debounceNotify(QueryField.DISPLAY_NAME));
             this.appendChild(this.displayNameEl);
 
             this.pathEl = new api.dom.SpanEl('path');
@@ -58,9 +62,8 @@ module api.app.wizard {
 
             this.nameEl = api.ui.text.AutosizeTextInput.middle().setForbiddenCharsRe(this.forbiddenChars);
             this.nameEl.setPlaceholder('<' + i18n('field.path') + '>').setName('name');
-            this.nameEl.onValueChanged((event: api.ValueChangedEvent) => {
-                this.notifyPropertyChanged('<' + i18n('field.path') + '>', event.getOldValue(), event.getNewValue());
-            });
+            this.nameEl.onValueChanged(debounceNotify(`<${i18n('field.path')}>`));
+
             this.appendChild(this.nameEl);
 
             this.displayNameEl.onValueChanged((event: api.ValueChangedEvent) => {

--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
@@ -821,11 +821,13 @@ module api.app.wizard {
         }
 
         onWizardHeaderCreated(listener: () => void) {
-            this.validityManager.onValidityChanged(listener);
+            this.wizardHeaderCreatedListeners.push(listener);
         }
 
         unWizardHeaderCreated(listener: () => void) {
-            this.validityManager.unValidityChanged(listener);
+            this.wizardHeaderCreatedListeners = this.wizardHeaderCreatedListeners.filter((curr) => {
+                return curr !== listener;
+            });
         }
 
         notifyWizardHeaderCreated() {


### PR DESCRIPTION
Fixed bug with binding listeners to the wrong array: `validityManager`, instead of `wizardHeaderCreatedListeners`.
Optimized notifications for `name` and `displayName` fields from `WizardHeader` by wrapping them with `debounce`. This will prevent generating unwanted events when the key is constantly pressed or pressed very quickly, e.g. when deleting text with the backspace key.