### PR TITLE
Refactoring of modal dialogs

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/dialog/ConfirmationDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ConfirmationDialog.ts
@@ -12,18 +12,24 @@ module api.ui.dialog {
         private noAction: api.ui.Action;
 
         constructor(config: ModalDialogConfig = {}) {
-            super((() => {
-                config.title = config.title || i18n('dialog.confirm.title');
-                config.closeIconCallback = config.closeIconCallback || (() => this.close());
-                return config;
-            })());
+            super({
+                title: config.title || i18n('dialog.confirm.title'),
+                closeIconCallback: config.closeIconCallback || (() => this.close()),
+                class: 'confirmation-dialog'
+            });
+        }
 
-            this.addClass('confirmation-dialog');
+        protected initElements() {
+            super.initElements();
 
             this.questionEl = new api.dom.H6El('question');
-            this.appendChildToContentPanel(this.questionEl);
-
             this.noAction = new api.ui.Action(i18n('action.no'), 'esc');
+            this.yesAction = new api.ui.Action(i18n('action.yes'));
+        }
+
+        protected initListeners() {
+            super.initListeners();
+
             this.noAction.onExecuted(() => {
                 this.close();
 
@@ -32,7 +38,6 @@ module api.ui.dialog {
                 }
             });
 
-            this.yesAction = new api.ui.Action(i18n('action.yes'));
             this.yesAction.onExecuted(() => {
                 this.close();
 
@@ -40,10 +45,16 @@ module api.ui.dialog {
                     this.yesCallback();
                 }
             });
+        }
 
-            this.addAction(this.yesAction, true);
-            this.addAction(this.noAction);
+        doRender(): Q.Promise<boolean> {
+            return super.doRender().then((rendered) => {
+                this.appendChildToContentPanel(this.questionEl);
+                this.addAction(this.yesAction, true);
+                this.addAction(this.noAction);
 
+                return rendered;
+            });
         }
 
         setQuestion(question: string): ConfirmationDialog {

--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -44,6 +44,8 @@ module api.ui.dialog {
 
         protected closeIcon: DivEl;
 
+        protected loadMask: api.ui.mask.LoadMask;
+
         private cancelButton: DialogButton;
 
         protected confirmationDialog: ConfirmationDialog;
@@ -90,6 +92,7 @@ module api.ui.dialog {
             this.contentPanel = new ModalDialogContentPanel();
             this.body = new DivEl('modal-dialog-body');
             this.footer = new DivEl('modal-dialog-footer');
+            this.loadMask = new api.ui.mask.LoadMask(this.contentPanel);
             this.initConfirmationDialog();
         }
 
@@ -126,7 +129,7 @@ module api.ui.dialog {
         }
 
         protected postInitElements() {
-            //
+            this.loadMask.setRemoveWhenMaskedRemoved(false);
         }
 
         protected initListeners() {
@@ -383,6 +386,8 @@ module api.ui.dialog {
                 const wrapper = new DivEl('modal-dialog-wrapper');
                 wrapper.appendChildren<Element>(this.header, this.body, this.footer);
                 this.appendChild(wrapper);
+
+                this.appendChildToContentPanel(this.loadMask);
 
                 return rendered;
             });

--- a/src/main/resources/assets/admin/common/js/ui/mask/Mask.ts
+++ b/src/main/resources/assets/admin/common/js/ui/mask/Mask.ts
@@ -1,14 +1,18 @@
 module api.ui.mask {
 
     import ResponsiveManager = api.ui.responsive.ResponsiveManager;
+
     export class Mask extends api.dom.DivEl {
 
         private masked: api.dom.Element;
+
+        private removeWhenMaskedRemoved: boolean;
 
         constructor(itemToMask?: api.dom.Element) {
             super('mask', api.StyleHelper.COMMON_PREFIX);
 
             this.masked = itemToMask;
+            this.removeWhenMaskedRemoved = true;
 
             if (this.masked) {
                 this.masked.onHidden((event: api.dom.ElementHiddenEvent) => {
@@ -16,7 +20,11 @@ module api.ui.mask {
                         this.hide();
                     }
                 });
-                this.masked.onRemoved(() => this.remove());
+                this.masked.onRemoved(() => {
+                    if (this.removeWhenMaskedRemoved) {
+                        this.remove();
+                    }
+                });
                 // Masked element might have been resized on window resize
                 ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), () => {
                     if (this.isVisible()) {
@@ -25,6 +33,10 @@ module api.ui.mask {
                 });
             }
             api.dom.Body.get().appendChild(this);
+        }
+
+        setRemoveWhenMaskedRemoved(value: boolean) {
+            this.removeWhenMaskedRemoved = value;
         }
 
         show() {


### PR DESCRIPTION
-Divided modal dialog constructor init process to several phases:

1. Initializing variables (initElements() method), pure vars initialization
2. Doing actions not related to vars initializing, like setting click ignored element or setting element to focus on open or whatever that is supposed to be done after elements initialized (postInitElements() method)
3. Initializing event listeners (initListeners() method)

-Moved dom related actions, like appendChild() or addClass(), to doRender()

-Added mask/unmask methods to remove hardcoded addClass('masked')

-Added setElementToFocusOnShow() to set focus on correct element when dialogs is opened, taking into account if dialog is already rendered or not

-Saving dialog config in var