### PR TITLE
Selected item loses selection after grid refresh #1148

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -82,6 +82,8 @@ module api.ui.treegrid {
 
         private keyBindings: KeyBinding[] = [];
 
+        private expandedNodesDataIds: string[] = [];
+
         constructor(builder: TreeGridBuilder<DATA>) {
 
             super(builder.getClasses());
@@ -900,14 +902,21 @@ module api.ui.treegrid {
         private loadEmptyNode(node: TreeNode<DATA>) {
             if (!this.getDataId(node.getData())) {
                 this.fetchChildren(node.getParent()).then((dataList: DATA[]) => {
-                    let oldChildren = node.getParent().getChildren();
+                    const oldChildren: TreeNode<DATA>[] = node.getParent().getChildren();
                     // Ensure to remove empty node from the end if present
                     if (oldChildren.length > 0 && oldChildren[oldChildren.length - 1].getDataId() === '') {
                         oldChildren.pop();
                     }
-                    let fetchedChildren = this.dataToTreeNodes(dataList, node.getParent());
-                    let needToCheckFetchedChildren = this.areAllOldChildrenSelected(oldChildren);
-                    let newChildren = oldChildren.concat(fetchedChildren.slice(oldChildren.length));
+                    const fetchedChildren: TreeNode<DATA>[] = this.dataToTreeNodes(dataList, node.getParent());
+                    const needToCheckFetchedChildren: boolean = this.areAllOldChildrenSelected(oldChildren);
+                    const childrenToAdd: TreeNode<DATA>[] = fetchedChildren.slice(oldChildren.length);
+                    childrenToAdd
+                        .filter((child: TreeNode<DATA>) => this.expandedNodesDataIds.indexOf(child.getDataId()) > -1)
+                        .forEach((child: TreeNode<DATA>) => {
+                            child.setExpanded(true);
+                            this.expandNode(child);
+                        });
+                    const newChildren: TreeNode<DATA>[] = oldChildren.concat(childrenToAdd);
                     node.getParent().setChildren(newChildren);
                     this.initData(this.root.getCurrentRoot().treeToList());
                     if (needToCheckFetchedChildren) {
@@ -1164,10 +1173,7 @@ module api.ui.treegrid {
 
         // Hard reset
 
-        reload(parentNodeData?: DATA, _idPropertyName?: string, rememberExpanded: boolean = true): wemQ.Promise<void> {
-            const expandedNodesDataId = rememberExpanded ? this.grid.getDataView().getItems()
-                .filter(item => item.isExpanded()).map(item => item.getDataId()) : [];
-
+        reload(parentNodeData?: DATA): wemQ.Promise<void> {
             const selection = this.root.getCurrentSelection();
             const highlightedNode = this.highlightedNode;
 
@@ -1178,7 +1184,7 @@ module api.ui.treegrid {
 
             this.mask();
 
-            return this.reloadNode(null, expandedNodesDataId)
+            return this.reloadNode(null)
                 .then(() => {
                     this.root.setCurrentSelection(selection);
                     const root = this.root.getCurrentRoot();
@@ -1223,10 +1229,10 @@ module api.ui.treegrid {
             }
         }
 
-        private reloadNode(parentNode?: TreeNode<DATA>, expandedNodesDataId?: String[]): wemQ.Promise<void> {
+        private reloadNode(parentNode?: TreeNode<DATA>): wemQ.Promise<void> {
 
-            let deferred = wemQ.defer<void>();
-            let promises = [];
+            const deferred = wemQ.defer<void>();
+            const promises = [];
 
             this.fetchData(parentNode).then((dataList: DATA[]) => {
                 let hasNotEmptyChildren = false;
@@ -1235,14 +1241,14 @@ module api.ui.treegrid {
                 parentNode.getChildren().length = 0;
 
                 dataList.forEach((data: DATA) => {
-                    let child = this.dataToTreeNode(data, parentNode);
-                    let dataId = this.getDataId(data);
-                    child.setExpanded(this.expandAll || expandedNodesDataId.indexOf(dataId) > -1);
+                    const child = this.dataToTreeNode(data, parentNode);
+                    const dataId = this.getDataId(data);
+                    child.setExpanded(this.expandAll || this.expandedNodesDataIds.indexOf(dataId) > -1);
                     parentNode.addChild(child);
 
                     if (child.isExpanded() && this.hasChildren(data)) {
                         hasNotEmptyChildren = true;
-                        promises.push(this.reloadNode(child, expandedNodesDataId));
+                        promises.push(this.reloadNode(child));
                     }
                 });
 
@@ -1567,43 +1573,55 @@ module api.ui.treegrid {
         }
 
         expandNode(node?: TreeNode<DATA>, expandAll: boolean = false): wemQ.Promise<boolean> {
-            let deferred = wemQ.defer<boolean>();
-
             node = node || this.root.getCurrentRoot();
 
             if (node) {
-                node.setExpanded(true);
-
-                if (node.hasChildren()) {
-                    this.initData(this.root.getCurrentRoot().treeToList());
-                    this.updateExpanded();
-                    if (expandAll) {
-                        node.getChildren().forEach((child: TreeNode<DATA>) => {
-                            this.expandNode(child, false);
-                        });
-                    }
-                    deferred.resolve(true);
-                } else {
-                    this.mask();
-                    this.fetchData(node)
-                        .then((dataList: DATA[]) => {
-                            node.setChildren(this.dataToTreeNodes(dataList, node, expandAll));
-                            this.initData(this.root.getCurrentRoot().treeToList());
-                            this.updateExpanded();
-                            if (expandAll) {
-                                node.getChildren().forEach((child: TreeNode<DATA>) => {
-                                    this.expandNode(child, false);
-                                });
-                            }
-                            deferred.resolve(true);
-                        }).catch((reason: any) => {
-                        this.handleError(reason);
-                        deferred.resolve(false);
-                    }).done(() => this.notifyLoaded());
-                }
+                return this.doExpandNode(node, expandAll);
             }
 
-            return deferred.promise;
+            return wemQ(false);
+        }
+
+        private doExpandNode(node: TreeNode<DATA>, expandAll: boolean = false): wemQ.Promise<boolean> {
+            node.setExpanded(true);
+
+            if (this.expandedNodesDataIds.indexOf(node.getDataId()) < 0) {
+                this.expandedNodesDataIds.push(node.getDataId());
+            }
+
+            return this.fetchExpandedNodeChildren(node)
+                .then(() => {
+                    this.initData(this.root.getCurrentRoot().treeToList());
+                    this.updateExpanded();
+                    this.expandNodeChildren(node, expandAll);
+
+                    return wemQ(true);
+                }).catch((reason: any) => {
+                    this.handleError(reason);
+                    return false;
+                });
+        }
+
+        private fetchExpandedNodeChildren(node: TreeNode<DATA>, expandAll: boolean = false): wemQ.Promise<void> {
+            if (node.hasChildren()) {
+                return wemQ(null);
+            }
+
+            this.mask();
+
+            return this.fetchData(node)
+                .then((dataList: DATA[]) => {
+                    node.setChildren(this.dataToTreeNodes(dataList, node, expandAll));
+                })
+                .finally(this.unmask.bind(this));
+        }
+
+        private expandNodeChildren(node: TreeNode<DATA>, expandAll: boolean) {
+            node.getChildren().forEach((child: TreeNode<DATA>) => {
+                if (expandAll || this.expandedNodesDataIds.indexOf(child.getDataId()) > -1) {
+                    this.expandNode(child);
+                }
+            });
         }
 
         isAllSelected(): boolean {
@@ -1642,9 +1660,13 @@ module api.ui.treegrid {
 
         collapseNode(node: TreeNode<DATA>, collapseAll: boolean = false) {
             node.setExpanded(false);
+            this.expandedNodesDataIds.splice(this.expandedNodesDataIds.indexOf(node.getDataId()), 1);
 
             if (collapseAll) {
-                node.treeToList(false, false).forEach(n => n.setExpanded(false));
+                node.treeToList(false, false).forEach((n: TreeNode<DATA>) => {
+                    n.setExpanded(false);
+                    this.expandedNodesDataIds.splice(this.expandedNodesDataIds.indexOf(n.getDataId()), 1);
+                });
             }
 
             // Save the selected collapsed rows in cache
@@ -1854,6 +1876,10 @@ module api.ui.treegrid {
             }
 
             return null;
+        }
+
+        resetExpandedNodesDataIds() {
+            this.expandedNodesDataIds = [];
         }
     }
 }

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1595,7 +1595,7 @@ module api.ui.treegrid {
                     this.updateExpanded();
                     this.expandNodeChildren(node, expandAll);
 
-                    return wemQ(true);
+                    return true;
                 }).catch((reason: any) => {
                     this.handleError(reason);
                     return false;


### PR DESCRIPTION
-Maintaining list of expanded nodes, thus after grid is reloaded it's nodes that will be loaded on scroll will be expanded if needed