### PR TITLE
CKE: in live edit cke's internal elements not removed when saving #670

### DIFF
--- a/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
+++ b/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
@@ -872,7 +872,7 @@
     };
 
     function setWrapperAlign(widget, alignClasses) { // change #1
-        var wrapper = widget.wrapper,
+        var wrapper = widget.wrapper.findOne('figure') || widget.wrapper,
             align = widget.data.align,
             hasCaption = widget.data.hasCaption,
             keepSize = widget.data.lock;


### PR DESCRIPTION
-Using figure tag to align images in editor instead of cke's wrapper element taht will be removed on save