### PR TITLE
Scrollbar in the tree grid is not taking full available height #1043

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/ui/treegrid/tree-grid.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/treegrid/tree-grid.less
@@ -8,7 +8,7 @@
     padding-top: 40px;
   }
 
-  .slick-viewport {
+  .slick-pane-top, .slick-viewport {
     overflow-x: hidden !important;
     height: 100% !important; // only without animation
   }


### PR DESCRIPTION
-SlickGrid structure changed after latest update, need to reflect those changes in css