### PR TITLE
Save button remains enabled after checkbox state is changed and content is saved (#1463)

### DIFF
--- a/src/main/resources/assets/admin/common/js/data/ValueTypeBoolean.ts
+++ b/src/main/resources/assets/admin/common/js/data/ValueTypeBoolean.ts
@@ -27,7 +27,7 @@ export class ValueTypeBoolean
 
     newValue(value: string): Value {
         if (!this.isConvertible(value)) {
-            return new Value(null, this);
+            return this.newBoolean(false);
         }
         return new Value(this.convertFromString(value), this);
     }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/checkbox/Checkbox.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/checkbox/Checkbox.ts
@@ -56,16 +56,12 @@ export class Checkbox
         if (Checkbox.debug) {
             console.debug('Checkbox.updateProperty' + (unchangedOnly ? ' (unchanged only)' : ''), property);
         }
-        if ((!unchangedOnly || !this.checkbox.isDirty()) && property.hasNonNullValue()) {
-            this.checkbox.setChecked(property.getBoolean());
+        if (!unchangedOnly || !this.checkbox.isDirty()) {
+            this.checkbox.setChecked(property.hasNonNullValue() ? property.getBoolean() : false);
         } else if (this.checkbox.isDirty()) {
-            this.resetPropertyValue();
+            this.checkbox.resetBaseValues();
         }
         return Q<void>(null);
-    }
-
-    resetPropertyValue() {
-        this.getProperty().setValue(ValueTypes.BOOLEAN.newValue(this.checkbox.getValue()));
     }
 
     reset() {

--- a/src/main/resources/assets/admin/common/js/ui/Checkbox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/Checkbox.ts
@@ -137,15 +137,6 @@ export class Checkbox
         this.checkbox = <InputEl> new Element(new NewElementBuilder().setTagName('input').setGenerateId(true));
         this.checkbox.getEl().setAttribute('type', 'checkbox');
         this.addClass(this.getInputAlignmentAsString(inputAlignment));
-
-        $(this.checkbox.getHTMLElement()).on('change', (e) => {
-            if (Checkbox.debug) {
-                console.debug('Checkbox on change', e);
-            }
-            this.refreshValueChanged();
-            this.refreshDirtyState();
-        });
-
     }
 
     private initLabel(text: string) {

--- a/src/main/resources/assets/admin/common/js/ui/RadioGroup.ts
+++ b/src/main/resources/assets/admin/common/js/ui/RadioGroup.ts
@@ -82,11 +82,6 @@ export class RadioButton
 
         this.label = new LabelEl(label, this.radio);
         this.appendChild(this.label);
-
-        $(this.radio.getHTMLElement()).on('change', () => {
-            this.refreshDirtyState();
-            this.refreshValueChanged();
-        });
     }
 
     setValue(value: string): RadioButton {


### PR DESCRIPTION
Changed `Checkbox.updateProperty` to reset dirty state instead of updating property value. Changed default value of a boolean value type to `false` instead of null. Removed `onChange` event handlers of Checkbox and Radiogroup inputs since they are doing the same as FormInputEl's `onChange` handler 