### PR TITLE
Selecting content items with a checkbox no longer enables toolbar act…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
@@ -250,7 +250,7 @@ module api.ui.grid {
         }
 
         getSelectedRows(): number[] {
-            return this.slickGrid.getSelectedRows();
+            return this.slickGrid.getSelectedRows().slice();
         }
 
         getSelectedRowItems(): T[] {


### PR DESCRIPTION
…ions #1016

-When taking slickgrid's selected rows array we used to manipulate it's directly (original one was returned) instead of making array copy