### PR TITLE
Make RadioGroup and RadioButton extendable #1242

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4337,7 +4337,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/src/main/resources/assets/admin/common/js/dom/LabelEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/LabelEl.ts
@@ -7,8 +7,12 @@ export class LabelEl
         super(new NewElementBuilder().setTagName('label').setClassName(className));
         this.setValue(value);
         if (forElement) {
-            this.getEl().setAttribute('for', forElement.getId());
+            this.setForElement(forElement);
         }
+    }
+
+    setForElement(forElement: Element) {
+        this.getEl().setAttribute('for', forElement.getId());
     }
 
     setValue(value: string) {

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -15,7 +15,7 @@ import {ContentSummary} from '../../../content/ContentSummary';
 import {FormEditEvent} from '../../../content/event/FormEditEvent';
 import {DefaultErrorHandler} from '../../../DefaultErrorHandler';
 import {FormInputEl} from '../../../dom/FormInputEl';
-import {RadioButton} from '../../../ui/RadioGroup';
+import {RadioButton} from '../../../ui/RadioButton';
 import {ValueTypeString} from '../../../data/ValueTypeString';
 import {BrowserHelper} from '../../../BrowserHelper';
 import {Element} from '../../../dom/Element';
@@ -353,7 +353,12 @@ export class FormOptionSetOptionView
     private makeSelectionRadioButton(): RadioButton {
         const selectedProperty = this.getSelectedOptionsArray().get(0);
         const checked = !!selectedProperty && selectedProperty.getString() === this.getName();
-        const button = new RadioButton(this.formOptionSetOption.getLabel(), '', this.getParent().getEl().getId(), checked);
+        const button = new RadioButton({
+            label: this.formOptionSetOption.getLabel(),
+            value: '',
+            name: this.getParent().getEl().getId(),
+            checked,
+        });
 
         button.onChange(() => {
             let selectedProp = this.getSelectedOptionsArray().get(0);

--- a/src/main/resources/assets/admin/common/js/ui/RadioButton.ts
+++ b/src/main/resources/assets/admin/common/js/ui/RadioButton.ts
@@ -83,13 +83,17 @@ export class RadioButton
         return this.radio.getName();
     }
 
-    public isChecked(): boolean {
+    isChecked(): boolean {
         return super.getValue() === 'true';
     }
 
-    public setChecked(checked: boolean, silent?: boolean): RadioButton {
+    setChecked(checked: boolean, silent?: boolean): RadioButton {
         super.setValue(String(checked), silent);
         return this;
+    }
+
+    setDisabled(disabled: boolean) {
+        this.radio.getEl().setDisabled(disabled);
     }
 
     giveFocus(): boolean {

--- a/src/main/resources/assets/admin/common/js/ui/RadioButton.ts
+++ b/src/main/resources/assets/admin/common/js/ui/RadioButton.ts
@@ -1,0 +1,110 @@
+import {Element} from '../dom/Element';
+import {FormInputEl} from '../dom/FormInputEl';
+import {InputEl} from '../dom/InputEl';
+import {LabelEl} from '../dom/LabelEl';
+import {ObjectHelper} from '../ObjectHelper';
+
+export type RadioButtonLabel = LabelEl | string;
+
+export class RadioButtonConfig {
+    label: RadioButtonLabel;
+    value: string;
+    name: string;
+    checked?: boolean;
+}
+
+export class RadioButton
+    extends FormInputEl {
+
+    public static debug: boolean = false;
+
+    protected radio: InputEl;
+
+    protected label: LabelEl;
+
+    constructor(config: RadioButtonConfig) {
+        const originalValue = String(config.checked != null ? config.checked : false);
+        super('span', 'radio-button', undefined, originalValue);
+
+        this.initElements(config);
+    }
+
+    protected initElements(config: RadioButtonConfig): void {
+        this.radio = this.createRadio(config);
+        this.label = this.createLabel(config, this.radio);
+        this.appendChildren<Element>(this.radio, this.label);
+    }
+
+    protected createRadio(config: RadioButtonConfig): InputEl {
+        const {name, value} = config;
+        const radio = new InputEl();
+        radio.getEl().setAttribute('type', 'radio');
+        radio.setName(name).setValue(value);
+        return radio;
+    }
+
+    protected createLabel(config: RadioButtonConfig, radio: InputEl): LabelEl {
+        const {label} = config;
+
+        if (ObjectHelper.iFrameSafeInstanceOf(label, LabelEl)) {
+            const labelEl = label as LabelEl;
+            labelEl.setForElement(radio);
+            return labelEl;
+        }
+
+        return new LabelEl(label as string, radio);
+    }
+
+    setValue(value: string): RadioButton {
+        if (RadioButton.debug) {
+            console.warn('RadioButton.setValue sets the value attribute, you may have wanted to use setChecked instead');
+        }
+        this.radio.setValue(value);
+        return this;
+    }
+
+    getValue(): string {
+        if (RadioButton.debug) {
+            console.warn('RadioButton.getValue gets the value attribute, you may have wanted to use isChecked instead');
+        }
+        return this.radio.getValue();
+    }
+
+    setLabel(text: string): RadioButton {
+        this.label.setValue(text);
+        return this;
+    }
+
+    getLabel(): string {
+        return this.label.getValue();
+    }
+
+    getName(): string {
+        return this.radio.getName();
+    }
+
+    public isChecked(): boolean {
+        return super.getValue() === 'true';
+    }
+
+    public setChecked(checked: boolean, silent?: boolean): RadioButton {
+        super.setValue(String(checked), silent);
+        return this;
+    }
+
+    giveFocus(): boolean {
+        return this.radio.giveFocus();
+    }
+
+    protected doSetValue(value: string) {
+        if (RadioButton.debug) {
+            console.warn('RadioButton.doSetValue', value);
+        }
+        this.radio.getHTMLElement()['checked'] = value === 'true';
+    }
+
+    protected doGetValue(): string {
+        return String(this.radio.getHTMLElement()['checked']);
+    }
+
+}

--- a/src/main/resources/assets/admin/common/js/ui/RadioGroup.ts
+++ b/src/main/resources/assets/admin/common/js/ui/RadioGroup.ts
@@ -28,11 +28,12 @@ export class RadioGroup
         return this;
     }
 
-    public addOption(value: string, label: RadioButtonLabel) {
+    public addOption(value: string, label: RadioButtonLabel): RadioButton {
         const checked = value === this.getOriginalValue();
         const radio = this.createRadioButton({label, value, checked, name: this.groupName});
         this.options.push(radio);
         this.appendChild(radio);
+        return radio;
     }
 
     protected createRadioButton(config: RadioButtonConfig): RadioButton {

--- a/src/main/resources/assets/admin/common/js/ui/RadioGroup.ts
+++ b/src/main/resources/assets/admin/common/js/ui/RadioGroup.ts
@@ -1,8 +1,6 @@
-import * as $ from 'jquery';
 import {FormInputEl} from '../dom/FormInputEl';
 import {ElementRegistry} from '../dom/ElementRegistry';
-import {InputEl} from '../dom/InputEl';
-import {LabelEl} from '../dom/LabelEl';
+import {RadioButton, RadioButtonConfig, RadioButtonLabel} from './RadioButton';
 
 export enum RadioOrientation {
     VERTICAL,
@@ -15,9 +13,9 @@ export class RadioGroup
     // Group name is similar to name, but have and addition counter
     // to prevent inappropriate behaviour of the radio group on one page
     // with the same names
-    private groupName: string;
+    protected groupName: string;
 
-    private options: RadioButton[] = [];
+    protected options: RadioButton[] = [];
 
     constructor(name: string, originalValue?: string) {
         super('div', 'radio-group', undefined, originalValue);
@@ -30,13 +28,19 @@ export class RadioGroup
         return this;
     }
 
-    public addOption(value: string, label: string) {
-        let checked = value === this.getOriginalValue();
-        let radio = new RadioButton(label, value, this.groupName, checked);
-
-        radio.onValueChanged(() => this.setValue(this.doGetValue(), false, true));
+    public addOption(value: string, label: RadioButtonLabel) {
+        const checked = value === this.getOriginalValue();
+        const radio = this.createRadioButton({label, value, checked, name: this.groupName});
         this.options.push(radio);
         this.appendChild(radio);
+    }
+
+    protected createRadioButton(config: RadioButtonConfig): RadioButton {
+        const radio = new RadioButton(config);
+        radio.onValueChanged(() => {
+            this.setValue(this.doGetValue(), false, true);
+        });
+        return radio;
     }
 
     doSetValue(value: string): RadioGroup {
@@ -62,78 +66,4 @@ export class RadioGroup
     giveFocus(): boolean {
         return this.options.length < 1 ? false : this.options[0].giveFocus();
     }
-
-}
-
-export class RadioButton
-    extends FormInputEl {
-
-    public static debug: boolean = false;
-    private radio: InputEl;
-    private label: LabelEl;
-
-    constructor(label: string, value: string, name: string, checked?: boolean) {
-        super('span', 'radio-button', undefined, String(checked != null ? checked : false));
-
-        this.radio = new InputEl();
-        this.radio.getEl().setAttribute('type', 'radio');
-        this.radio.setName(name).setValue(value);
-        this.appendChild(this.radio);
-
-        this.label = new LabelEl(label, this.radio);
-        this.appendChild(this.label);
-    }
-
-    setValue(value: string): RadioButton {
-        if (RadioButton.debug) {
-            console.warn('RadioButton.setValue sets the value attribute, you may have wanted to use setChecked instead');
-        }
-        this.radio.setValue(value);
-        return this;
-    }
-
-    getValue(): string {
-        if (RadioButton.debug) {
-            console.warn('RadioButton.getValue gets the value attribute, you may have wanted to use isChecked instead');
-        }
-        return this.radio.getValue();
-    }
-
-    setLabel(text: string): RadioButton {
-        this.label.setValue(text);
-        return this;
-    }
-
-    getLabel(): string {
-        return this.label.getValue();
-    }
-
-    getName(): string {
-        return this.radio.getName();
-    }
-
-    public isChecked(): boolean {
-        return super.getValue() === 'true';
-    }
-
-    public setChecked(checked: boolean, silent?: boolean): RadioButton {
-        super.setValue(String(checked), silent);
-        return this;
-    }
-
-    giveFocus(): boolean {
-        return this.radio.giveFocus();
-    }
-
-    protected doSetValue(value: string) {
-        if (RadioButton.debug) {
-            console.warn('RadioButton.doSetValue', value);
-        }
-        this.radio.getHTMLElement()['checked'] = value === 'true';
-    }
-
-    protected doGetValue(): string {
-        return String(this.radio.getHTMLElement()['checked']);
-    }
-
 }


### PR DESCRIPTION
* Updated `RadioButton` and `RadioGroup` to be customizable.
* Moved `RadioButton` to the separate file.
* Refactored `RadioButton`, making it receive config object instead of a lot of properties.
* Made it posible to pass the label element instead of a string to the `RadioButton`.