### PR TITLE
Row loses selection after the content has been modified in sorted and…

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/ui/treegrid/tree-grid.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/treegrid/tree-grid.less
@@ -63,7 +63,7 @@
         .notSelectable();
       }
 
-      .selected, &.selected {
+      .selected, &.selected, .highlight {
         background-color: @admin-blue;
         color: @admin-white;
 


### PR DESCRIPTION
… scrollable grid #982

-Highlighting was lost when grid redraws its' items; Fixed treegrid to set highlighting correctly via slickgrid api so it is preserved when grid updates items