### PR TITLE
Site configurator with HtmlArea - error in console when try to insert…

### DIFF
--- a/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
+++ b/src/main/resources/assets/admin/common/lib/ckeditor/plugins/image2/plugin.js
@@ -1501,7 +1501,11 @@
             return;
         }
 
-        CKEDITOR.on('dialogDefinition', function (evt) {
+        editor.on('contentDomUnload', function (evt) {
+            CKEDITOR.removeListener('dialogDefinition', df);
+        });
+
+        var df = function (evt) {
             var dialog = evt.data;
 
             if (dialog.name == 'link') {
@@ -1551,7 +1555,9 @@
                     }
                 };
             }
-        });
+        };
+
+        CKEDITOR.on('dialogDefinition', df);
 
         // Overwrite default behaviour of unlink command.
         editor.getCommand('unlink').on('exec', function (evt) {


### PR DESCRIPTION
… a link after an image was removed #802

-Seems to be ckeditor bug; when closing site config dialog it's editor is removed and destroyed but global event listener in image plugin remains and fires when inserting link in newly opened site config dialog; Fixed by removing listener