### PR TITLE
Move PropertyTreeHelper from CS to lib-admin-ui

### DIFF
--- a/src/main/resources/assets/admin/common/js/security/IdProviderConfig.ts
+++ b/src/main/resources/assets/admin/common/js/security/IdProviderConfig.ts
@@ -1,4 +1,7 @@
 module api.security {
+
+    import PropertyTreeHelper = api.util.PropertyTreeHelper;
+
     export class IdProviderConfig
         implements api.Equitable {
         private applicationKey: api.application.ApplicationKey;
@@ -25,7 +28,7 @@ module api.security {
             return new IdProviderConfigBuilder().fromJson(json).build();
         }
 
-        equals(o: api.Equitable): boolean {
+        equals(o: api.Equitable, ignoreEmptyValues: boolean = false): boolean {
             if (!api.ObjectHelper.iFrameSafeInstanceOf(o, IdProviderConfig)) {
                 return false;
             }
@@ -33,7 +36,7 @@ module api.security {
             let other = <IdProviderConfig> o;
 
             return this.applicationKey.equals(other.applicationKey) &&
-                   this.config.equals(other.config);
+                   PropertyTreeHelper.propertyTreesEqual(this.config, other.config, ignoreEmptyValues);
         }
 
         toJson(): IdProviderConfigJson {

--- a/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
@@ -12,14 +12,20 @@ module api.util {
         }
 
         static propertyTreesEqual(config: PropertyTree, otherConfig: PropertyTree, ignoreEmptyValues: boolean = true): boolean {
-            if (ignoreEmptyValues && (!config || config.isEmpty()) && (!otherConfig || otherConfig.isEmpty())) {
+            if (ignoreEmptyValues) {
+                return PropertyTreeHelper.propertyTreesEqualIgnoreEmptyValues(config, otherConfig);
+            }
+
+            return api.ObjectHelper.equals(config, otherConfig);
+        }
+
+        static propertyTreesEqualIgnoreEmptyValues(config: PropertyTree, otherConfig: PropertyTree): boolean {
+            if ((!config || config.isEmpty()) && (!otherConfig || otherConfig.isEmpty())) {
                 return true;
             }
 
-            const data: PropertyTree = !!config && ignoreEmptyValues ? PropertyTreeHelper.trimPropertyTree(config) : config;
-            const otherData: PropertyTree = !!otherConfig && ignoreEmptyValues
-                                            ? PropertyTreeHelper.trimPropertyTree(otherConfig)
-                                            : otherConfig;
+            const data: PropertyTree = !!config ? PropertyTreeHelper.trimPropertyTree(config) : config;
+            const otherData: PropertyTree = !!otherConfig ? PropertyTreeHelper.trimPropertyTree(otherConfig) : otherConfig;
 
             return api.ObjectHelper.equals(data, otherData);
         }

--- a/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
@@ -1,0 +1,27 @@
+module api.util {
+
+    import PropertyTree = api.data.PropertyTree;
+
+    export class PropertyTreeHelper {
+
+        static trimPropertyTree(data: PropertyTree): PropertyTree {
+            const copy: PropertyTree = data.copy();
+            copy.getRoot().removeEmptyValues();
+
+            return copy;
+        }
+
+        static propertyTreesEqual(config: PropertyTree, otherConfig: PropertyTree, ignoreEmptyValues: boolean = true): boolean {
+            if (ignoreEmptyValues && (!config || config.isEmpty()) && (!otherConfig || otherConfig.isEmpty())) {
+                return true;
+            }
+
+            const data: PropertyTree = !!config && ignoreEmptyValues ? PropertyTreeHelper.trimPropertyTree(config) : config;
+            const otherData: PropertyTree = !!otherConfig && ignoreEmptyValues
+                                            ? PropertyTreeHelper.trimPropertyTree(otherConfig)
+                                            : otherConfig;
+
+            return ObjectHelper.equals(data, otherData);
+        }
+    }
+}

--- a/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
@@ -31,11 +31,15 @@ module api.util {
         }
 
         private static bothEmpty(config: PropertyTree, otherConfig: PropertyTree): boolean {
-            if ((!config || config.isEmpty()) && (!otherConfig || otherConfig.isEmpty())) {
+            if (PropertyTreeHelper.isEmpty(config) && PropertyTreeHelper.isEmpty(otherConfig)) {
                 return true;
             }
 
             return false;
+        }
+
+        private static isEmpty(config: PropertyTree): boolean {
+            return !config || config.isEmpty();
         }
     }
 }

--- a/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
@@ -24,8 +24,8 @@ module api.util {
                 return true;
             }
 
-            const data: PropertyTree = !!config ? PropertyTreeHelper.trimPropertyTree(config) : config;
-            const otherData: PropertyTree = !!otherConfig ? PropertyTreeHelper.trimPropertyTree(otherConfig) : otherConfig;
+            const data: PropertyTree = config ? PropertyTreeHelper.trimPropertyTree(config) : config;
+            const otherData: PropertyTree = otherConfig ? PropertyTreeHelper.trimPropertyTree(otherConfig) : otherConfig;
 
             return api.ObjectHelper.equals(data, otherData);
         }

--- a/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
@@ -21,7 +21,7 @@ module api.util {
                                             ? PropertyTreeHelper.trimPropertyTree(otherConfig)
                                             : otherConfig;
 
-            return ObjectHelper.equals(data, otherData);
+            return api.ObjectHelper.equals(data, otherData);
         }
     }
 }

--- a/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/PropertyTreeHelper.ts
@@ -20,7 +20,7 @@ module api.util {
         }
 
         static propertyTreesEqualIgnoreEmptyValues(config: PropertyTree, otherConfig: PropertyTree): boolean {
-            if ((!config || config.isEmpty()) && (!otherConfig || otherConfig.isEmpty())) {
+            if (PropertyTreeHelper.bothEmpty(config, otherConfig)) {
                 return true;
             }
 
@@ -28,6 +28,14 @@ module api.util {
             const otherData: PropertyTree = otherConfig ? PropertyTreeHelper.trimPropertyTree(otherConfig) : otherConfig;
 
             return api.ObjectHelper.equals(data, otherData);
+        }
+
+        private static bothEmpty(config: PropertyTree, otherConfig: PropertyTree): boolean {
+            if ((!config || config.isEmpty()) && (!otherConfig || otherConfig.isEmpty())) {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/main/resources/assets/admin/common/js/util/_module.ts
+++ b/src/main/resources/assets/admin/common/js/util/_module.ts
@@ -17,3 +17,4 @@
 ///<reference path='LocalDateTime.ts' />
 ///<reference path='DateTime.ts' />
 ///<reference path='Timezone.ts' />
+///<reference path='PropertyTreeHelper.ts' />


### PR DESCRIPTION
Moving PropertyTreeHelper.ts from contentstudio to lib-admin-ui thus any app could use it.