### PR TITLE
CKE: anchors don't work as supposed to #653

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/AnchorModalDialogCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/AnchorModalDialogCKE.ts
@@ -45,8 +45,16 @@ module api.util.htmlarea.dialog {
 
             this.addAction(submitAction.onExecuted(() => {
                 if (this.validate()) {
-                    this.ckeOriginalDialog.setValueOf('info', 'txtName', this.nameField.getInput().getEl().getValue());
-                    this.ckeOriginalDialog.getButton('ok').click();
+                    const value: string = this.nameField.getInput().getEl().getValue();
+                    const isAnythingSelected: boolean = !!this.getEditor().getSelection().getSelectedText();
+
+                    if (isAnythingSelected) {
+                        this.ckeOriginalDialog.setValueOf('info', 'txtName', value);
+                        this.ckeOriginalDialog.getButton('ok').click();
+                    } else {
+                        this.getEditor().insertHtml(`<a id="${value}" name="${value}">&nbsp;</a>`);
+                    }
+
                     this.close();
                 }
             }));


### PR DESCRIPTION
-Actually they work as supposed to: when image is saved editor's data is processed and empty anchors that are represented with `<img>` tag in editor are transformed to `<a>`. However it might be confusing for user,thus when inserting empty anchor we'd like to prevent having lone `<img>` tag and instead set anchor tag with `&nbsp;` text, that makes `<a>` tag appear immediately