### PR TITLE
Item-set inside part config is not properly rendered in the Inspect panel #955

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
@@ -77,7 +77,8 @@ module api.form {
                         context: this.context,
                         formItemSet: formItemSet,
                         parent: this.parent,
-                        parentDataSet: propertySet
+                        parentDataSet: propertySet,
+                        occurrencesLazyRender: this.lazyRender
                     });
                 }
 

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetView.ts
@@ -116,7 +116,7 @@ module api.form {
                 }
             });
 
-            this.formItemOccurrences.getOccurrenceViews().map((formSetOccurrenceView: V)=> {
+            this.formItemOccurrences.getOccurrenceViews().forEach((formSetOccurrenceView: V) => {
                 formSetOccurrenceView.onValidityChanged((event: RecordingValidityChangedEvent) => {
                     this.handleFormSetOccurrenceViewValidityChanged(event);
                 });

--- a/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetOccurrenceView.ts
@@ -13,6 +13,8 @@ module api.form {
         parent: FormItemSetOccurrenceView;
 
         dataSet: PropertySet;
+
+        lazyRender?: boolean;
     }
 
     export class FormItemSetOccurrenceView extends FormSetOccurrenceView {
@@ -27,6 +29,7 @@ module api.form {
             this.propertySet = config.dataSet;
 
             this.formItemLayer = new FormItemLayer(config.context);
+            this.formItemLayer.setLazyRender(config.lazyRender);
         }
 
         private setTitle() {

--- a/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetOccurrences.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetOccurrences.ts
@@ -12,12 +12,16 @@ module api.form {
         parent: FormItemSetOccurrenceView;
 
         propertyArray: PropertyArray;
+
+        lazyRender?: boolean;
     }
 
     /*
      * A kind of a controller, which adds/removes FormItemSetOccurrenceView-s
      */
     export class FormItemSetOccurrences extends FormSetOccurrences<FormItemSetOccurrenceView> {
+
+        private lazyRender: boolean;
 
         constructor(config: FormItemSetOccurrencesConfig) {
             super(<FormItemOccurrencesConfig>{
@@ -31,23 +35,26 @@ module api.form {
             this.formSet = config.formItemSet;
             this.parent = config.parent;
             this.occurrencesCollapsed = false;
+            this.lazyRender = config.lazyRender;
         }
 
         createNewOccurrenceView(occurrence: FormSetOccurrence<FormItemSetOccurrenceView>): FormItemSetOccurrenceView {
 
-            let dataSet = this.getSetFromArray(occurrence);
+            const dataSet = this.getSetFromArray(occurrence);
 
-            let newOccurrenceView = new FormItemSetOccurrenceView(<FormItemSetOccurrenceViewConfig>{
+            const newOccurrenceView = new FormItemSetOccurrenceView(<FormItemSetOccurrenceViewConfig>{
                 context: this.context,
                 formSetOccurrence: occurrence,
                 formItemSet: <FormItemSet> this.formSet,
                 parent: this.parent,
-                dataSet: dataSet
+                dataSet: dataSet,
+                lazyRender: this.lazyRender
             });
 
             newOccurrenceView.onRemoveButtonClicked((event: RemoveButtonClickedEvent<FormItemSetOccurrenceView>) => {
                 this.removeOccurrenceView(event.getView());
             });
+
             return newOccurrenceView;
         }
     }

--- a/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetView.ts
@@ -11,9 +11,13 @@ module api.form {
         parent: FormItemSetOccurrenceView;
 
         parentDataSet: PropertySet;
+
+        occurrencesLazyRender?: boolean;
     }
 
     export class FormItemSetView extends FormSetView<FormItemSetOccurrenceView> {
+
+        private occurrencesLazyRender: boolean;
 
         constructor(config: FormItemSetViewConfig) {
             super(<FormItemViewConfig> {
@@ -26,6 +30,7 @@ module api.form {
             this.formSet = config.formItemSet;
             this.classPrefix = 'form-item-set';
             this.helpText = this.formSet.getHelpText();
+            this.occurrencesLazyRender = config.occurrencesLazyRender;
 
             this.addClass(this.formSet.getPath().getElements().length % 2 ? 'even' : 'odd');
             if (this.formSet.getOccurrences().getMaximum() === 1) {
@@ -40,7 +45,8 @@ module api.form {
                 occurrenceViewContainer: this.occurrenceViewsContainer,
                 formItemSet: <FormItemSet> this.formSet,
                 parent: this.getParent(),
-                propertyArray: this.getPropertyArray(this.parentDataSet)
+                propertyArray: this.getPropertyArray(this.parentDataSet),
+                lazyRender: this.occurrencesLazyRender
             });
         }
     }

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -79,7 +79,7 @@ module api.form {
 
         toggleHelpText(show?: boolean) {
             this.formItemLayer.toggleHelpText(show);
-            if (!!this.helpText) {
+            if (this.helpText) {
                 this.helpText.toggleHelpText(show);
             }
         }


### PR DESCRIPTION
* Added `lazyRender` status passing from one `FormItemLayer` to another through `FormItemSetOccurrenceView`, just like through the `FieldSetView` or `FormOptionSetOptionView`.