### PR TITLE
CKEditor assets are not added to jar file #583

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ jar {
         exclude 'ckeditor/plugins/quicktable/plugin.js'
         exclude 'ckeditor/plugins/quicktable/lang/*.*'
         exclude 'ckeditor/plugins/autogrow/plugin.js'
+        exclude 'ckeditor/plugins/sharedspace/plugin.js'
         exclude 'ckeditor/plugins/macro/icons/macro.png'
         exclude 'ckeditor/skins/moono-lisa/**/*.*'
         exclude 'ckeditor/lang/en*.js'


### PR DESCRIPTION
Fixed another missing dependency, that is loaded from the Live Edit.