### PR TITLE
Browse toolbar is not refreshed when selected contents have been deleted #911

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -854,10 +854,6 @@ module api.ui.treegrid {
             return this.root;
         }
 
-        isNewlySelected(): boolean {
-            return this.getRoot().isNewlySelected();
-        }
-
         isActive(): boolean {
             return this.active;
         }

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1685,16 +1685,6 @@ module api.ui.treegrid {
             return this.gridData.getItem(rowIndex);
         }
 
-        private isSelectionEqual(selection: TreeNode<DATA>[]): boolean {
-            const currentSelection = this.root.getCurrentSelection();
-
-            if (selection.length !== currentSelection.length) {
-                return false;
-            }
-
-            return selection.every((node: TreeNode<DATA>) => currentSelection.indexOf(node) > -1);
-        }
-
         private notifySelectionChanged(rows: number[]): void {
             const newSelection: TreeNode<DATA>[] = [];
             if (rows) {
@@ -1703,13 +1693,13 @@ module api.ui.treegrid {
                 });
             }
 
-            if (this.isSelectionEqual(newSelection)) {
-                return;
-            }
+            const selectionWasRemoved = this.root.getSelectionChangeType() === SelectionChangeType.REMOVED;
 
             this.root.setCurrentSelection(newSelection);
 
-            this.triggerSelectionChangedListeners();
+            if (this.root.isSelectionChanged() || selectionWasRemoved) {
+                this.triggerSelectionChangedListeners();
+            }
         }
 
         private showContextMenuAt(x: number, y: number) {

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
@@ -15,8 +15,6 @@ module api.ui.treegrid {
 
         private filtered: boolean;
 
-        private newlySelected: boolean;
-
         private selectionChangeType: SelectionChangeType;
 
         private currentSelection: TreeNode<DATA>[];
@@ -33,8 +31,6 @@ module api.ui.treegrid {
             this.currentSelection = [];
 
             this.stashedSelection = [];
-
-            this.updateNewlySelected([]);
 
             this.selectionChangeType = SelectionChangeType.NONE;
         }
@@ -91,30 +87,6 @@ module api.ui.treegrid {
             this.filtered = filtered;
         }
 
-        isNewlySelected(): boolean {
-            return this.newlySelected;
-        }
-
-        // Should be called before selection changed
-        private updateNewlySelected(newSelection: TreeNode<DATA>[]) {
-            const isEmpty = (selection: TreeNode<DATA>[]) => (!selection || selection.length === 0);
-            const isUnary = (selection: TreeNode<DATA>[]) => (!!selection && selection.length === 1);
-            const isNew = (selection: TreeNode<DATA>) => {
-                return this.getFullSelection().map(el => el.getDataId()).every(id => id !== selection.getDataId());
-            };
-
-            const curr = this.currentSelection;
-            const stash = this.stashedSelection;
-
-            const firstSelection = newSelection[0];
-
-            if (isUnary(newSelection) && firstSelection && isNew(firstSelection)) {
-                this.newlySelected = isEmpty(stash);
-            } else { // isMultiary or isEmpty
-                this.newlySelected = isEmpty(curr) && isEmpty(stash);
-            }
-        }
-
         getSelectionChangeType(): SelectionChangeType {
             return this.selectionChangeType;
         }
@@ -148,10 +120,6 @@ module api.ui.treegrid {
 
         setCurrentSelection(selection: TreeNode<DATA>[]) {
             this.selectionChangeType = this.calcSelectionChangeType(selection);
-
-            if (this.isSelectionChanged()) {
-                this.updateNewlySelected(selection);
-            }
 
             this.currentSelection = selection;
 


### PR DESCRIPTION
* Added check for the selection modification type, to prevent multiple selection updates notification, even when the selection hasn't changed.
* Added check for the previous selection modification type to show notification, when the selection was removed.
* Removed obsolete checks for newly selected content.