### PR TITLE
Display name field no longer gets focus in the new content wizard #969

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -276,7 +276,9 @@ module api.ui.selector.dropdown {
             let option = this.getOptionByRow(index);
             if (option != null) {
                 this.selectOption(option, silent);
-                api.dom.FormEl.moveFocusToNextFocusable(this.input);
+                if (!silent) {
+                    api.dom.FormEl.moveFocusToNextFocusable(this.input);
+                }
             }
         }
 


### PR DESCRIPTION
* Updated `selectRow` to not change the focus when the row is selected. `silent = false` is used by default most of the time but in some cases, like in `WidgetsSelectionRow` update, the previously selected row is restored in silent mode, which should not result in a focus change.