### PR TITLE
Site Wizard - The list of selected applications is not refreshed after version rollback

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/src/main/resources/assets/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -80,13 +80,13 @@ module api.content.site.inputtype.siteconfigurator {
 
                 this.siteConfigProvider.setPropertyArray(propertyArray);
 
-                const selectedOptions = propertyArray.map(property => this.selectOptionFromProperty(property));
+                const selectedOptionViews = propertyArray.map(property =>
+                    <SiteConfiguratorSelectedOptionView>this.selectOptionFromProperty(property).getOptionView());
 
-                const optionsToDeselect = this.getOptionsToDeselect(selectedOptions);
+                const optionsToDeselect = this.getOptionsToDeselect(selectedOptionViews);
                 optionsToDeselect.forEach(option => this.comboBox.deselect(option.getApplication(), true));
 
-                const updatePromises = selectedOptions.map((option, index) => {
-                    const view = <SiteConfiguratorSelectedOptionView>option.getOptionView();
+                const updatePromises = selectedOptionViews.map((view, index) => {
                     const configSet = propertyArray.get(index).getPropertySet().getProperty('config').getPropertySet();
                     return view.getFormView().update(configSet, unchangedOnly);
                 });
@@ -108,10 +108,9 @@ module api.content.site.inputtype.siteconfigurator {
             return option.getApplication().getApplicationKey().toString();
         }
 
-        private getOptionsToDeselect(selectedOptions: SelectedOption<Application>[]) {
-            return this.comboBox.getSelectedOptionViews().filter(view => !selectedOptions.some(option =>
-                SiteConfigurator.optionViewToKey(<SiteConfiguratorSelectedOptionView>option.getOptionView()) ===
-                SiteConfigurator.optionViewToKey(view)) // tslint:disable-line max-line-length
+        private getOptionsToDeselect(selectedOptionViews: SiteConfiguratorSelectedOptionView[]) {
+            return this.comboBox.getSelectedOptionViews().filter(oldView => !selectedOptionViews.some(newView =>
+                SiteConfigurator.optionViewToKey(newView) === SiteConfigurator.optionViewToKey(oldView))
             );
         }
 

--- a/src/main/resources/assets/admin/common/js/data/PropertyArray.ts
+++ b/src/main/resources/assets/admin/common/js/data/PropertyArray.ts
@@ -55,10 +55,14 @@ module api.data {
             };
         }
 
-        forEach(callBack: {(property: Property, index: number): void;}) {
+        forEach(callBack: (property: Property, index: number) => void) {
             this.array.forEach((property: Property, index: number) => {
                 callBack(property, index);
             });
+        }
+
+        map<U>(callBack: (property: Property, index: number) => U): U[] {
+            return this.array.map(callBack);
         }
 
         containsValue(value: Value): boolean {

--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -153,6 +153,11 @@ module api.ui.selector.combobox {
             return this.selectedOptionsView.getByOption(option);
         }
 
+        getSelectedOptionByValue(value: string): SelectedOption<OPTION_DISPLAY_VALUE> {
+            const option = this.getOptionByValue(value);
+            return option && this.selectedOptionsView.getByOption(option);
+        }
+
         getSelectedOptionView(): SelectedOptionsView<OPTION_DISPLAY_VALUE> {
             return this.selectedOptionsView;
         }


### PR DESCRIPTION
Added combobox selected options update from site configurator on `propertyArray` update.
Set `ignorePropertyChange` to `true` before updates to avoid cyclic `update` method calls, when multiple options are selected and updated.