### PR TITLE
Limit max allowed concurrent requests by uploader #1227

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/uploader/UploaderEl.ts
+++ b/src/main/resources/assets/admin/common/js/ui/uploader/UploaderEl.ts
@@ -521,6 +521,7 @@ export class UploaderEl<MODEL extends Equitable>
             multiple: this.config.allowMultiSelection,
             folders: false,
             autoUpload: false,
+            maxConnections: 1,
             request: {
                 endpoint: this.config.url,
                 params: this.config.params || {},


### PR DESCRIPTION
-Not letting uploader send more than 1 request simultaneously, otherwise when sending multiple items result is unpredictable