### PR TITLE
Update combo box viewers

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/NamesAndIconView.ts
+++ b/src/main/resources/assets/admin/common/js/app/NamesAndIconView.ts
@@ -126,17 +126,11 @@ module api.app {
             return this.namesView;
         }
 
-        /**
-         * protected, to be used by inheritors
-         */
         getIconImageEl(): api.dom.ImgEl {
             return this.iconImageEl;
         }
 
-        /**
-         * protected, to be used by inheritors
-         */
-        getWrapperDivEl(): api.dom.DivEl {
+        protected getWrapperDivEl(): api.dom.DivEl {
             return this.wrapperDivEl;
         }
 

--- a/src/main/resources/assets/admin/common/js/content/ContentComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/content/ContentComboBox.ts
@@ -255,6 +255,7 @@ module api.content {
                     .setEditable(true)
                     .setDraggable(true)
             );
+            this.addClass('content-selected-option-view');
         }
 
         resolveIconUrl(content: ContentTreeSelectorItem): string {
@@ -290,7 +291,7 @@ module api.content {
 
         optionDataHelper: OptionDataHelper<ContentTreeSelectorItem> = new ContentSummaryOptionDataHelper();
 
-        optionDisplayValueViewer: Viewer<any> = <Viewer<any>>new ContentSummaryViewer();
+        optionDisplayValueViewer: Viewer<ContentTreeSelectorItem> = new ContentTreeSelectorItemViewer();
 
         maximumOccurrences: number = 0;
 

--- a/src/main/resources/assets/admin/common/js/content/ContentTreeSelectorItemViewer.ts
+++ b/src/main/resources/assets/admin/common/js/content/ContentTreeSelectorItemViewer.ts
@@ -1,0 +1,47 @@
+module api.content {
+
+    import ContentUnnamed = api.content.ContentUnnamed;
+    import ContentTreeSelectorItem = api.content.resource.ContentTreeSelectorItem;
+
+    export class ContentTreeSelectorItemViewer
+        extends api.ui.NamesAndIconViewer<ContentTreeSelectorItem> {
+
+        constructor() {
+            super('content-tree-selector-item-viewer');
+        }
+
+        resolveDisplayName(object: ContentTreeSelectorItem): string {
+            let contentName = object.getName();
+            let invalid = !object.isValid() || !object.getDisplayName() || contentName.isUnnamed();
+            let pendingDelete = object.getContentState().isPendingDelete();
+            this.toggleClass('invalid', invalid);
+            this.toggleClass('pending-delete', pendingDelete);
+
+            return object.getDisplayName();
+        }
+
+        resolveUnnamedDisplayName(object: ContentTreeSelectorItem): string {
+            return object.getType() ? object.getType().getLocalName() : '';
+        }
+
+        resolveSubName(object: ContentTreeSelectorItem, relativePath: boolean = false): string {
+            let contentName = object.getName();
+            if (relativePath) {
+                return !contentName.isUnnamed() ? object.getName().toString() : ContentUnnamed.prettifyUnnamed();
+            } else {
+                return !contentName.isUnnamed() ? object.getPath().toString() :
+                       ContentPath.fromParent(object.getPath().getParentPath(), ContentUnnamed.prettifyUnnamed()).toString();
+            }
+        }
+
+        resolveSubTitle(object: ContentTreeSelectorItem): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconUrl(object: ContentTreeSelectorItem): string {
+            if (object) {
+                return new api.content.util.ContentIconUrlResolver().setContent(object.getContent()).resolve();
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/admin/common/js/content/_module.ts
+++ b/src/main/resources/assets/admin/common/js/content/_module.ts
@@ -13,7 +13,7 @@
 ///<reference path='ExtraData.ts' />
 
 ///<reference path='ContentTreeSelectorQueryRequest.ts' />
-
+///<reference path='ContentTreeSelectorItemViewer.ts' />
 ///<reference path='ContentComboBox.ts' />
 ///<reference path='CompareStatus.ts' />
 ///<reference path='PublishStatus.ts' />

--- a/src/main/resources/assets/admin/common/js/content/image/ImageSelectorViewer.ts
+++ b/src/main/resources/assets/admin/common/js/content/image/ImageSelectorViewer.ts
@@ -6,7 +6,7 @@ module api.content.image {
         extends api.ui.NamesAndIconViewer<MediaTreeSelectorItem> {
 
         constructor() {
-            super();
+            super('image-selector-viewer');
         }
 
         resolveDisplayName(object: MediaTreeSelectorItem): string {

--- a/src/main/resources/assets/admin/common/js/content/resource/ContentTreeSelectorItem.ts
+++ b/src/main/resources/assets/admin/common/js/content/resource/ContentTreeSelectorItem.ts
@@ -84,6 +84,10 @@ module api.content.resource {
             return this.content ? this.content.isSite() : null;
         }
 
+        getLanguage(): string {
+            return this.content ? this.content.getLanguage() : null;
+        }
+
         isSelectable(): boolean {
             return this.selectable;
         }

--- a/src/main/resources/assets/admin/common/js/dom/Element.ts
+++ b/src/main/resources/assets/admin/common/js/dom/Element.ts
@@ -786,7 +786,7 @@ module api.dom {
         private isInViewport(): boolean {
             const container = this.getFirstNonEmptyAncestor();
 
-            if (container.isEmptyElement()) {
+            if (!container || container.isEmptyElement()) {
                 return false;
             }
 

--- a/src/main/resources/assets/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/src/main/resources/assets/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -164,7 +164,7 @@
     position: fixed;
     // to be above image input type mask and the input type itself
     z-index: @z-index-scroll-stick;
-    top: 43px;
+    top: 39px;
     border-top: 1px solid @admin-medium-gray-border;
 
     box-shadow: -3px 3px 6px 0 @admin-toolbar-shadow;

--- a/src/main/resources/assets/admin/common/styles/api/content/content-tree-selector-item-viewer.less
+++ b/src/main/resources/assets/admin/common/styles/api/content/content-tree-selector-item-viewer.less
@@ -1,0 +1,13 @@
+.content-tree-selector-item-viewer {
+  &.invalid .names-and-icon-view .@{_COMMON_PREFIX}wrapper:before {
+    content: "!";
+    background: @admin-red;
+    color: @admin-white;
+  }
+
+  &.pending-delete .names-and-icon-view .@{_COMMON_PREFIX}names-view {
+    .@{_COMMON_PREFIX}main-name, .@{_COMMON_PREFIX}sub-name {
+      text-decoration: line-through;
+    }
+  }
+}

--- a/src/main/resources/assets/admin/common/styles/styles.less
+++ b/src/main/resources/assets/admin/common/styles/styles.less
@@ -117,6 +117,7 @@
 @import "api/content/image/image-content-combo-box";
 @import "api/content/content-summary-viewer";
 @import "api/content/content-summary-and-compare-status-viewer";
+@import "api/content/content-tree-selector-item-viewer";
 @import "api/content/inputtype/relationship/relationship";
 @import "api/content/inputtype/image/image-selector";
 @import "api/content/inputtype/mediaselector/media-selector";


### PR DESCRIPTION
* Fixed the default ContentComboBox viewer, removing `any` typecast to the ContentSummaryViewer.
* Fixed toolbar position.
* Added additional check for the empty parent in case of its absence.