### PR TITLE
TreeGrid in Dropdown: postload() on TreeGrid is being invoked constan…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/DropdownTreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/DropdownTreeGrid.ts
@@ -134,5 +134,13 @@ module api.ui.selector {
             const item = this.getGridData().getItemById(value);
             return item ? item.getData() : null;
         }
+
+        show() {
+            this.optionsTreeGrid.show();
+        }
+
+        hide() {
+            this.optionsTreeGrid.hide();
+        }
     }
 }


### PR DESCRIPTION
…tly even after dropdown is collapsed #1132

-TreeGrid's postload() is toggled on it's grid shown/hidden, so for DropdownTreeGrid have to toggle show/hide methods instead off pure css; Otherwise after TreeGrid is shown first time it's postload() will be running constantly, even after dropdown is collapsed