### PR TITLE
CKE: anchors are duplicated in the Insert Link dialog #654

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/LinkModalDialogCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/LinkModalDialogCKE.ts
@@ -48,7 +48,7 @@ module api.util.htmlarea.dialog {
             const anchors: any[] = CKEDITOR.plugins.link.getEditorAnchors(this.getEditor())
                 .filter((anchor: any) => !!anchor.id) // filter anchors with missing id's
                 .map((anchor: any) => anchor.id)
-                .filter((item, pos, self) => self.indexOf(item) == pos) // filter duplicates cke returns;
+                .filter((item, pos, self) => self.indexOf(item) == pos); // filter duplicates cke returns;
 
             if (anchors.length > 0) {
                 this.dockedPanel.addItem(this.tabNames.anchor, true, this.createAnchorPanel(anchors), this.isAnchor());

--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/LinkModalDialogCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/LinkModalDialogCKE.ts
@@ -45,9 +45,10 @@ module api.util.htmlarea.dialog {
         }
 
         private createAnchorPanelIfNeeded() {
-            const anchors: any[] = CKEDITOR.plugins.link.getEditorAnchors(this.getEditor()).map((anchor: any) => {
-                return anchor.id;
-            });
+            const anchors: any[] = CKEDITOR.plugins.link.getEditorAnchors(this.getEditor())
+                .filter((anchor: any) => !!anchor.id) // filter anchors with missing id's
+                .map((anchor: any) => anchor.id)
+                .filter((item, pos, self) => self.indexOf(item) == pos) // filter duplicates cke returns;
 
             if (anchors.length > 0) {
                 this.dockedPanel.addItem(this.tabNames.anchor, true, this.createAnchorPanel(anchors), this.isAnchor());


### PR DESCRIPTION
-CKE's getEditorAnchors() method returns all items duplicated; Filtering duplicated items on our side, not changing plugin itself