### PR TITLE
Error after selecting an option in Image Selector

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -574,20 +574,23 @@ module api.ui.selector.combobox {
                    (filteredOption.sort().join() !== gridOptions.sort().join());
         }
 
-        selectRowOrApplySelection(index: number, keyCode: number = -1) {
-
+        private handleEnterPressed() {
             // fast alternative to isSelectionChanged()
             if (this.applySelectionsButton && this.applySelectionsButton.isVisible()) {
-                this.selectiondDelta.forEach((value: string) => {
-                    let row = this.comboBoxDropdown.getDropdownGrid().getRowByValue(value);
-                    this.handleRowSelected(row, keyCode);
-                });
-                this.input.setValue('');
-                this.hideDropdown();
+                this.applySelection(13);
             } else {
-                this.handleRowSelected(index, keyCode);
-                this.input.setValue('');
+                this.handleRowSelected(this.comboBoxDropdown.getActiveRow(), 13);
+                this.input.setValue('', true);
             }
+        }
+
+        private applySelection(keyCode: number = -1) {
+            this.selectiondDelta.forEach((value: string) => {
+                const row: number = this.comboBoxDropdown.getDropdownGrid().getRowByValue(value);
+                this.handleRowSelected(row, keyCode);
+            });
+            this.input.setValue('', true);
+            this.hideDropdown();
         }
 
         selectOption(option: Option<OPTION_DISPLAY_VALUE>, silent: boolean = false, keyCode: number = -1) {
@@ -789,7 +792,7 @@ module api.ui.selector.combobox {
             });
 
             if (this.applySelectionsButton) {
-                this.applySelectionsButton.onClicked(this.selectRowOrApplySelection.bind(this, -1));
+                this.applySelectionsButton.onClicked(this.applySelection.bind(this));
             }
 
             this.input.onValueChanged((event: api.ValueChangedEvent) => {
@@ -937,7 +940,7 @@ module api.ui.selector.combobox {
                 this.input.setReadOnly(true);
                 break;
             case 13: // Enter
-                this.selectRowOrApplySelection(this.comboBoxDropdown.getActiveRow(), 13);
+                this.handleEnterPressed();
                 break;
             case 32: // Spacebar
                 if (this.input.isReadOnly() && this.applySelectionsButton) {


### PR DESCRIPTION
-Combobox has incorrect behaviour - when there's something typed in it's input and apply/enter pressed then input's value gets reset with empty string '', that triggers unwanted loader requests on closed combobox dropdown
-In case of image selector: enter/apply on filtered combobox triggers slickgrid's update that goes into infinite cycle because of our gallery mode logic
-Fixed via resetting input's value silently