### PR TITLE
Content Studio - Set content name as unnamed #603

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/resource/UpdateContentRequest.ts
+++ b/src/main/resources/assets/admin/common/js/content/resource/UpdateContentRequest.ts
@@ -104,7 +104,7 @@ module api.content.resource {
             return {
                 contentId: this.id,
                 requireValid: this.requireValid,
-                contentName: this.name.isUnnamed() ? ContentName.UNNAMED_PREFIX : this.name.toString(),
+                contentName: this.name.isUnnamed() ? this.name.getValue() : this.name.toString(),
                 data: this.data.toJson(),
                 meta: (this.meta || []).map((extraData: ExtraData) => extraData.toJson()),
                 displayName: this.displayName,


### PR DESCRIPTION
-Before: saving unnamed content during update sends content's name as '__unnamed__' instead of '__unnamed__<unique_id>' it had before
-Now: sending unnamed content's name as is