### PR TITLE
Incorrect overflow behaviour inside modal dialog after resize

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -379,9 +379,8 @@ module api.ui.dialog {
         hide() {
             if (this.resizeObserver) {
                 this.resizeObserver.unobserve(this.body.getHTMLElement());
-            } else {
-                this.unResize(this.handleResize);
             }
+            this.unResize(this.handleResize);
 
             if (this.isSingleDialogGroup()) {
                 this.unBlurBackground();
@@ -565,9 +564,8 @@ module api.ui.dialog {
             }
             if (this.resizeObserver) {
                 this.resizeObserver.observe(this.body.getHTMLElement());
-            } else {
-                this.onResize(this.handleResize);
             }
+            this.onResize(this.handleResize);
 
             wemjq(this.body.getHTMLElement()).css('height', '');
         }


### PR DESCRIPTION
…n Publishing Wizard #1078

Added `onResize` handler, even if `ResizeObserver` is present, since the resize handler is optimized and may cover some resize handlers in this case.