### PR TITLE
"Show page editor" button won't open Page Editor after details panel …

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/panel/SplitPanel.ts
+++ b/src/main/resources/assets/admin/common/js/ui/panel/SplitPanel.ts
@@ -671,7 +671,7 @@ module api.ui.panel {
             this.secondPanel.getEl().setRightPx(-this.secondPanel.getEl().getWidthWithBorder());
         }
 
-        private getSplitterThickness(): number {
+        getSplitterThickness(): number {
             return this.splitterIsHidden ? 0 : this.splitterThickness;
         }
 


### PR DESCRIPTION
…is expanded in the Wizard #891

-need to fetch splitter thickness