### PR TITLE
ContentPath class has problem with fromParent() method #1014

### DIFF
--- a/src/main/resources/assets/admin/common/js/content/ContentPath.ts
+++ b/src/main/resources/assets/admin/common/js/content/ContentPath.ts
@@ -11,9 +11,7 @@ module api.content {
         private refString: string;
 
         public static fromParent(parent: ContentPath, name: string): ContentPath {
-
-            let elements = parent.elements;
-            elements.push(name);
+            const elements: string[] = [].concat(parent.getElements(), name);
             return new ContentPath(elements);
         }
 


### PR DESCRIPTION
-fromParent() method operates directly on parent's array of elements instead of making copy, thus parent's elements array gets modified when creating ContentPath instance using this method