### PR TITLE
Issue Detail Dialog - Tooltip stays when the dialog has been escaped …

### DIFF
--- a/src/main/resources/assets/admin/common/js/dom/ElementRegistry.ts
+++ b/src/main/resources/assets/admin/common/js/dom/ElementRegistry.ts
@@ -26,6 +26,11 @@ module api.dom {
             return id;
         }
 
+        public static reRegisterElement(el: api.dom.Element) {
+            const id = el.getId();
+            ElementRegistry.elements[id] = el;
+        }
+
         public static unregisterElement(el: api.dom.Element) {
             if (el) {
                 delete ElementRegistry.elements[el.getId()];


### PR DESCRIPTION
…#768

-When elements are removed from DOM and then added back they're not reregistered in ElementRegistry; tooltip handler uses ElementRegistry to find elements and bind removed/hidden events to them, thus elements not found