### PR TITLE
CKEditor: inline width css rule for dropped/pasted image not set #483

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/ImageModalDialogCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/ImageModalDialogCKE.ts
@@ -19,6 +19,7 @@ module api.util.htmlarea.dialog {
      * 1. setWrapperAlign() method updated to make image wrapper element have inline alignment styles we used to have
      * 2. data() function updated to set 'max-width: 100%' on all images, including dropped/pasted images
      * 3. data() function updated to set inline style 'display: none;' on drag handler container
+     * 4. init value of  widget's 'data.lock' parameter set to false to make dropped/pasted images align correctly
      * Update those in case ckeditor lib is updated
      */
     export class ImageModalDialogCKE

--- a/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
+++ b/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
@@ -383,7 +383,7 @@
                         height: image.getAttribute('height') || '',
 
                         // Lock ratio is on by default (https://dev.ckeditor.com/ticket/10833).
-                        lock: this.ready ? helpers.checkHasNaturalRatio(image) : true
+                        lock: false //this.ready ? helpers.checkHasNaturalRatio(image) : true // change #4
                     };
 
                 // If we used 'a' in widget#parts definition, it could happen that


### PR DESCRIPTION
-native 'lock' parameter was set to true for dropped/pasted image, this led to aligning not setting width inline style