### PR TITLE
CKE: don't destroy editor if it's iframe was removed #693

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/inputtype/text/HtmlAreaCK.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/text/HtmlAreaCK.ts
@@ -80,9 +80,6 @@ module api.form.inputtype.text {
                     });
                 }
             });
-            textAreaEl.onRemoved(() => {
-                this.destroyEditor(editorId);
-            });
 
             textAreaWrapper.appendChild(textAreaEl);
 
@@ -318,8 +315,8 @@ module api.form.inputtype.text {
         private editorLowerEdgeIsVisible(inputOccurence: Element): boolean {
             const distToTopOfScrlblArea = this.calcDistToTopOfScrlbleArea(inputOccurence);
             const editorToolbarHeight = wemjq(inputOccurence.getHTMLElement()).find(this.getToolbarClass()).outerHeight(true);
-            const mceStatusToolbarHeight = wemjq(inputOccurence.getHTMLElement()).find(this.getBottomBarClass()).outerHeight(true);
-            return (inputOccurence.getEl().getHeightWithoutPadding() - editorToolbarHeight - mceStatusToolbarHeight +
+            const statusToolbarHeight = wemjq(inputOccurence.getHTMLElement()).find(this.getBottomBarClass()).outerHeight(true);
+            return (inputOccurence.getEl().getHeightWithoutPadding() - editorToolbarHeight - statusToolbarHeight +
                     distToTopOfScrlblArea) > 0;
         }
 
@@ -419,7 +416,6 @@ module api.form.inputtype.text {
 
                 this.destroyEditor(editorId);
                 this.reInitEditor(editorId);
-                tinymce.execCommand('mceAddEditor', false, editorId);
             });
         }
 
@@ -427,7 +423,6 @@ module api.form.inputtype.text {
             const editorId = wemjq('textarea', ui.item)[0].id;
 
             this.reInitEditor(editorId);
-            tinymce.execCommand('mceAddEditor', false, editorId);
 
             this.getEditor(editorId).focus();
         }

--- a/src/main/resources/assets/admin/common/js/util/htmlarea/editor/HTMLAreaBuilderCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/editor/HTMLAreaBuilderCKE.ts
@@ -354,7 +354,6 @@ module api.util.htmlarea.editor {
             });
 
             ckeditor.on('blur', (e: eventInfo) => {
-                e.editor.getSelection().reset(); // that makes cke cleanup
 
                 if (this.hasActiveDialog) {
                     e.stop();


### PR DESCRIPTION
-Not invoking editor's destroy when occurence removed
-Stopped triggereing selection change on blur as it seems to be not needed anymore