### PR TITLE
FF specific bug. New Content Dialog - 'Recently Used' block is not di…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -366,6 +366,7 @@ module api.ui.dialog {
                 this.dialogContainer.appendChild(this);
             }
             api.dom.Body.get().appendChild(this.dialogContainer);
+            this.responsiveItem.update();
 
             this.blurBackground();
             super.show();


### PR DESCRIPTION
…splayed in the dialog when it opened in first-time #570

Added update of the dialog responsive range after appending to the body on `show()` call. Firefox calculates the width of the dialog (elements) when it's not yet inserted into the DOM differently, so we need to recalculate ranges after it is inserted into the DOM.