### PR TITLE
Site Wizard - the color of selected application-view is not updated, …

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/src/main/resources/assets/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -75,11 +75,15 @@ module api.content.site.inputtype.siteconfigurator {
         update(propertyArray: api.data.PropertyArray, unchangedOnly?: boolean): Q.Promise<void> {
             return super.update(propertyArray, unchangedOnly).then(() => {
                 this.siteConfigProvider.setPropertyArray(propertyArray);
-
-                if (!unchangedOnly || !this.comboBox.isDirty()) {
-                    this.comboBox.setValue(this.getValueFromPropertyArray(propertyArray));
-                }
-                return null;
+                const updatePromises = this.comboBox.getSelectedOptionViews().map((view, index) => {
+                    const config = propertyArray.getSet(index).getProperty('config').getPropertySet();
+                    return view.getFormView().update(config, unchangedOnly);
+                });
+                return wemQ.all(updatePromises).then(() => {
+                    if (!unchangedOnly || !this.comboBox.isDirty()) {
+                        this.comboBox.setValue(this.getValueFromPropertyArray(propertyArray));
+                    }
+                });
             });
         }
 

--- a/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
@@ -177,10 +177,9 @@ module api.form {
             if (FormItemLayer.debug) {
                 console.debug('FormItemLayer.update' + (unchangedOnly ? ' (unchanged only)' : ''), this, propertySet);
             }
-            let updatePromises = [];
 
-            this.formItemViews.forEach((formItemView: FormItemView) => {
-                updatePromises.push(formItemView.update(propertySet, unchangedOnly));
+            const updatePromises = this.formItemViews.map((formItemView: FormItemView) => {
+                return formItemView.update(propertySet, unchangedOnly);
             });
 
             return wemQ.all(updatePromises).spread<void>(() => {


### PR DESCRIPTION
…when switch between versions and site configurator in an application contains required fields #374

* Fixed `SiteConfigurator` update method by adding the missing update with the new `PropertyArray` each of the selected properties.