### PR TITLE
Add escape for all unsafe data, passed to setInnerHtml method #1145

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/NamesAndIconView.ts
+++ b/src/main/resources/assets/admin/common/js/app/NamesAndIconView.ts
@@ -82,7 +82,7 @@ export class NamesAndIconView
     }
 
     setMainName(value: string): NamesAndIconView {
-        this.namesView.setMainName(value, false);
+        this.namesView.setMainName(value);
         return this;
     }
 

--- a/src/main/resources/assets/admin/common/js/app/NamesView.ts
+++ b/src/main/resources/assets/admin/common/js/app/NamesView.ts
@@ -25,11 +25,20 @@ export class NamesView
         this.appendChild(this.subNameEl);
     }
 
-    setMainName(value: string, escapeHtml: boolean = true): NamesView {
-        this.mainNameEl.setHtml(value, escapeHtml);
+    setMainName(value: string): NamesView {
+        this.mainNameEl.setHtml(value);
         if (this.addTitleAttribute) {
             this.mainNameEl.getEl().setAttribute('title', value);
         }
+        return this;
+    }
+
+    setMainNameElements(elements: Element[]): NamesView {
+        this.mainNameEl.removeChildren();
+        elements.forEach((element: Element) => {
+            this.mainNameEl.appendChild(element);
+        });
+
         return this;
     }
 
@@ -42,6 +51,7 @@ export class NamesView
     }
 
     setSubNameElements(elements: Element[]): NamesView {
+        this.subNameEl.removeChildren();
         elements.forEach((element: Element) => {
             this.subNameEl.appendChild(element);
         });

--- a/src/main/resources/assets/admin/common/js/app/view/ItemStatisticsHeader.ts
+++ b/src/main/resources/assets/admin/common/js/app/view/ItemStatisticsHeader.ts
@@ -39,7 +39,8 @@ export class ItemStatisticsHeader<M extends Equitable>
             this.prependChild(this.iconEl);
 
             let displayName = item.getDisplayName() || '';
-            this.headerTitleEl.getEl().setInnerHtml(displayName).setAttribute('title', displayName);
+            this.headerTitleEl.setHtml(displayName);
+            this.headerTitleEl.getEl().setAttribute('title', displayName);
 
             this.headerPathEl.removeChildren();
             if (item.getPath()) {

--- a/src/main/resources/assets/admin/common/js/dom/AEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/AEl.ts
@@ -9,7 +9,7 @@ export class AEl
         this.setUrl('#');
     }
 
-    public setUrl(value: string, target?: string): AEl {
+    setUrl(value: string, target?: string): AEl {
         this.getEl().setAttribute('href', value);
         if (target) {
             this.getEl().setAttribute('target', target);
@@ -17,24 +17,30 @@ export class AEl
         return this;
     }
 
-    public setTitle(value: string): AEl {
+    setTitle(value: string): AEl {
         this.getEl().setTitle(value);
         return this;
     }
 
-    public getTitle(): string {
+    getTitle(): string {
         return this.getEl().getTitle();
     }
 
-    public getHref(): string {
+    getHref(): string {
         return this.getEl().getAttribute('href');
     }
 
-    public getTarget(): string {
+    getTarget(): string {
         return this.getEl().getAttribute('target');
     }
 
-    public getText(): string {
+    getText(): string {
         return this.getEl().getText();
+    }
+
+    static fromText(text: string): AEl {
+        const a = new AEl();
+        a.setHtml(text);
+        return a;
     }
 }

--- a/src/main/resources/assets/admin/common/js/dom/BEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/BEl.ts
@@ -1,0 +1,15 @@
+import {Element, NewElementBuilder} from './Element';
+
+export class BEl
+    extends Element {
+
+    constructor(className?: string, prefix?: string) {
+        super(new NewElementBuilder().setTagName('b').setClassName(className, prefix));
+    }
+
+    static fromText(text: string): BEl {
+        const b = new BEl();
+        b.setHtml(text);
+        return b;
+    }
+}

--- a/src/main/resources/assets/admin/common/js/dom/IEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/IEl.ts
@@ -6,4 +6,10 @@ export class IEl
     constructor(className?: string) {
         super(new NewElementBuilder().setTagName('i').setClassName(className));
     }
+
+    static fromText(text: string): IEl {
+        const i = new IEl();
+        i.setHtml(text);
+        return i;
+    }
 }

--- a/src/main/resources/assets/admin/common/js/dom/SpanEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/SpanEl.ts
@@ -6,4 +6,10 @@ export class SpanEl
     constructor(className?: string, prefix?: string) {
         super(new NewElementBuilder().setTagName('span').setClassName(className, prefix));
     }
+
+    static fromText(text: string): SpanEl {
+        const span = new SpanEl();
+        span.setHtml(text);
+        return span;
+    }
 }

--- a/src/main/resources/assets/admin/common/js/ui/button/Button.ts
+++ b/src/main/resources/assets/admin/common/js/ui/button/Button.ts
@@ -28,7 +28,7 @@ export class Button
     }
 
     setLabel(label: string, escapeHtml: boolean = true): Button {
-        this.labelEl.getEl().setInnerHtml(label, escapeHtml);
+        this.labelEl.setHtml(label, escapeHtml);
         return this;
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -438,8 +438,8 @@ export abstract class ModalDialog
         return this.cancelButton;
     }
 
-    setTitle(value: string, escapeHtml: boolean = true) {
-        this.header.setTitle(value, escapeHtml);
+    setTitle(value: string) {
+        this.header.setTitle(value);
     }
 
     appendChildToContentPanel(child: Element) {
@@ -682,8 +682,8 @@ export class DefaultModalDialogHeader
         this.appendChild(this.titleEl);
     }
 
-    setTitle(value: string, escapeHtml: boolean = true) {
-        this.titleEl.setHtml(value, escapeHtml);
+    setTitle(value: string) {
+        this.titleEl.setHtml(value);
     }
 
     getTitle(): string {


### PR DESCRIPTION
Removed unsafe `setHtml(*, false)` calls without html escaping. 
Added additional `fromText` methods to the text elements (`<span>`, `,<b>`, etc.) to create element with text inside.