### PR TITLE
Edge specific bug - 'null' appears in the description-text area, when…

### DIFF
--- a/src/main/resources/assets/admin/common/js/dom/ElementHelper.ts
+++ b/src/main/resources/assets/admin/common/js/dom/ElementHelper.ts
@@ -147,7 +147,7 @@ module api.dom {
         }
 
         setValue(value: string): ElementHelper {
-            this.el['value'] = value;
+            this.el['value'] = value || '';
             return this;
         }
 


### PR DESCRIPTION
… a site has been saved #601

-Setting input's value to null has some browser specifics:
1. In IE setting null e.g. <code>el['value'] = null;</code> sets value to 'null' rather then to ''. Same with undefined
2. Other browsers set input's value to '' when setting null