### PR TITLE
Fix the way <head> element is added to the HTML document

### DIFF
--- a/src/main/resources/assets/admin/common/js/dom/Body.ts
+++ b/src/main/resources/assets/admin/common/js/dom/Body.ts
@@ -16,7 +16,7 @@ module api.dom {
             let html = Element.fromHtmlElement(body.parentElement);
 
             if (html.getEl().getChild(0) instanceof HTMLHeadElement) {
-                html.appendChild(Element.fromHtmlElement(<HTMLElement>html.getEl().getChild(0)));
+                html.insertChild(Element.fromHtmlElement(<HTMLElement>html.getEl().getChild(1)), 1);
             }
 
             super(new ElementFromHelperBuilder().setHelper(new ElementHelper(body)).setLoadExistingChildren(loadExistingChildren));


### PR DESCRIPTION
…ave #1157

-Issue is related to https://github.com/enonic/lib-admin-ui/issues/283, we used to do a trick with switching positions of head and body elements to keep `<head>` element first within it's `<html> `parent, however moving head makes all resources placed in head, including css, reload and that makes page reapply styles when they are loaded; restoring highlighted selection is invoked during resources load, thus position of highlighter is calculated before styles applied and gets shifted after reload
-Solved by moving` <body>` element instead of `<head>`