### PR TITLE
Incorrect layout in Wizard Step Navigator Toolbar #1267

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardPanel.ts
@@ -94,10 +94,24 @@ export class WizardPanel<EQUITABLE extends Equitable>
         // have to be in constructor because onValidityChanged uses it
         this.validityManager = new WizardValidityManager();
 
+        this.initEventsListeners();
+    }
+
+    private initEventsListeners() {
         this.onRendered((event: ElementRenderedEvent) => {
             if (WizardPanel.debug) {
                 console.debug('WizardPanel: rendered', event);
             }
+
+            ResponsiveManager.onAvailableSizeChanged(this.stepNavigatorAndToolbarContainer, (item: ResponsiveItem) => {
+                // update offset if step navigator is resized
+                if (this.isVisible()) {
+                    this.updateStickyToolbar();
+                    this.stepsPanel.setScrollOffset(item.getElement().getEl().getHeight());
+
+                    this.stepNavigatorAndToolbarContainer.checkAndMinimize();
+                }
+            });
         });
 
         this.onShown((event: ElementShownEvent) => {
@@ -124,6 +138,7 @@ export class WizardPanel<EQUITABLE extends Equitable>
             }
         });
     }
+
 
     /*
      Wait for loadData to finish in order to render
@@ -729,15 +744,6 @@ export class WizardPanel<EQUITABLE extends Equitable>
             this.stepsPanel.setScrollOffset(event.getElement().getEl().getHeight());
         });
 
-        ResponsiveManager.onAvailableSizeChanged(this.stepNavigatorAndToolbarContainer, (item: ResponsiveItem) => {
-            // update offset if step navigator is resized
-            if (this.isVisible()) {
-                this.updateStickyToolbar();
-                this.stepsPanel.setScrollOffset(item.getElement().getEl().getHeight());
-
-                this.stepNavigatorAndToolbarContainer.checkAndMinimize();
-            }
-        });
         this.formPanel.appendChildren(headerAndNavigatorContainer, this.stepsPanel);
 
         let leftPanel: Panel;

--- a/src/main/resources/assets/admin/common/js/app/wizard/WizardStepNavigatorAndToolbar.ts
+++ b/src/main/resources/assets/admin/common/js/app/wizard/WizardStepNavigatorAndToolbar.ts
@@ -41,10 +41,12 @@ export class WizardStepNavigatorAndToolbar
             if (this.stepToolbar) {
                 this.appendChild(this.stepToolbar);
             }
+
             this.appendChild(this.foldButton);
             this.appendChild(this.stepNavigator);
 
             this.checkAndMinimize();
+
             return rendered;
         });
     }
@@ -60,6 +62,10 @@ export class WizardStepNavigatorAndToolbar
     }
 
     checkAndMinimize() {
+        if (!this.isRendered()) {
+            return;
+        }
+
         const isMinimized: boolean = this.isFolded();
         const isUpdateNeeded: boolean = this.isStepNavigatorFit() === isMinimized;
 
@@ -114,7 +120,7 @@ export class WizardStepNavigatorAndToolbar
         const width = this.stepNavigator.getEl().getWidthWithoutPadding();
         const stepsWidth = this.calculateStepsWidth();
 
-        return Math.ceil(width) >= Math.ceil(stepsWidth);
+        return Math.ceil(width) - Math.ceil(stepsWidth) >= -1; // Issue in Chrome with steps bigger than parent by 1px
     }
 
     private isStepNavigatorFit(): boolean {


### PR DESCRIPTION
-Triggering resize handler only after elements rendered, also using debounce whenever possible (can't use it for navigator toolbar since it must be updated immediately on resize)