### PR TITLE
Browse toolbar is not updated after deleting filtered content #1273

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
@@ -312,43 +312,24 @@ export class Grid<T extends Slick.SlickData>
     }
 
     moveSelectedUp() {
-        if (this.slickGrid.getDataLength() > 0) {
-            let selected: number[] = this.getSelectedRows();
-            let row = selected.length >= 1
-                      ? selected[0] - 1
-                      : -1;
+        if (this.getDataLength() > 0) {
+            const row: number = new GridSelectionHelper(this.getSelectedRows()).getRowToSingleSelectUp();
 
-            if (selected.length === 1) {
-                if (row >= 0) {
-                    this.selectRow(row, true);
-                    return row;
-                } else {
-                    this.clearSelection(true);
-                    return 0;
-                }
-            } else if (selected.length > 1) {
-                row = Math.max(row, 0);
+            if (row >= 0) {
                 this.selectRow(row, true);
-                return row;
             }
         }
-
-        return -1;
     }
 
     moveSelectedDown() {
         if (this.slickGrid.getDataLength() > 0) {
-            let selected: number[] = this.getSelectedRows();
-            let row = selected.length >= 1
-                      ? Math.min(selected[selected.length - 1] + 1, this.slickGrid.getDataLength() - 1)
-                      : 0;
+            const row: number = new GridSelectionHelper(this.getSelectedRows()).getRowToSingleSelectDown(this.getDataLength());
 
-            this.selectRow(row, true);
-
-            return row;
+            if (row >= 0) {
+                this.selectRow(row, true);
+            }
         }
 
-        return -1;
     }
 
     addSelectedUp() {

--- a/src/main/resources/assets/admin/common/js/ui/grid/GridSelectionHelper.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/GridSelectionHelper.ts
@@ -112,4 +112,82 @@ export class GridSelectionHelper {
 
         return nextNonSelectedRowDown;
     }
+
+    getRowToToggleWhenShiftingUp(): number {
+        if (this.selected.length === 0) {
+            return -1;
+        }
+
+        const lastSelectedRow: number = this.selected[this.selected.length - 1];
+        const nextRowUp: number = lastSelectedRow - 1;
+
+        if (nextRowUp < 0) {
+            return -1;
+        }
+
+        if (!this.isSelected(nextRowUp)) {
+            return nextRowUp;
+        }
+
+        const nextRowDown: number = lastSelectedRow + 1;
+
+        if (!this.isSelected(nextRowDown)) {
+            return this.selected.pop();
+        }
+
+        const nextNonSelectedRowUp: number = this.findFirstNotSelectedRowAbove(nextRowUp);
+
+        if (nextNonSelectedRowUp >= 0) {
+            return nextNonSelectedRowUp;
+        }
+
+        return -1;
+    }
+
+    getRowToToggleWhenShiftingDown(totalItems: number): number {
+        if (this.selected.length === 0) {
+            return -1;
+        }
+
+        const lastSelectedRow: number = this.selected[this.selected.length - 1];
+        const nextRowDown: number = lastSelectedRow + 1;
+
+        if (nextRowDown >= totalItems) {
+            return -1;
+        }
+
+        if (!this.isSelected(nextRowDown)) {
+            return nextRowDown;
+        }
+
+        const nextRowUp: number = lastSelectedRow - 1;
+
+        if (!this.isSelected(nextRowUp)) {
+            return this.selected.pop();
+        }
+
+        const nextNonSelectedRowDown: number = this.findFirstNotSelectedRowUnder(nextRowDown, totalItems);
+
+        if (nextNonSelectedRowDown < totalItems) {
+            return nextNonSelectedRowDown;
+        }
+
+        return -1;
+    }
+
+    getRowToSingleSelectUp(): number {
+        if (this.selected.length === 0) {
+            return -1;
+        }
+
+        return this.selected[0] - 1;
+    }
+
+    getRowToSingleSelectDown(totalItems: number): number {
+        const row: number = this.selected.length >= 1
+            ? Math.min(this.selected[this.selected.length - 1] + 1, totalItems - 1)
+            : 0;
+
+        return row;
+    }
 }

--- a/src/main/resources/assets/admin/common/js/ui/selector/DropdownTreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/DropdownTreeGrid.ts
@@ -69,7 +69,6 @@ export class DropdownTreeGrid<OPTION_DISPLAY_VALUE>
     }
 
     markSelections(selectedOptions: Option<OPTION_DISPLAY_VALUE>[], ignoreEmpty: boolean = false) {
-        this.optionsTreeGrid.getRoot().clearStashedSelection();
         super.markSelections(selectedOptions, ignoreEmpty);
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -25,6 +25,8 @@ import {TreeGridToolbar} from './TreeGridToolbar';
 import {TreeGridContextMenu} from './TreeGridContextMenu';
 import {TreeGridItemClickedEvent} from './TreeGridItemClickedEvent';
 import {ContextMenuShownEvent} from './ContextMenuShownEvent';
+import {TreeGridSelection} from './TreeGridSelection';
+import {GridSelectionHelper} from '../grid/GridSelectionHelper';
 
 export enum SelectionOnClickType {
     HIGHLIGHT,
@@ -68,6 +70,8 @@ export class TreeGrid<DATA>
     private errorPanel: ValidationRecordingViewer;
 
     private highlightedNode: TreeNode<DATA>;
+
+    private selection: TreeGridSelection = new TreeGridSelection();
 
     private selectionOnClick: SelectionOnClickType = SelectionOnClickType.HIGHLIGHT;
 
@@ -159,12 +163,56 @@ export class TreeGrid<DATA>
         return this.highlightedNode != null;
     }
 
-    public getHighlightedNode(): TreeNode<DATA> {
-        return this.highlightedNode;
+    public getHighlightedItem(): DATA {
+        return this.highlightedNode.getData();
     }
 
-    public getFirstSelectedOrHighlightedNode(): TreeNode<DATA> {
-        return this.highlightedNode ? this.highlightedNode : this.getRoot().getFullSelection()[0];
+    public getFirstSelectedOrHighlightedItem(): DATA {
+        const node: TreeNode<DATA> = this.getFirstSelectedOrHighlightedNode();
+
+        if (node) {
+            return node.getData();
+        }
+
+        return null;
+    }
+
+    protected getFirstSelectedOrHighlightedNode(): TreeNode<DATA> {
+        if (this.highlightedNode) {
+            return this.highlightedNode;
+        }
+
+        if (this.selection.hasSelectedItems()) {
+            return this.root.getNodeByDataId(this.selection.getFirstItem());
+        }
+
+        return null;
+    }
+
+    public hasSelectedOrHighlightedNode(): boolean {
+        return this.hasHighlightedNode() || this.selection.hasSelectedItems();
+    }
+
+    public hasSelectedItems(): boolean {
+        return this.selection.hasSelectedItems();
+    }
+
+    public getFirstSelectedItem(): DATA {
+        const node: TreeNode<DATA> = this.getFirstSelectedNode();
+
+        if (node) {
+            return node.getData();
+        }
+
+        return null;
+    }
+
+    protected getFirstSelectedNode(): TreeNode<DATA> {
+        if (this.selection.isEmpty()) {
+            return null;
+        }
+
+        return this.root.getNodeByDataId(this.selection.getFirstItem());
     }
 
     public setContextMenu(contextMenu: TreeGridContextMenu) {
@@ -287,32 +335,48 @@ export class TreeGrid<DATA>
         return this.root;
     }
 
-    getTotalFullSelected(): number {
-        return this.root.getFullSelection().length;
+    getTotalSelected(): number {
+        return this.selection.total();
     }
 
     getTotalCurrentSelected(): number {
-        return this.root.getCurrentSelection().length;
-    }
-
-    getTotalStashedSelected(): number {
-        return this.root.getStashedSelection().length;
+        return this.gridData.getItems().filter((node: TreeNode<DATA>) => this.selection.contains(node.getDataId())).length;
     }
 
     getCurrentTotal(): number {
         return this.root.getCurrentRoot().treeToList().length;
     }
 
-    getFullSelection(uniqueOnly: boolean = true): TreeNode<DATA>[] {
-        return this.root.getFullSelection(uniqueOnly);
+    getFullSelection(): DATA[] {
+        return this.getFullSelectionNodes().map((node: TreeNode<DATA>) => node.getData());
     }
 
-    getCurrentSelection(): TreeNode<DATA>[] {
-        return this.root.getCurrentSelection();
+    protected getFullSelectionNodes(): TreeNode<DATA>[] {
+        const result: TreeNode<DATA>[] = [];
+
+        this.selection.getItems().forEach((dataId: string) => {
+            const node: TreeNode<DATA> = this.root.getNodeByDataId(dataId);
+
+            if (node) {
+                result.push(node);
+            }
+        });
+
+        return result;
     }
 
-    getStashedSelection(): TreeNode<DATA>[] {
-        return this.root.getStashedSelection();
+    getCurrentSelection(): DATA[] {
+        const result: DATA[] = [];
+
+        this.selection.getItems().forEach((dataId: string) => {
+            const node: TreeNode<DATA> = this.root.getNodeByDataIdFromCurrent(dataId);
+
+            if (node) {
+                result.push(node.getData());
+            }
+        });
+
+        return result;
     }
 
     isActive(): boolean {
@@ -475,8 +539,8 @@ export class TreeGrid<DATA>
     }
 
     selectNode(dataId: string, expand: boolean = false) {
-        let root = this.root.getCurrentRoot();
-        let node = root.findNode(dataId);
+        const root: TreeNode<DATA> = this.root.getCurrentRoot();
+        const node: TreeNode<DATA> = root.findNode(dataId);
 
         if (node) {
             this.removeHighlighting(true);
@@ -484,8 +548,11 @@ export class TreeGrid<DATA>
             if (expand) {
                 this.recursivelyExpandNode(node);
             }
-            let row = this.getRowIndexByNode(node);
-            this.grid.selectRow(row);
+
+            this.selection.add(node.getDataId());
+
+            const row: number = this.getRowIndexByNode(node);
+            this.selectRow(row);
         }
     }
 
@@ -500,24 +567,35 @@ export class TreeGrid<DATA>
 
     selectAll() {
         this.removeHighlighting(true);
-        let rows = [];
-        for (let i = 0; i < this.gridData.getLength(); i++) {
-            if (!StringHelper.isEmpty(this.gridData.getItem(i).getDataId())) {
+        const rows: number[] = [];
+
+        this.gridData.getItems().forEach((node: TreeNode<DATA>, i: number) => {
+            const dataId: string = node.getDataId();
+
+            if (!StringHelper.isEmpty(dataId)) {
                 rows.push(i);
+
+                this.selection.add(node.getDataId());
             }
-        }
+        });
+
         this.grid.setSelectedRows(rows);
     }
 
-    deselectAll() {
-        this.removeHighlighting(true);
+    deselectAll(unhighlight: boolean = true) {
+        if (unhighlight) {
+            this.removeHighlighting(true);
+        }
+
+        this.selection.reset();
+
         this.grid.clearSelection();
     }
 
     deselectNodes(dataIds: string[]) {
-        let oldSelected = this.root.getFullSelection();
-        let newSelected = [];
-        let newSelectedRows = [];
+        const oldSelected: TreeNode<DATA>[] = this.getFullSelectionNodes();
+        const newSelected: TreeNode<DATA>[] = [];
+        const newSelectedRows: number[] = [];
 
         for (let i = 0; i < oldSelected.length; i++) {
             if (dataIds.indexOf(oldSelected[i].getDataId()) < 0) {
@@ -526,9 +604,11 @@ export class TreeGrid<DATA>
             }
         }
 
-        if (oldSelected.length !== newSelected.length) {
-            this.grid.setSelectedRows(newSelectedRows);
-        }
+        dataIds.forEach((nodeDataId: string) => {
+            this.selection.remove(nodeDataId);
+        });
+
+        this.grid.setSelectedRows(newSelectedRows);
     }
 
     getSelectedNodes(): TreeNode<DATA>[] {
@@ -536,15 +616,13 @@ export class TreeGrid<DATA>
     }
 
     getSelectedDataList(): DATA[] {
-        let selectedItems = this.root.getFullSelection();
+        const selectedItems: DATA[] = this.getFullSelection();
 
         if (!!this.highlightedNode && selectedItems.length <= 1) {
             return [this.highlightedNode.getData()];
         }
 
-        return selectedItems.map((node: TreeNode<DATA>) => {
-            return node.getData();
-        });
+        return selectedItems;
     }
 
     setSelectionOnClick(type: SelectionOnClickType): void {
@@ -555,8 +633,6 @@ export class TreeGrid<DATA>
         const expandedNodesDataId = rememberExpanded ? this.grid.getDataView().getItems()
             .filter(item => item.isExpanded()).map(item => item.getDataId()) : [];
 
-        const selection: TreeNode<DATA>[] = this.root.getCurrentSelection();
-        this.root.setCurrentSelection([]);
         const highlightedNode: TreeNode<DATA> = this.highlightedNode;
 
         this.root.resetCurrentRoot(parentNodeData);
@@ -568,7 +644,6 @@ export class TreeGrid<DATA>
 
         return this.reloadNode(null, expandedNodesDataId)
             .then(() => {
-                this.root.setCurrentSelection(selection);
                 const root: TreeNode<DATA> = this.root.getCurrentRoot();
                 this.initData(root.treeToList());
                 this.updateExpanded();
@@ -759,6 +834,16 @@ export class TreeGrid<DATA>
         this.resetHighlightedNode(nodes);
     }
 
+    expandNodeByDataId(dataId: string, expandAll: boolean = false): Q.Promise<boolean> {
+        const node = this.root.getNodeByDataIdFromCurrent(dataId);
+
+        if (node) {
+            return this.expandNode(node, expandAll);
+        }
+
+        return Q(false);
+    }
+
     expandNode(node?: TreeNode<DATA>, expandAll: boolean = false): Q.Promise<boolean> {
         let deferred = Q.defer<boolean>();
 
@@ -835,6 +920,14 @@ export class TreeGrid<DATA>
         return this.grid.isAnySelected();
     }
 
+    collapseNodeByDataId(dataId: string, collapseAll: boolean = false) {
+        const node = this.root.getNodeByDataIdFromCurrent(dataId);
+
+        if (node) {
+            this.collapseNode(node, collapseAll);
+        }
+    }
+
     collapseNode(node: TreeNode<DATA>, collapseAll: boolean = false) {
         node.setExpanded(false);
 
@@ -846,9 +939,6 @@ export class TreeGrid<DATA>
                 this.expandedNodesDataIds.splice(this.expandedNodesDataIds.indexOf(n.getDataId()), 1);
             });
         }
-
-        // Save the selected collapsed rows in cache
-        this.root.stashSelection();
 
         this.gridData.refresh();
         this.invalidate();
@@ -940,7 +1030,15 @@ export class TreeGrid<DATA>
     invalidate() {
         this.grid.invalidate();
 
+        if (this.isHighlightedNodeSelected() && !this.gridOptions.isMultipleSelectionDisabled()) {
+            return;
+        }
+
         this.highlightCurrentNode();
+    }
+
+    private isHighlightedNodeSelected() {
+        return this.highlightedNode && this.selection.contains(this.highlightedNode.getDataId());
     }
 
     invalidateNodes(nodes: TreeNode<DATA>[]) {
@@ -1028,7 +1126,7 @@ export class TreeGrid<DATA>
         this.getGrid().clearSelection();
         this.refreshNode(node);
         let row = this.getRowIndexByNode(node);
-        this.grid.selectRow(row);
+        this.selectRow(row);
     }
 
     protected getErrorPanel(): ValidationRecordingViewer {
@@ -1066,10 +1164,17 @@ export class TreeGrid<DATA>
         if (!this.gridOptions.isMultipleSelectionDisabled()) {
             this.keyBindings = [
                 new KeyBinding('shift+up', (event: ExtendedKeyboardEvent) => {
-                    this.onSelectRange(event, this.grid.addSelectedUp.bind(this.grid));
+                    const rowToToggle: number = new GridSelectionHelper(this.grid.getSelectedRows()).getRowToToggleWhenShiftingUp();
+                    this.onSelectRange(rowToToggle);
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
                 }),
                 new KeyBinding('shift+down', (event: ExtendedKeyboardEvent) => {
-                    this.onSelectRange(event, this.grid.addSelectedDown.bind(this.grid));
+                    const rowToToggle: number =
+                        new GridSelectionHelper(this.grid.getSelectedRows()).getRowToToggleWhenShiftingDown(this.grid.getDataLength());
+                    this.onSelectRange(rowToToggle);
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
                 })
             ];
         }
@@ -1085,28 +1190,28 @@ export class TreeGrid<DATA>
         ]);
     }
 
-    private onSelectRange(event: ExtendedKeyboardEvent, navigateFn: Function) {
-        if (this.isActive()) {
-            let row;
-            if (this.highlightedNode) {
-                this.recursivelyExpandHighlightedNode();
-                row = this.getRowIndexByNode(this.highlightedNode);
-                if (!this.grid.isRowSelected(row)) {
-                    this.grid.selectRow(row);
-                }
-            } else if (this.grid.getSelectedRows().length === 1) {
-                row = this.grid.getSelectedRows()[0];
-            }
-
-            navigateFn(row);
-            this.scrollToRow(this.grid.getSelectedRows().pop());
+    private onSelectRange(rowToToggle: number) {
+        if (!this.isActive()) {
+            return;
         }
-        event.preventDefault();
-        event.stopImmediatePropagation();
+
+        if (this.highlightedNode) {
+            this.recursivelyExpandHighlightedNode();
+            const row: number = this.getRowIndexByNode(this.highlightedNode);
+            if (!this.grid.isRowSelected(row)) {
+                this.selectRow(row);
+            }
+        }
+
+        if (rowToToggle < 0) {
+            return;
+        }
+
+        this.toggleRow(rowToToggle);
+        this.scrollToRow(this.grid.getSelectedRows().pop());
     }
 
     private initEventListeners(builder: TreeGridBuilder<DATA>) {
-
         this.onClicked(() => {
             this.grid.focus();
         });
@@ -1297,13 +1402,13 @@ export class TreeGrid<DATA>
                 if (highlightFrom > highlightTo) {
                     for (let i = highlightFrom; i >= highlightTo; i--) {
                         if (!this.grid.isRowSelected(i)) {
-                            this.grid.toggleRow(i);
+                            this.toggleRow(i);
                         }
                     }
                 } else {
                     for (let i = highlightFrom; i <= highlightTo; i++) {
                         if (!this.grid.isRowSelected(i)) {
-                            this.grid.toggleRow(i);
+                            this.toggleRow(i);
                         }
                     }
                 }
@@ -1315,7 +1420,8 @@ export class TreeGrid<DATA>
                 this.deselectAll();
             }
         }
-        this.grid.toggleRow(data.row);
+
+        this.toggleRow(data.row);
     }
 
     private onClickWithCmd(data: Slick.OnClickEventArgs<DATA>) {
@@ -1323,7 +1429,7 @@ export class TreeGrid<DATA>
         if (!this.grid.isRowSelected(data.row) && this.highlightedNode !== node) {
             this.removeHighlighting(true);
         }
-        this.grid.toggleRow(data.row);
+        this.toggleRow(data.row);
     }
 
     private onExpand(elem: ElementHelper, data: Slick.OnClickEventArgs<DATA>) {
@@ -1360,8 +1466,7 @@ export class TreeGrid<DATA>
         const node = this.gridData.getItem(data.row);
 
         if (this.gridOptions.isMultipleSelectionDisabled()) {
-            this.root.clearStashedSelection();
-            this.grid.selectRow(data.row);
+            this.selectRow(data.row);
             return;
         }
 
@@ -1371,40 +1476,51 @@ export class TreeGrid<DATA>
             this.removeHighlighting(true);
         }
 
-        this.grid.toggleRow(data.row);
-    }
-
-    private isSelectionNotEmpty() {
-        return this.grid.getSelectedRows().length > 0 || this.root.getStashedSelection().length > 0;
+        this.toggleRow(data.row);
     }
 
     private onUpKeyPress() {
-        if (this.isActive()) {
-            this.recursivelyExpandHighlightedNode();
+        if (!this.isActive()) {
+            return;
+        }
 
-            if (this.contextMenu) {
-                this.contextMenu.hide();
+        this.recursivelyExpandHighlightedNode();
+
+        if (this.contextMenu) {
+            this.contextMenu.hide();
+        }
+
+        if (this.gridOptions.isMultipleSelectionDisabled()) {
+            const row: number = new GridSelectionHelper(this.grid.getSelectedRows()).getRowToSingleSelectUp();
+            if (row >= 0) {
+                this.selectRow(row, true);
+                this.scrollToRow(row);
             }
-            if (this.gridOptions.isMultipleSelectionDisabled()) {
-                this.scrollToRow(this.grid.moveSelectedUp());
-            } else {
-                this.navigateUp();
-            }
+        } else {
+            this.navigateUp();
         }
     }
 
     private onDownKeyPress() {
-        if (this.isActive()) {
-            this.recursivelyExpandHighlightedNode();
+        if (!this.isActive()) {
+            return;
+        }
 
-            if (this.contextMenu) {
-                this.contextMenu.hide();
+        this.recursivelyExpandHighlightedNode();
+
+        if (this.contextMenu) {
+            this.contextMenu.hide();
+        }
+
+        if (this.gridOptions.isMultipleSelectionDisabled()) {
+            const row: number = new GridSelectionHelper(this.grid.getSelectedRows()).getRowToSingleSelectDown(this.grid.getDataLength());
+
+            if (row >= 0) {
+                this.selectRow(row, true);
+                this.scrollToRow(row);
             }
-            if (this.gridOptions.isMultipleSelectionDisabled()) {
-                this.scrollToRow(this.grid.moveSelectedDown());
-            } else {
-                this.navigateDown();
-            }
+        } else {
+            this.navigateDown();
         }
     }
 
@@ -1432,8 +1548,8 @@ export class TreeGrid<DATA>
                 let row = this.getRowIndexByNode(node);
                 this.collapseNode(node);
                 if (selected[0]) {
-                    this.unselectAllRows();
-                    this.grid.selectRow(row, true);
+                    this.deselectAll();
+                    this.selectRow(row, true);
                 } else {
                     this.highlightRowByNode(node);
                 }
@@ -1469,7 +1585,7 @@ export class TreeGrid<DATA>
         if (this.highlightedNode) {
             this.recursivelyExpandHighlightedNode();
             let row = this.getRowIndexByNode(this.highlightedNode);
-            this.grid.toggleRow(row);
+            this.toggleRow(row);
         } else if (this.grid.getSelectedRows().length > 0) {
             this.deselectAll();
         }
@@ -1490,14 +1606,14 @@ export class TreeGrid<DATA>
 
         if (elem.hasClass('sort-dialog-trigger') && (isRowSelected || isRowHighlighted)) {
             if (isMultipleRowsSelected) {
-                this.grid.selectRow(data.row);
+                this.selectRow(data.row);
             }
             return;
         }
 
         // Clear selection and highlighting if something was selected or highlighted from before
-        if (this.isSelectionNotEmpty() || isRowHighlighted) {
-            this.clearAllSelection();
+        if (this.selection.hasSelectedItems() || isRowHighlighted) {
+            this.deselectAll();
         }
 
         if (!isRowHighlighted) {
@@ -1512,11 +1628,11 @@ export class TreeGrid<DATA>
         }
 
         let selectedIndex = this.highlightedNode
-                            ? this.getRowIndexByNode(this.highlightedNode)
-                            : this.grid.getSelectedRows()[selectedCount - 1];
+            ? this.getRowIndexByNode(this.highlightedNode)
+            : this.grid.getSelectedRows()[selectedCount - 1];
 
         if (selectedIndex > 0) {
-            this.unselectAllRows();
+            this.deselectAll();
             selectedIndex--;
             this.highlightRowByNode(this.gridData.getItem(selectedIndex));
             this.scrollToRow(selectedIndex, true);
@@ -1530,7 +1646,7 @@ export class TreeGrid<DATA>
         }
 
         if (this.gridData.getLength() > 0 && selectedIndex < this.gridData.getLength() - 1) {
-            this.unselectAllRows();
+            this.deselectAll();
             selectedIndex++;
             this.highlightRowByNode(this.gridData.getItem(selectedIndex));
             this.scrollToRow(selectedIndex, true);
@@ -1552,16 +1668,6 @@ export class TreeGrid<DATA>
         }
 
         return rowIndex;
-    }
-
-    private unselectAllRows(unhighlight: boolean = true) {
-
-        if (unhighlight) {
-            this.removeHighlighting();
-        }
-        if (this.grid.getSelectedRows().length > 0) {
-            this.grid.clearSelection();
-        }
     }
 
     private updateColumnsFormatter(columns: GridColumn<TreeNode<DATA>>[]) {
@@ -1821,9 +1927,8 @@ export class TreeGrid<DATA>
 
     private resetCurrentSelection(nodes: TreeNode<DATA>[]) {
         const selection: number[] = [];
-        const selectionIds: string[] = this.root.getFullSelection().map(el => el.getDataId());
 
-        selectionIds.forEach((selectionId) => {
+        this.selection.getItems().forEach((selectionId) => {
             nodes.forEach((node, index) => {
                 if (node.getDataId() === selectionId) {
                     selection.push(index);
@@ -1858,20 +1963,10 @@ export class TreeGrid<DATA>
             });
         }
 
-        const selectionChanged: boolean = this.isSelectionChanged(newSelection);
-        this.root.setCurrentSelection(newSelection);
-
-        if (selectionChanged) {
+        if (this.selection.isSelectionChanged()) {
             this.triggerSelectionChangedListeners();
+            this.selection.resetSelectionChanged();
         }
-    }
-
-    private isSelectionChanged(newSelection: TreeNode<DATA>[]): boolean {
-        const contains = (nodes: TreeNode<DATA>[], node: TreeNode<DATA>) => nodes.some((n) => n.getDataId() === node.getDataId());
-        const addedSelection: TreeNode<DATA>[] = newSelection.filter(selected => !contains(this.root.getCurrentSelection(), selected));
-        const removedSelection: TreeNode<DATA>[] = this.root.getCurrentSelection().filter(id => !contains(newSelection, id));
-
-        return addedSelection.length > 0 || removedSelection.length > 0;
     }
 
     private showContextMenuAt(x: number, y: number) {
@@ -1887,8 +1982,8 @@ export class TreeGrid<DATA>
 
         const isCurRowHighlighted = this.highlightedNode && this.highlightedNode === node;
 
-        if (this.isSelectionNotEmpty() || isCurRowHighlighted) {
-            this.clearAllSelection(false);
+        if (this.selection.hasSelectedItems() || isCurRowHighlighted) {
+            this.deselectAll(false);
         }
 
         if (!isCurRowHighlighted) {
@@ -1909,11 +2004,6 @@ export class TreeGrid<DATA>
         }
     }
 
-    private clearAllSelection(unhighlight: boolean = true) {
-        this.unselectAllRows(unhighlight);
-        this.root.clearStashedSelection();
-    }
-
     private notifyHighlightingChanged(force: boolean = false, callback?: Function): void {
         this.highlightingChangeListeners.forEach((listener: Function) => {
             listener(this.highlightedNode, force, callback);
@@ -1927,7 +2017,28 @@ export class TreeGrid<DATA>
         });
     }
 
+    private toggleRow(row: number) {
+        const nodeDataId: string = this.gridData.getItem(row).getDataId();
+
+        if (this.grid.isRowSelected(row)) {
+            this.selection.remove(nodeDataId);
+        } else {
+            this.selection.add(nodeDataId);
+        }
+
+        this.grid.toggleRow(row);
+    }
+
     resetExpandedNodesDataIds() {
         this.expandedNodesDataIds = [];
     }
+
+    private selectRow(row: number, debounce?: boolean) {
+        const nodeDataId: string = this.gridData.getItem(row).getDataId();
+        this.selection.reset();
+        this.selection.add(nodeDataId);
+
+        this.grid.selectRow(row, debounce);
+    }
+
 }

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGridSelection.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGridSelection.ts
@@ -1,0 +1,61 @@
+export class TreeGridSelection {
+
+    private selectedItems: string[] = [];
+
+    private selectionChanged: boolean = false;
+
+    add(id: string) {
+        if (this.selectedItems.indexOf(id) < 0) {
+            this.selectedItems.push(id);
+            this.selectionChanged = true;
+        }
+    }
+
+    remove(id: string) {
+        const totalSelected: number = this.selectedItems.length;
+
+        this.selectedItems = this.selectedItems.filter((itemId: string) => itemId !== id);
+
+        this.selectionChanged = totalSelected !== this.selectedItems.length;
+    }
+
+    reset() {
+        if (this.selectedItems.length > 0) {
+            this.selectionChanged = true;
+        }
+
+        this.selectedItems = [];
+    }
+
+    resetSelectionChanged() {
+        this.selectionChanged = false;
+    }
+
+    isSelectionChanged(): boolean {
+        return this.selectionChanged;
+    }
+
+    total(): number {
+        return this.selectedItems.length;
+    }
+
+    getFirstItem(): string {
+        return this.selectedItems[0];
+    }
+
+    hasSelectedItems(): boolean {
+        return this.selectedItems.length > 0;
+    }
+
+    isEmpty(): boolean {
+        return this.selectedItems.length === 0;
+    }
+
+    contains(id: string): boolean {
+        return this.selectedItems.indexOf(id) >= 0;
+    }
+
+    getItems(): string[] {
+        return this.selectedItems.slice();
+    }
+}

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
@@ -8,20 +8,11 @@ export class TreeRoot<DATA> {
 
     private filtered: boolean;
 
-    private currentSelection: TreeNode<DATA>[];
-
-    private stashedSelection: TreeNode<DATA>[];
-
     constructor() {
-
         this.defaultRoot = new TreeNodeBuilder<DATA>().setExpanded(true).build();
         this.filteredRoot = new TreeNodeBuilder<DATA>().setExpanded(true).build();
 
         this.filtered = false;
-
-        this.currentSelection = [];
-
-        this.stashedSelection = [];
     }
 
     getDefaultRoot(): TreeNode<DATA> {
@@ -67,65 +58,24 @@ export class TreeRoot<DATA> {
         if (filtered) {
             // reset the filter on switch to filter
             this.filteredRoot = new TreeNodeBuilder<DATA>().setExpanded(true).build();
-            this.stashSelection();
-        } else if (this.filtered && !filtered) {
-            // stash selection on switch from filter to default
-            this.stashSelection();
         }
 
         this.filtered = filtered;
     }
 
-    getCurrentSelection(): TreeNode<DATA>[] {
-        return this.currentSelection;
-    }
+    getNodeByDataId(dataId: string): TreeNode<DATA> {
+        if (this.isFiltered()) {
+            const node: TreeNode<DATA> = this.filteredRoot.findNode(dataId);
 
-    setCurrentSelection(selection: TreeNode<DATA>[]) {
-        this.currentSelection = selection;
-
-        this.cleanStashedSelection();
-    }
-
-    getStashedSelection(): TreeNode<DATA>[] {
-        return this.stashedSelection;
-    }
-
-    stashSelection() {
-        this.stashedSelection = this.stashedSelection.concat(this.currentSelection);
-        this.currentSelection = [];
-
-        this.cleanStashedSelection();
-    }
-
-    getFullSelection(uniqueOnly: boolean = true): TreeNode<DATA>[] {
-        let fullSelection = this.currentSelection.concat(this.stashedSelection);
-        if (uniqueOnly) {
-            let fullIds = fullSelection.map((el) => {
-                return el.getDataId();
-            });
-            fullSelection = fullSelection.filter((value, index) => {
-                return fullIds.indexOf(value.getDataId()) === index;
-            });
+            if (node) {
+                return node;
+            }
         }
 
-        fullSelection = fullSelection.filter((value) => {
-            return !!value.getDataId();
-        });
-
-        return fullSelection;
+        return this.defaultRoot.findNode(dataId);
     }
 
-    clearStashedSelection() {
-        this.stashedSelection = [];
-    }
-
-    private cleanStashedSelection() {
-        const currentIds: string[] = this.currentSelection.map(el => el.getDataId());
-        const stashedIds: string[] = this.stashedSelection.map(el => el.getDataId());
-
-        this.stashedSelection = this.stashedSelection.filter((value, index) => {
-            // remove duplicated nodes and those, that are already in `currentSelection`
-            return (currentIds.indexOf(value.getDataId()) < 0) && (stashedIds.indexOf(value.getDataId()) === index);
-        });
+    getNodeByDataIdFromCurrent(dataId: string): TreeNode<DATA> {
+        return this.getCurrentRoot().findNode(dataId);
     }
 }

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionController.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionController.ts
@@ -29,7 +29,6 @@ export class SelectionController
         this.treeGrid.onSelectionChanged(() => this.updateState());
         this.treeGrid.onLoaded(() => this.updateState());
         this.onClicked((event) => {
-
             event.preventDefault();
 
             if (this.isDisabled()) {
@@ -37,8 +36,7 @@ export class SelectionController
             }
 
             if (this.isChecked() || this.isPartial()) {
-                this.treeGrid.getRoot().clearStashedSelection();
-                this.treeGrid.getGrid().clearSelection();
+                this.treeGrid.deselectAll();
             } else {
                 this.treeGrid.selectAll();
             }
@@ -47,10 +45,6 @@ export class SelectionController
         this.onRendered(() => {
             this.setChecked(false, true);
         });
-    }
-
-    protected isEntireSelectionStashed(): boolean {
-        return this.treeGrid.getTotalCurrentSelected() === 0 && this.treeGrid.getTotalStashedSelected() !== 0;
     }
 
     protected updateState() {
@@ -77,7 +71,7 @@ export class SelectionController
     }
 
     private isAnySelected(): boolean {
-        return this.treeGrid.getTotalCurrentSelected() !== 0 || this.treeGrid.getTotalStashedSelected() !== 0;
+        return this.treeGrid.getTotalSelected() > 0;
     }
 
     private isAllSelected(): boolean {

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionPanelToggler.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionPanelToggler.ts
@@ -23,8 +23,8 @@ export class SelectionPanelToggler
 
         treeGrid.onSelectionChanged(() => {
             const oldLabel: string = this.getLabel();
-            const totalFullSelected: number = treeGrid.getTotalFullSelected();
-            const newLabel: string = totalFullSelected ? totalFullSelected.toString() : '';
+            const totalSelected: number = treeGrid.getTotalSelected();
+            const newLabel: string = totalSelected ? totalSelected.toString() : '';
 
             if (oldLabel === newLabel) {
                 return;
@@ -39,9 +39,9 @@ export class SelectionPanelToggler
             if (newLabel !== '') {
                 this.addClass(`size-${newLabel.length}`);
                 this.addClass('updated');
-                if (totalFullSelected >= 1) {
+                if (totalSelected >= 1) {
                     this.addClass('any-selected');
-                    const description = i18n(`field.item.${totalFullSelected === 1 ? 'single' : 'multiple'}`);
+                    const description = i18n(`field.item.${totalSelected === 1 ? 'single' : 'multiple'}`);
                     this.counterDescription.getEl().setAttribute('data-label', description);
                 }
                 setTimeout(() => {


### PR DESCRIPTION
-Keeping list of selected data items ids, NOT node ids. Thus no need to keep list of current and stashed selection and filter duplicated nodes when getting selected nodes
-BrowsePanel: treeNodesToBrowseItems -> dataItemsToBrowseItems since only node data was used in browse panels
-Left 1 function to deselect all rows instead of 3!
-RootNode and TreeNode is internal grid structure thing, should not be exposed to non-inheritors; Updated so non-inheritors get data items directly instead of nodes (most of them just needed to count items). Still a lot to be done