### PR TITLE
BrowsePanel - 'body mask' is still present, when 'Create Issue Dialog…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -432,7 +432,9 @@ module api.ui.dialog {
 
             api.ui.KeyBindings.get().unshelveBindings();
 
-            ModalDialog.openDialogsCounter--;
+            if (ModalDialog.openDialogsCounter > 0) {
+                ModalDialog.openDialogsCounter--;
+            }
             this.notifyClosed();
         }
 


### PR DESCRIPTION
…' has been closed #348

-'Close' was called for issue list dialog in spite of latest was not opened; Added check for open dialogs counter to not go down below 0