### PR TITLE
Implement tooltip for macro, image, link and anchor in HTML Area #719

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/editor/HTMLAreaBuilderCKE.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/editor/HTMLAreaBuilderCKE.ts
@@ -257,6 +257,7 @@ module api.util.htmlarea.editor {
             this.listenCKEditorEvents(ckeditor);
             this.handleFileUpload(ckeditor);
             this.handleNativeNotifications(ckeditor);
+            this.handleTooltipForClickableElements(ckeditor);
             this.setupDialogsToOpen(ckeditor);
             this.setupKeyboardShortcuts(ckeditor);
             this.addCustomLangEntries(ckeditor);
@@ -365,6 +366,28 @@ module api.util.htmlarea.editor {
                 if (this.blurHandler) {
                     this.blurHandler(<any>e);
                 }
+            });
+        }
+
+        private handleTooltipForClickableElements(ckeditor: HTMLAreaEditor) {
+            let tooltipElem: CKEDITOR.dom.element = null;
+            const tooltipText = i18n('editor.dblclicktoedit');
+
+            const mouseOverHandler = api.util.AppHelper.debounce((ev: eventInfo) => {
+                const targetEl: CKEDITOR.dom.element = ev.data.getTarget();
+                const isClickableElement: boolean = targetEl.is('a') || targetEl.is('img'); // imgs, links, anchors
+
+                if (isClickableElement) {
+                    tooltipElem.setAttribute('title', tooltipText);
+                } else {
+                    tooltipElem.removeAttribute('title');
+                }
+
+            }, 200);
+
+            ckeditor.on('instanceReady', () => {
+                tooltipElem = this.inline ? ckeditor.container : ckeditor.document.getBody().getParent();
+                ckeditor.editable().on('mouseover', mouseOverHandler);
             });
         }
 
@@ -608,6 +631,11 @@ module api.util.htmlarea.editor {
 
                 if (evt.editor.lang.common && evt.editor.lang.common.image.indexOf(imageTooltipPostfix) < 0) {
                     evt.editor.lang.common.image = evt.editor.lang.common.image + ' ' + imageTooltipPostfix;
+                }
+
+                // anchor tooltip
+                if (evt.editor.lang.fakeobjects) {
+                    evt.editor.lang.fakeobjects.anchor = i18n('editor.dblclicktoedit');
                 }
             });
         }

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -221,6 +221,7 @@ editor.cropimage=Crop Image
 editor.setautofocus=Set Autofocus
 editor.resetautofocus=Reset Autofocus
 editor.resetmask=Reset Mask
+editor.dblclicktoedit=Double-click to edit
 
 #
 #   XP Tour

--- a/src/main/resources/i18n/common_ru.properties
+++ b/src/main/resources/i18n/common_ru.properties
@@ -220,6 +220,7 @@ editor.cropimage=Обрезать изображение
 editor.setautofocus=Установить автофокус
 editor.resetautofocus=Сбросить автофокус
 editor.resetmask=Сбросить маску
+editor.dblclicktoedit=Дважды клик чтобы редактировать
 
 #
 #   XP Tour


### PR DESCRIPTION
-using mouseover event to identify clickable elements
-to not modify editor's content using title attribute of editor's parent element (different for inline and regular mode) to display tooltip

Macro skipped because there are no tags wrapping it thus unable to identify when cursor is over macro.