### PR TITLE
OptionSet wizard - Incorrect behavior of validation #983

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrences.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrences.ts
@@ -118,5 +118,31 @@ module api.form {
         refreshOccurence(index: number) {
             this.occurrenceViews[index].refreshViews();
         }
+
+        update(propertyArray: PropertyArray, unchangedOnly?: boolean): wemQ.Promise<void> {
+            if (propertyArray.isEmpty()) {
+                return this.updateNoData(propertyArray, unchangedOnly);
+            } else {
+                return super.update(propertyArray, unchangedOnly);
+            }
+        }
+
+        private updateNoData(propertyArray: PropertyArray, unchangedOnly?: boolean): wemQ.Promise<void> {
+            const promises: wemQ.Promise<void>[] = [];
+            const occurrencesViewClone: V[] = [].concat(this.occurrenceViews);
+            const occurrencesNoDataSize: number = this.constructOccurrencesForNoData().length;
+
+            for (let i = 0; i < occurrencesNoDataSize; i++) {
+                promises.push(this.updateOccurrenceView(occurrencesViewClone[i], propertyArray, unchangedOnly));
+            }
+
+            for (let i = occurrencesNoDataSize; i < occurrencesViewClone.length; i++) {
+                this.removeOccurrenceView(occurrencesViewClone[i]);
+            }
+
+            this.propertyArray = propertyArray;
+
+            return wemQ.all(promises).spread<void>(() => wemQ<void>(null));
+        }
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -421,7 +421,7 @@ module api.form {
 
         update(propertySet: api.data.PropertySet, unchangedOnly?: boolean): Q.Promise<void> {
             this.parentDataSet = propertySet;
-            const propertyArray = this.getOptionItemsPropertyArray(propertySet);
+            const propertyArray: PropertyArray = this.getOptionItemsPropertyArray(propertySet);
 
             return this.formItemLayer.update(propertyArray.getSet(0), unchangedOnly).then(() => {
                 if (!this.isRadioSelection()) {
@@ -430,7 +430,14 @@ module api.form {
                     if (this.getThisPropertyFromSelectedOptionsArray() == null) {
                         wemjq(this.getHTMLElement()).find('input:radio').first().prop('checked', false);
                     }
-                    this.subscribedOnDeselect = false;
+
+                    const selectedProperty = this.getSelectedOptionsArray().get(0);
+                    if (selectedProperty) {
+                        this.subscribeOnRadioDeselect(selectedProperty);
+                        this.subscribedOnDeselect = true;
+                    } else {
+                        this.subscribedOnDeselect = false;
+                    }
                 }
 
                 this.updateViewState();


### PR DESCRIPTION
Fixed so form sets get correctly updated after content is saved.
Issue is with how we store option set data and how it is set in wizard; when option set is created (during layout() invocation) in wizard it adds empty property set for each option available to be chosen (that is not saved if option is not selected), but that doesn't happen after content is saved/updated