### PR TITLE
Start/stop menu in the Application info panel won't close after switching to another application

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/menu/ActionMenu.ts
+++ b/src/main/resources/assets/admin/common/js/ui/menu/ActionMenu.ts
@@ -38,14 +38,16 @@ module api.ui.menu {
             let actionMenuItem = new ActionMenuItem(action);
             this.actionListEl.appendChild(actionMenuItem);
             actionMenuItem.onClicked(() => {
-                this.removeClass('expanded');
+                this.removeClass('down');
+                this.labelEl.removeClass('down');
             });
         }
 
         private foldMenuOnOutsideClick(evt: Event): void {
             if (!this.getEl().contains(<HTMLElement> evt.target)) {
                 // click outside menu
-                this.removeClass('expanded');
+                this.removeClass('down');
+                this.labelEl.removeClass('down');
             }
         }
     }

--- a/src/main/resources/assets/admin/common/styles/api/ui/menu/action-menu.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/menu/action-menu.less
@@ -13,7 +13,7 @@
     z-index: 2;
     display: block;
     line-height: 20px;
-    padding: 8px 5px;
+    padding: 8px 25px 8px 5px;
     text-align: center;
     cursor: pointer;
     background-color: white;


### PR DESCRIPTION
…as unselected #575

Fixed invalid status class name ("expanded" to "down").
Added missing handlers.

**Additional:**
Fixed styles, by centering label text (between left border and dropdown). This will also prevent text from overflowing in some non-default languages (Russian, etc.).