### PR TITLE
Svg image in HTML editor disappears when center-aligned #632

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/ImageModalDialogCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/ImageModalDialogCKE.ts
@@ -24,6 +24,7 @@ module api.util.htmlarea.dialog {
      * 5. hasCaption() updated to wrap image into figure tag on drag and drop
      * 6. templateBlock variable updated to set margin:0 on figure tag when inserted
      * 7. updated image plugin to enable justify button on toolbar
+     * 8. centered figure will have 'display: block' instead of inline-block to properly display svg
      *
      * NB: Modifications were made in ckeditor.js (VERY SORRY FOR THAT):
      * LINE 1279: updateDragHandlerPosition() function updated to set inline style 'display: none;' on drag handler container

--- a/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
+++ b/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
@@ -568,7 +568,7 @@
                     // Finally set display for figure.
                     if (!alignClasses && el.is('figure')) {
                         if (newValue == 'center') {
-                            el.setStyle('display', 'inline-block');
+                            el.setStyle('display', 'block'); // #8
                         } else {
                             el.removeStyle('display');
                         }


### PR DESCRIPTION
-updated image plugin to set display to 'block' instead of 'inline-block' when centering image