### PR TITLE
Site Wizard - Invalid number of applications present after restoring …

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -153,6 +153,11 @@ module api.ui.selector.combobox {
             return this.selectedOptionsView.getByOption(option);
         }
 
+        getSelectedOptionByValue(value: string): SelectedOption<OPTION_DISPLAY_VALUE> {
+            const option = this.getOptionByValue(value);
+            return option && this.selectedOptionsView.getByOption(option);
+        }
+
         getSelectedOptionView(): SelectedOptionsView<OPTION_DISPLAY_VALUE> {
             return this.selectedOptionsView;
         }


### PR DESCRIPTION
…to previous version #379

Added combobox selected options update from site configurator on `propertyArray` update.
Set `ignorePropertyChange` to `true` before updates to avoid cyclic `update` method calls, when multiple options are selected and updated.