### PR TITLE
Parent node gets selected after a child node added to the grid

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1758,7 +1758,7 @@ export class TreeGrid<DATA>
                 this.sortNodeChildren(parentNode);
             } else {
                 if (!stashedParentNode) {
-                    this.updateSelectedNode(parentNode);
+                    this.refreshNode(parentNode);
                 }
             }
         }


### PR DESCRIPTION
-Parent node we're inserting childe to could be not selected or highlighted at all, so no need to reselect it