### PR TITLE
Most Popular section should be present on the new content dialog, whe…

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/resource/AggregateContentTypesByPathRequest.ts
+++ b/src/main/resources/assets/admin/common/js/content/resource/AggregateContentTypesByPathRequest.ts
@@ -46,7 +46,7 @@ module api.content.resource {
         private buildAggregationsQuery(parentPath: ContentPath): ContentQuery {
             let contentQuery: ContentQuery = new ContentQuery();
             contentQuery.setQueryExpr(new QueryExpr(CompareExpr.eq(new FieldExpr('_parentPath'),
-                ValueExpr.string('/content' + parentPath.toString()))));
+                ValueExpr.string('/content' + (parentPath.isRoot() ? '' : parentPath.toString())))));
 
             contentQuery.setSize(0);
             contentQuery.setFrom(0);


### PR DESCRIPTION
…n no selections in the grid and the dialog is opened #596

-When fetching from root wrong parent path was used: '/content/' instead of '/content'