### PR TITLE
UploaderEl doesn't correctly process response of upload operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4272,7 +4272,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/src/main/resources/assets/admin/common/js/ui/uploader/UploaderEl.ts
+++ b/src/main/resources/assets/admin/common/js/ui/uploader/UploaderEl.ts
@@ -525,7 +525,8 @@ export class UploaderEl<MODEL extends Equitable>
                 endpoint: this.config.url,
                 params: this.config.params || {},
                 inputName: 'file',
-                filenameParam: 'name'
+                filenameParam: 'name',
+                requireSuccessJson: false
             },
             validation: {
                 acceptFiles: this.getFileExtensions(this.config.allowExtensions)
@@ -819,7 +820,12 @@ export class UploaderEl<MODEL extends Equitable>
                 if (uploadItem) {
                     const model: MODEL = this.createModel(JSON.parse(xhrOrXdr.response));
                     uploadItem.setModel(model);
-                    this.notifyFileUploaded(uploadItem);
+                    const hasFailed = response && response.success === false;
+                    if (hasFailed) {
+                        this.notifyUploadFailed(uploadItem);
+                    } else {
+                        this.notifyFileUploaded(uploadItem);
+                    }
                 }
             } catch (e) {
                 console.warn('Failed to parse the response', response, e);

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -54,8 +54,8 @@ notify.item.undeleted=Item is undeleted
 notify.items.undeleted=Items are undeleted
 notify.nothingToUndelete=No items found to undelete
 notify.optionset.notempty=The fields inside deselected option will be cleared on save!
-notify.upload.success="{0}" uploaded
-notify.upload.failure="{0}" upload failed
+notify.upload.success="{0}" is successfully uploaded
+notify.upload.failure=Upload of "{0}" failed
 #
 # Admin UI
 #

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -54,16 +54,16 @@ notify.item.undeleted=Item is undeleted
 notify.items.undeleted=Items are undeleted
 notify.nothingToUndelete=No items found to undelete
 notify.optionset.notempty=The fields inside deselected option will be cleared on save!
-
+notify.upload.success="{0}" uploaded
+notify.upload.failure="{0}" upload failed
 #
 # Admin UI
 #
-
 #
 #   Fields
 #
 field.displayName=Display Name
-field.name = Name
+field.name=Name
 field.path = path
 field.pswGenerator.generate=Generate
 field.pswGenerator.show=Show


### PR DESCRIPTION
…d pictures and files #1198

Set option that was added in the new version of the file uploader (`requireSuccessJson`) to `false`, since we don't follow specific JSON response scheme and don't add `success` parameter to that JSON, absence of which has lead to request treated as failed fy the library.
Added localization for attachment upload success and failure.