### PR TITLE
Refactor usage of save confirmation dialog #1229

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardStepForm.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardStepForm.ts
@@ -19,13 +19,13 @@ export class WizardStepForm
     /*
      *   public to be used by inheritors
      */
-    public validate(_silent?: boolean): ValidationRecording {
+    public validate(): ValidationRecording {
         return new ValidationRecording();
     }
 
     public isValid(): boolean {
         if (!this.previousValidation) {
-            this.previousValidation = this.validate(true);
+            this.previousValidation = this.validate();
         }
         return this.previousValidation.isValid();
     }

--- a/src/main/resources/assets/admin/common/js/ui/dialog/ConfirmationDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ConfirmationDialog.ts
@@ -27,8 +27,6 @@ export class ConfirmationDialog
     doRender(): Q.Promise<boolean> {
         return super.doRender().then((rendered) => {
             this.appendChildToContentPanel(this.questionEl);
-            this.addAction(this.yesAction, true);
-            this.addAction(this.noAction);
 
             return rendered;
         });
@@ -67,8 +65,15 @@ export class ConfirmationDialog
         super.initElements();
 
         this.questionEl = new H6El('question');
-        this.noAction = new Action(i18n('action.no'), 'esc');
-        this.yesAction = new Action(i18n('action.yes'));
+
+        this.noAction = new Action(i18n('action.no'), i18n('action.no').slice(0, 1).toLowerCase());
+        this.noAction.setMnemonic(i18n('action.no').slice(0, 1).toLowerCase());
+
+        this.yesAction = new Action(i18n('action.yes'), i18n('action.yes').slice(0, 1).toLowerCase());
+        this.yesAction.setMnemonic(i18n('action.yes').slice(0, 1).toLowerCase());
+
+        this.addAction(this.yesAction, true);
+        this.addAction(this.noAction);
     }
 
     protected initListeners() {

--- a/src/main/resources/assets/admin/common/js/ui/dialog/ConfirmationDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ConfirmationDialog.ts
@@ -66,11 +66,13 @@ export class ConfirmationDialog
 
         this.questionEl = new H6El('question');
 
-        this.noAction = new Action(i18n('action.no'), i18n('action.no').slice(0, 1).toLowerCase());
-        this.noAction.setMnemonic(i18n('action.no').slice(0, 1).toLowerCase());
+        const noActionText: string = i18n('action.no');
+        this.noAction = new Action(noActionText, noActionText.slice(0, 1).toLowerCase());
+        this.noAction.setMnemonic(noActionText.slice(0, 1).toLowerCase());
 
-        this.yesAction = new Action(i18n('action.yes'), i18n('action.yes').slice(0, 1).toLowerCase());
-        this.yesAction.setMnemonic(i18n('action.yes').slice(0, 1).toLowerCase());
+        const yesActionText: string = i18n('action.yes');
+        this.yesAction = new Action(yesActionText, yesActionText.slice(0, 1).toLowerCase());
+        this.yesAction.setMnemonic(yesActionText.slice(0, 1).toLowerCase());
 
         this.addAction(this.yesAction, true);
         this.addAction(this.noAction);

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -152,7 +152,7 @@ dialog.confirm.applyChanges=You have made changes to the form, do you want to ap
 dialog.confirm.occurrences.title=Remove {0}?
 dialog.confirm.occurrences.delete=Are you sure you want to remove this item?
 dialog.notification.title=Notification
-dialog.saveBeforeClose.msg=There are unsaved changes, do you want to save them before closing?
+dialog.confirm.unsavedChanges=There are unsaved changes, do you want to save them before closing?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_es.properties
+++ b/src/main/resources/i18n/common_es.properties
@@ -154,7 +154,7 @@ panel.filter.dependencies.outbound=Dependencias salientes
 dialog.newContent.pathDescription=En
 dialog.confirm.title=Confirmación
 dialog.confirm.applyChanges=Ha hecho cambios al formulario, ¿desea aplicarlos?
-dialog.saveBeforeClose.msg=Hay cambios sin guardar, ¿desea guardarlos antes de cerrar?
+dialog.confirm.unsavedChanges=Hay cambios sin guardar, ¿desea guardarlos antes de cerrar?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_fr.properties
+++ b/src/main/resources/i18n/common_fr.properties
@@ -152,7 +152,7 @@ dialog.confirm.applyChanges=Vous avez modifié le formulaire, voulez-vous appliq
 dialog.confirm.occurrences.title= Supprimer {0}?
 dialog.confirm.occurrences.delete= Êtes-vous sûr de vouloir supprimer cet article?
 dialog.notification.title=Notification
-dialog.saveBeforeClose.msg=Il y a des changements non enregistrés, voulez-vous les enregistrer avant de fermer?
+dialog.confirm.unsavedChanges=Il y a des changements non enregistrés, voulez-vous les enregistrer avant de fermer?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_no.properties
+++ b/src/main/resources/i18n/common_no.properties
@@ -148,7 +148,7 @@ dialog.confirm.applyChanges=Du har gjort endringer i skjema.  Ønsker du å bruk
 dialog.confirm.occurrences.title=Fjern {0}?
 dialog.confirm.occurrences.delete=Er du sikker på at du vil fjerne denne?
 dialog.notification.title=Varsel
-dialog.saveBeforeClose.msg=Det er endringer som ikke er lagret. Vil du lagre disse før vinduet blir lukket?
+dialog.confirm.unsavedChanges=Det er endringer som ikke er lagret. Vil du lagre disse før vinduet blir lukket?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_pl.properties
+++ b/src/main/resources/i18n/common_pl.properties
@@ -152,7 +152,7 @@ dialog.confirm.applyChanges=Wprowadziłeś zmiany na tym formularzu. Czy chcesz 
 dialog.confirm.occurrences.title=Usunąć {0}?
 dialog.confirm.occurrences.delete=Czy jesteś pewien, że chcesz usunąć ten element?
 dialog.notification.title=Powiadomienie
-dialog.saveBeforeClose.msg=Istnieją niezapisane zmiany. Czy chcesz je zapisać przed zamknięciem?
+dialog.confirm.unsavedChanges=Istnieją niezapisane zmiany. Czy chcesz je zapisać przed zamknięciem?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_pt.properties
+++ b/src/main/resources/i18n/common_pt.properties
@@ -152,7 +152,7 @@ dialog.confirm.applyChanges=Você fez mudanças no formulário, deseja aplicá-l
 dialog.confirm.occurrences.title=Remover {0}
 dialog.confirm.occurrences.delete=Você tem certeza que deseja remover este item?
 dialog.notification.title=Notificação
-dialog.saveBeforeClose.msg=Há mudanças sem salvar, você deseja salvá-las antes de fechar?
+dialog.confirm.unsavedChanges=Há mudanças sem salvar, você deseja salvá-las antes de fechar?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_ru.properties
+++ b/src/main/resources/i18n/common_ru.properties
@@ -152,7 +152,7 @@ dialog.confirm.applyChanges=Вы изменили значения в форме
 dialog.confirm.occurrences.title=Удалить {0}?
 dialog.confirm.occurrences.delete=Уверены что хотите удалить этот элемент?
 dialog.notification.title=Уведомление
-dialog.saveBeforeClose.msg=Данные были изменены. Хотите сохранить их перед закрытием?
+dialog.confirm.unsavedChanges=Данные были изменены. Хотите сохранить их перед закрытием?
 
 #
 #    Drag & Drop

--- a/src/main/resources/i18n/common_sv.properties
+++ b/src/main/resources/i18n/common_sv.properties
@@ -152,7 +152,7 @@ dialog.confirm.applyChanges=Du har gjort ändringar, vill du spara dem?
 dialog.confirm.occurrences.title=Radera {0}?
 dialog.confirm.occurrences.delete=Är du säker på att du vill radera detta innehåll?
 dialog.notification.title=Meddelanden
-dialog.saveBeforeClose.msg=Det är ändringar som inte har sparats. Vill du spara dessa innan du stänger fönstret?
+dialog.confirm.unsavedChanges=Det är ändringar som inte har sparats. Vill du spara dessa innan du stänger fönstret?
 
 #
 #    Drag & Drop


### PR DESCRIPTION
-NB: Had to move addAction() calls into initElements(), otherwise if triggered after ModalDialog's open() key bindings won't be set