### PR TITLE
Page content is cropped in the Page Editor #439

### DIFF
--- a/src/main/resources/assets/admin/common/styles/global.less
+++ b/src/main/resources/assets/admin/common/styles/global.less
@@ -1,7 +1,3 @@
-html, body {
-  height: 100%
-}
-
 body {
   overflow-y: hidden; // Fix for scrollbar
   font-family: @admin-font-family;


### PR DESCRIPTION
Removed page cropping and scroll absence (cases 2 & 3).
Height `100%` is set in the launcher (html).