### PR TITLE
HtmlArea - impossible to embed an <iframe> element in an HTML area #765

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
@@ -193,7 +193,7 @@ module api.util.htmlarea.dialog {
                 if (this.selectedMacro) {
                     this.insertUpdatedMacroIntoTextArea(macroString);
                 } else {
-                    (<CKEDITOR.editor>this.getEditor()).insertHtml(macroString);
+                    this.getEditor().insertText(macroString);
                 }
 
                 this.close();


### PR DESCRIPTION
-CKEditor stripped off iframe when inserted as html; inserting macro as text now