### PR TITLE
Long checkbox labels float over the boxes

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/util/htmlarea/modal-dialog.less
+++ b/src/main/resources/assets/admin/common/styles/api/util/htmlarea/modal-dialog.less
@@ -1,7 +1,7 @@
 .modal-dialog-margin-mixin(@label-width: @form-label-width) {
   .form-view {
     .input-view {
-      label {
+      & > label {
         float: left;
         max-width: @label-width - 10px;
       }
@@ -82,6 +82,17 @@
       }
       .form-view.display-validation-errors .input-view label + .input-wrapper {
         margin-left: 0;
+      }
+    }
+    &.link-modal-dialog,
+    &.search-and-replace-modal-dialog {
+      .dialog-content .form-view .input-view {
+        .checkbox label::before {
+          margin-left: 0;
+        }
+        .checkbox label {
+          padding-left: 22px;
+        }
       }
     }
   }
@@ -181,10 +192,19 @@
 
   }
 
-  &.link-modal-dialog, &.search-and-replace-modal-dialog {
-    input[type="checkbox"] + label:before {
-      position: absolute;
-      margin-left: 108px;
+  &.link-modal-dialog,
+  &.search-and-replace-modal-dialog {
+    input[type="checkbox"] + label {
+      padding-left: 130px;
+      padding-right: 0;
+      box-sizing: border-box;
+      .ellipsis();
+      &::before {
+        position: absolute;
+        margin-top: 2px;
+        margin-left: 108px;
+        left: 0;
+      }
     }
 
     .dialog-content .panel {


### PR DESCRIPTION
Updated Link and Search-and-Replace modal dialogs checkboxes to support long labels in different localizations.