### PR TITLE
Selection is not reset in in the Inspect panel's descriptor selector …

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -147,6 +147,10 @@ module api.ui.selector.dropdown {
             this.dropdownList.resetActiveSelection();
         }
 
+        resetSelected() {
+            this.dropdownList.markSelections([]);
+        }
+
         private defaultFilter(option: Option<OPTION_DISPLAY_VALUE>, args: any) {
 
             if (!args.searchString || api.util.StringHelper.isEmpty(args.searchString)) {


### PR DESCRIPTION
…#1103

-adding possibility to reset 'selected' class on grid items