### PR TITLE
Content Wizard - error in language selector #857

### DIFF
--- a/src/main/resources/assets/admin/common/js/locale/Locale.ts
+++ b/src/main/resources/assets/admin/common/js/locale/Locale.ts
@@ -2,6 +2,13 @@ module api.locale {
 
     export class Locale implements api.Equitable {
 
+        private static TH: string = 'th-TH-u-nu-thai-x-lvariant-TH';
+        private static TH_TAG: string = 'th-TH-TH';
+        private static JP: string = 'ja-JP-u-ca-japanese-x-lvariant-JP';
+        private static JP_TAG: string = 'ja-JP-JP';
+        private static NO: string = 'nn-NO-x-lvariant-NY';
+        private static NO_TAG: string = 'nn-NO-NY';
+
         private tag: string;
         private displayName: string;
         private language: string;
@@ -40,6 +47,31 @@ module api.locale {
         }
 
         public getTag() {
+            return this.tag;
+        }
+
+        public getId() {
+            if (this.tag === 'nn-NO' && this.variant === 'NY') {
+                return Locale.NO;
+            }
+
+            return this.tag;
+        }
+
+        // handling some special locale cases
+        public getProcessedTag() {
+            if (this.tag === Locale.JP) {
+                return Locale.JP_TAG;
+            }
+
+            if (this.tag === Locale.TH) {
+                return Locale.TH_TAG;
+            }
+
+            if (this.tag === 'nn-NO' && this.variant === 'NY') {
+                return Locale.NO_TAG;
+            }
+
             return this.tag;
         }
 

--- a/src/main/resources/assets/admin/common/js/ui/locale/LocaleComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/locale/LocaleComboBox.ts
@@ -12,9 +12,7 @@ module api.ui.locale {
                 this.clearSelection();
             });
             let builder = new api.ui.selector.combobox.RichComboBoxBuilder<Locale>().
-                setMaximumOccurrences(maxOccurrences || 0).
-                setComboBoxName('localeSelector').
-                setIdentifierMethod('getTag').
+                setMaximumOccurrences(maxOccurrences || 0).setComboBoxName('localeSelector').setIdentifierMethod('getId').
                 setLoader(new LocaleLoader()).
                 setValue(value).
                 setSelectedOptionsView(localeSelectedOptionsView).

--- a/src/main/resources/assets/admin/common/js/ui/locale/LocaleViewer.ts
+++ b/src/main/resources/assets/admin/common/js/ui/locale/LocaleViewer.ts
@@ -15,7 +15,8 @@ module api.ui.locale {
         }
 
         setObject(locale: Locale) {
-            this.namesView.setMainName(api.util.StringHelper.format(this.displayNamePattern, locale.getDisplayName(), locale.getTag()));
+            this.namesView.setMainName(
+                api.util.StringHelper.format(this.displayNamePattern, locale.getDisplayName(), locale.getProcessedTag()));
 
             return super.setObject(locale);
         }


### PR DESCRIPTION
-Three non-conforming locales must be treated as special cases. These are ja_JP_JP, th_TH_TH, nn_NO_NY. Last one have been breaking locale dropdown because it has same 'nn_NO' locale tag as a regular nn_NO locale