### PR TITLE
CK editor must inherit and use same fonts as the rest of content stud…

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/src/main/resources/assets/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -212,3 +212,13 @@
 .cke_dialog a {
   pointer-events: auto;
 }
+
+body.cke_editable {
+  font-family: @admin-font-family;
+  font-size: 14px;
+  line-height: 1.3;
+
+  strong {
+    font-family: @admin-font-family;
+  }
+}


### PR DESCRIPTION
…io #494

-aligned input type's cke styling with tiny