### PR TITLE
Site wizard - application-view is not correctly updated in few cases #424

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/src/main/resources/assets/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -75,6 +75,9 @@ module api.content.site.inputtype.siteconfigurator {
 
         update(propertyArray: api.data.PropertyArray, unchangedOnly?: boolean): Q.Promise<void> {
             return super.update(propertyArray, unchangedOnly).then(() => {
+                const optionsMissing = !!propertyArray && propertyArray.getSize() > 0 && this.comboBox.getOptions().length === 0;
+                return optionsMissing ? this.comboBox.getLoader().preLoad() : null;
+            }).then(() => {
                 const ignorePropertyChange = this.ignorePropertyChange;
                 this.ignorePropertyChange = true;
 


### PR DESCRIPTION
Added check for the absence of the pre-loaded options (when the combobox element has no selected options and there was no interaction with it).