### PR TITLE
Icons are not displayed in `HtmlArea` on the mce-toolbar #426

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ jar {
     fileTree("$buildDir/assets/admin/common/lib") {
         exclude '_all.js'
         exclude '**/*.css'
+        exclude '**/fonts/tinymce*.*'
     }.each { f -> exclude buildDir.toURI().relativize( file( f.path ).toURI() ).toString() }
 
     includeEmptyDirs = false


### PR DESCRIPTION
Added excluded TinyMCE fonts to the distribution.