### PR TITLE
Confirm deletion of a changed item/option-set occurrence #895

### DIFF
--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -142,6 +142,7 @@ panel.filter.dependencies.outbound=Outbound Dependencies
 dialog.newContent.pathDescription=In
 dialog.confirm.title=Confirmation
 dialog.confirm.applyChanges=You have made changes to the form, do you want to apply them?
+dialog.confirm.occurrences.delete=The form data has been changed. Are you sure you want to delete it?
 
 
 #

--- a/src/main/resources/i18n/common_ru.properties
+++ b/src/main/resources/i18n/common_ru.properties
@@ -141,6 +141,7 @@ panel.filter.dependencies.outbound=Исходящие зависимости
 dialog.newContent.pathDescription=В
 dialog.confirm.title=Подтверждение
 dialog.confirm.applyChanges=Вы изменили значения в форме, применить изменения?
+dialog.confirm.occurrences.delete=Вы изменили значения в форме, уверены что хотите удалить их?
 
 #
 #    Drag & Drop


### PR DESCRIPTION
-Listening PropertyValueChangedEvent to know when any FormItemView data in FormSetOccurrenceView was updated
-Maintaining map like object to keep modified FormItemViews with their original and current value (FormItemView is added to map only after PropertyValueChangedEvent); When value reset back to original - removing FormItemView from map object
-If delete occurrence button pressed then checking if map object is empty or not