### PR TITLE
Page Component View is not scrollable when page is locked #435

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/mask/Mask.ts
+++ b/src/main/resources/assets/admin/common/js/ui/mask/Mask.ts
@@ -11,18 +11,6 @@ module api.ui.mask {
             this.masked = itemToMask;
 
             if (this.masked) {
-                // pass the mousewheel event to the masked element to be able to scroll
-                this.onMouseWheel((event: WheelEvent) => {
-
-                    let evt = this.cloneWheelEvent(event);
-                    this.masked.getHTMLElement().dispatchEvent(evt);
-
-                    if (this.isBrowserFirefox()) { //scrolling manually ff as dispatch event not working
-                        this.triggerScroll(event);
-                    }
-
-                });
-
                 this.masked.onHidden((event: api.dom.ElementHiddenEvent) => {
                     if (event.getTarget() === this.masked) {
                         this.hide();
@@ -35,12 +23,17 @@ module api.ui.mask {
                         this.positionOver(this.masked);
                     }
                 });
+                this.masked.onClicked(event => {
+                    if (this.masked.hasClass('masked')) {
+                        this.getHTMLElement().dispatchEvent(this.cloneMouseEvent(event));
+                    }
+                });
             }
             api.dom.Body.get().appendChild(this);
         }
 
-        private cloneWheelEvent(e: WheelEvent): WheelEvent {
-            return api.ObjectHelper.create(WheelEvent, e.type, {
+        private cloneMouseEvent(e: MouseEvent): MouseEvent {
+            return api.ObjectHelper.create(MouseEvent, e.type, {
                 bubbles: e.bubbles,
                 cancelable: e.cancelable,
                 cancelBubble: e.cancelBubble,
@@ -52,10 +45,6 @@ module api.ui.mask {
                 clientY: e.clientY,
                 layerX: e.layerX,
                 layerY: e.layerY,
-                deltaX: e.deltaX,
-                deltaY: e.deltaY,
-                deltaZ: e.deltaZ,
-                deltaMode: e.deltaMode,
                 ctrlKey: e.ctrlKey,
                 altKey: e.altKey,
                 shiftKey: e.shiftKey,
@@ -70,6 +59,12 @@ module api.ui.mask {
             if (this.masked) {
                 this.positionOver(this.masked);
             }
+            this.masked.addClass('masked');
+        }
+
+        hide() {
+            super.hide();
+            this.masked.removeClass('masked');
         }
 
         private positionOver(masked: api.dom.Element) {
@@ -125,18 +120,5 @@ module api.ui.mask {
                 setWidth(maskedDimensions.width).
                 setHeight(maskedDimensions.height);
         }
-
-        private isBrowserFirefox(): boolean {
-            return /Firefox/i.test(navigator.userAgent);
-        }
-
-        private triggerScroll(event: WheelEvent) {
-            wemjq(this.masked.getHTMLElement()).stop().animate({
-                // converting ff wheel deltaY from lines to px (approximate)
-                scrollTop: this.masked.getHTMLElement().scrollTop + event.deltaY * 25
-            }, 600 / Math.abs(event.deltaY), 'linear');
-        }
-
     }
-
 }

--- a/src/main/resources/assets/admin/common/js/ui/mask/Mask.ts
+++ b/src/main/resources/assets/admin/common/js/ui/mask/Mask.ts
@@ -23,35 +23,8 @@ module api.ui.mask {
                         this.positionOver(this.masked);
                     }
                 });
-                this.masked.onClicked(event => {
-                    if (this.masked.hasClass('masked')) {
-                        this.getHTMLElement().dispatchEvent(this.cloneMouseEvent(event));
-                    }
-                });
             }
             api.dom.Body.get().appendChild(this);
-        }
-
-        private cloneMouseEvent(e: MouseEvent): MouseEvent {
-            return api.ObjectHelper.create(MouseEvent, e.type, {
-                bubbles: e.bubbles,
-                cancelable: e.cancelable,
-                cancelBubble: e.cancelBubble,
-                view: e.view,
-                detail: e.detail,
-                screenX: e.screenX,
-                screenY: e.screenY,
-                clientX: e.clientX,
-                clientY: e.clientY,
-                layerX: e.layerX,
-                layerY: e.layerY,
-                ctrlKey: e.ctrlKey,
-                altKey: e.altKey,
-                shiftKey: e.shiftKey,
-                metaKey: e.metaKey,
-                button: e.button,
-                relatedTarget: e.relatedTarget
-            });
         }
 
         show() {
@@ -59,12 +32,6 @@ module api.ui.mask {
             if (this.masked) {
                 this.positionOver(this.masked);
             }
-            this.masked.addClass('masked');
-        }
-
-        hide() {
-            super.hide();
-            this.masked.removeClass('masked');
         }
 
         private positionOver(masked: api.dom.Element) {


### PR DESCRIPTION
**First commit/solution:**
* Removed scroll animation, that must be replaced by pure CSS.
* Added click event propagation from masked element to sibling (mask) element to bypass `pointer-events: none` limitations.

**Second and final commit/solution:**
* Removed click propagation, since it is now handled in the masked element.