### PR TITLE
Components View - image and table can be displayed in the text-compon…

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/editor/HTMLAreaBuilderCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/editor/HTMLAreaBuilderCKE.ts
@@ -212,6 +212,8 @@ module api.util.htmlarea.editor {
             });
 
             ckeditor.on('blur', (e: eventInfo) => {
+                e.editor.getSelection().reset(); // that makes cke cleanup
+
                 if (this.hasActiveDialog) {
                     e.stop();
                     this.hasActiveDialog = false;

--- a/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
+++ b/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
@@ -9,7 +9,7 @@
 
     var template = '<img alt="" src="" />',
         templateBlock = new CKEDITOR.template(
-            '<figure class="{captionedClass}">' +
+            '<figure style="margin: 0" class="{captionedClass}">' +
             template +
             '<figcaption>{captionPlaceholder}</figcaption>' +
             '</figure>'),


### PR DESCRIPTION
…ent item

-Extracting editor's element text
-Found heavy issue with PageComponentsView - listeners were attached on text components each time pcv tree grid reloaded
-Setting margin:0 on figure tags directly in plugin