### PR TITLE
Draggable plugin is called in the wrong context #1181

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/DragHelper.ts
+++ b/src/main/resources/assets/admin/common/js/ui/DragHelper.ts
@@ -17,11 +17,11 @@ export class DragHelper
     }
 
     static get(): DragHelper {
-        let instance: DragHelper = Store.parentInstance().get(DRAG_HELPER_KEY);
+        let instance: DragHelper = Store.instance().get(DRAG_HELPER_KEY);
 
         if (instance == null) {
             instance = new DragHelper();
-            Store.parentInstance().set(DRAG_HELPER_KEY, instance);
+            Store.instance().set(DRAG_HELPER_KEY, instance);
         }
 
         return instance;


### PR DESCRIPTION
Replaced `DragHelper` root instance with the local (document).
When the instance of the `DragHelper` was passing to the drag handlers in the iframe, the handlers were evaluating the scrollableParent incorrectly, using root `document`, instead of the one from an iframe.