### PR TITLE
ConfirmationDialog - wrong behavior for "Enter"-key #818

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -624,7 +624,6 @@ module api.ui.treegrid {
         }
 
         private onEnterKeyPress() {
-            console.log('tree grid enter');
             if (this.highlightedNode) {
                 this.editItem(this.highlightedNode);
             }

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -184,7 +184,7 @@ module api.ui.treegrid {
                     new KeyBinding('right', this.onRightKeyPress.bind(this)),
                     new KeyBinding('mod+a', this.onAwithModKeyPress.bind(this)),
                     new KeyBinding('space', this.onSpaceKeyPress.bind(this)),
-                    new KeyBinding('enter', this.onEnterKeyPress.bind(this), KeyBindingAction.KEYUP)
+                    new KeyBinding('enter', this.onEnterKeyPress.bind(this))
                 ]);
             }
         }
@@ -624,6 +624,7 @@ module api.ui.treegrid {
         }
 
         private onEnterKeyPress() {
+            console.log('tree grid enter');
             if (this.highlightedNode) {
                 this.editItem(this.highlightedNode);
             }


### PR DESCRIPTION
-There's keybinding on 'enter' key set in TreeGrid that is shelved when modal dialog is open; When closing modal dialog with enter key and unshelving previous keybindings (including 'enter' handler) enter event is triggered immediately, seems because it is setup to be triggered on KEYUP. Fixed by setting treegrid's enter handler on keydown