### PR TITLE
Site Wizard - broken layout after selecting a controller #947

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/ui/mask.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/mask.less
@@ -45,6 +45,7 @@
 
   &.load-mask {
     background-color: white;
+    overflow: hidden;
   }
 
   &.drag-mask {


### PR DESCRIPTION
Hid overflow to prevent spinner to be visible, even when the load mask has zero width, which may result in wrong calculations.