### PR TITLE
Options in combobox are empty when mode is 'Prod' #419

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -146,10 +146,8 @@ module api.form.inputtype.combobox {
 
         private comboBoxFilter(item: api.ui.selector.Option<string>, args: any) {
             // Do not change to one-liner `return !(...);`. Bugs expected with UglifyJs + SlickGrid filter compilation.
-            if (args && args.searchString) {
-                return item.displayValue.toUpperCase().indexOf(args.searchString.toUpperCase()) !== -1;
-            }
-            return true;
+            const isEmptyInput = args == null || args.searchString == null;
+            return isEmptyInput || item.displayValue.toUpperCase().indexOf(args.searchString.toUpperCase()) !== -1;
         }
 
         protected getNumberOfValids(): number {


### PR DESCRIPTION
Updated function, that is compiled and precessed with RegExp in SlickGrid to be used in a filter to the version, that has a space between `return` and expression after uglyfication.