### PR TITLE
[iOS/Safari] Scrolling is not working in content wizard when cursor is over an input field

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/src/main/resources/assets/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -65,6 +65,7 @@
   }
 
   .form-panel {
+    -webkit-overflow-scrolling: touch !important;
     overflow-y: auto !important;
     &.rendering {
       opacity: 0;


### PR DESCRIPTION
…zard, when cursor over an input field #565