### PR TITLE
CKE: Can't change anchor link to point to another anchor #678

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/LinkModalDialogCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/LinkModalDialogCKE.ts
@@ -520,7 +520,7 @@ module api.util.htmlarea.dialog {
         }
 
         private getOriginalAnchorElem(): CKEDITOR.ui.dialog.uiElement {
-            return (<any>this.getElemFromOriginalDialog('info', 'anchorOptions')).getChild([0, 0, 1]);
+            return (<any>this.getElemFromOriginalDialog('info', 'anchorOptions')).getChild([0, 0, 0]);
         }
 
         private getOriginalProtocolElem(): CKEDITOR.ui.dialog.uiElement {


### PR DESCRIPTION
-Original link/anchor dialog has 2 dropdowns to pick anchor - by id and by name; We used 'by id', but it is not switching anchors; now using the one 'by name'