### PR TITLE
Wizard Step navigator is partially visible in collapsed mode #643

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
@@ -575,11 +575,11 @@ module api.app.wizard {
                 this.stepNavigator.selectNavigationItem(navigationIndex, false, true);
             }
 
+            const maximized = !this.minimized;
             if (this.helpTextToggleButton) {
-                const maximized = !this.minimized;
                 this.helpTextToggleButton.setVisible(maximized);
-                this.stepNavigatorAndToolbarContainer.changeOrientation(maximized);
             }
+            this.stepNavigatorAndToolbarContainer.changeOrientation(maximized);
         }
 
         private toggleHelpTextShown() {

--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardStepNavigatorAndToolbar.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardStepNavigatorAndToolbar.ts
@@ -106,7 +106,7 @@ module api.app.wizard {
             }
 
             const help = this.helpTextToggleButton;
-            const width = (!!help && help.isVisible())
+            const width = (help && help.isVisible())
                 ? this.getEl().getWidthWithoutPadding() - help.getEl().getWidthWithMargin()
                 : this.getEl().getWidthWithoutPadding();
 


### PR DESCRIPTION
Fixed issue, when orientation change didn't happen if help text button was absent.