### PR TITLE
Handle overflow in modal dialogs on page resize

### DIFF
--- a/src/main/resources/assets/admin/common/js/dom/ElementHelper.ts
+++ b/src/main/resources/assets/admin/common/js/dom/ElementHelper.ts
@@ -383,6 +383,10 @@ module api.dom {
             return this;
         }
 
+        getMaxHeight(): number {
+            return parseFloat(this.getComputedProperty('max-height')) || 0;
+        }
+
         setMinHeight(value: string): ElementHelper {
             this.el.style.minHeight = value;
             return this;
@@ -391,6 +395,10 @@ module api.dom {
         setMinHeightPx(value: number): ElementHelper {
             this.setMinHeight(value + 'px');
             return this;
+        }
+
+        getMinHeight(): number {
+            return parseFloat(this.getComputedProperty('min-height')) || 0;
         }
 
         getHeightWithoutPadding(): number {

--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -273,9 +273,8 @@ module api.ui.dialog {
             };
             ResponsiveManager.onAvailableSizeChanged(Body.get(), this.handleResize);
 
-            const resizeObserver = window['ResizeObserver'];
-            if (resizeObserver) {
-                this.resizeObserver = new resizeObserver(this.handleResize);
+            if (window['ResizeObserver']) {
+                this.resizeObserver = new window['ResizeObserver'](this.handleResize);
             }
         }
 

--- a/src/main/resources/assets/admin/common/styles/api/ui/dialog/modal-dialog.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/dialog/modal-dialog.less
@@ -54,6 +54,7 @@
 
   .modal-dialog-body {
     padding: 15px 30px 0 30px;
+    overflow: auto;
     flex: 1;
     max-height: 50vh;
   }

--- a/src/main/resources/assets/admin/common/styles/api/ui/dialog/modal-dialog.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/dialog/modal-dialog.less
@@ -57,7 +57,13 @@
     overflow: auto;
     flex: 1;
     max-height: 50vh;
+
+    &.non-scrollable {
+      overflow: visible;
+    }
   }
+
+
 
   .modal-dialog-footer {
     padding: 20px 30px;


### PR DESCRIPTION
* Updated overflow update, making element to use the default one (auto), until the debounced handler does not update it.
* Updated ModalDialog to use CSS classes, instead of setting properties directly.
* Refactored resize handlers.