### PR TITLE
Options in combobox are empty when mode is 'Prod' #419

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -145,7 +145,11 @@ module api.form.inputtype.combobox {
         }
 
         private comboBoxFilter(item: api.ui.selector.Option<string>, args: any) {
-            return !(args && args.searchString && item.displayValue.toUpperCase().indexOf(args.searchString.toUpperCase()) === -1);
+            // Do not change to one-liner `return !(...);`. Bugs expected with UglifyJs + SlickGrid filter compilation.
+            if (args && args.searchString) {
+                return item.displayValue.toUpperCase().indexOf(args.searchString.toUpperCase()) !== -1;
+            }
+            return true;
         }
 
         protected getNumberOfValids(): number {


### PR DESCRIPTION
Fixed the problem with minification && SlickGrid filter compilation, when minified code was  transformed to the invalid filter function with RegExp.