### PR TITLE
Install Applications Dialog - incorrect state of application, when th…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -64,7 +64,7 @@ module api.ui.treegrid {
 
         private loadBufferSize: number;
 
-        private loading: boolean = false;
+        protected loading: boolean = false;
 
         private scrollable: api.dom.Element;
 


### PR DESCRIPTION
…e dialog has been opened after the 'Log in' #572

for https://github.com/enonic/app-applications/issues/8

-Need to make 'loading' variable protected for children grids to know loading state