### PR TITLE
-Keeping list of selected data items ids, NOT node ids. Thus no need …

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
@@ -312,43 +312,24 @@ export class Grid<T extends Slick.SlickData>
     }
 
     moveSelectedUp() {
-        if (this.slickGrid.getDataLength() > 0) {
-            let selected: number[] = this.getSelectedRows();
-            let row = selected.length >= 1
-                      ? selected[0] - 1
-                      : -1;
+        if (this.getDataLength() > 0) {
+            const row: number = new GridSelectionHelper(this.getSelectedRows()).getRowToSingleSelectUp();
 
-            if (selected.length === 1) {
-                if (row >= 0) {
-                    this.selectRow(row, true);
-                    return row;
-                } else {
-                    this.clearSelection(true);
-                    return 0;
-                }
-            } else if (selected.length > 1) {
-                row = Math.max(row, 0);
+            if (row >= 0) {
                 this.selectRow(row, true);
-                return row;
             }
         }
-
-        return -1;
     }
 
     moveSelectedDown() {
         if (this.slickGrid.getDataLength() > 0) {
-            let selected: number[] = this.getSelectedRows();
-            let row = selected.length >= 1
-                      ? Math.min(selected[selected.length - 1] + 1, this.slickGrid.getDataLength() - 1)
-                      : 0;
+            const row: number = new GridSelectionHelper(this.getSelectedRows()).getRowToSingleSelectDown(this.getDataLength());
 
-            this.selectRow(row, true);
-
-            return row;
+            if (row >= 0) {
+                this.selectRow(row, true);
+            }
         }
 
-        return -1;
     }
 
     addSelectedUp() {

--- a/src/main/resources/assets/admin/common/js/ui/grid/GridSelectionHelper.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/GridSelectionHelper.ts
@@ -112,4 +112,82 @@ export class GridSelectionHelper {
 
         return nextNonSelectedRowDown;
     }
+
+    getRowToToggleWhenShiftingUp(): number {
+        if (this.selected.length === 0) {
+            return -1;
+        }
+
+        const lastSelectedRow: number = this.selected[this.selected.length - 1];
+        const nextRowUp: number = lastSelectedRow - 1;
+
+        if (nextRowUp < 0) {
+            return -1;
+        }
+
+        if (!this.isSelected(nextRowUp)) {
+            return nextRowUp;
+        }
+
+        const nextRowDown: number = lastSelectedRow + 1;
+
+        if (!this.isSelected(nextRowDown)) {
+            return this.selected.pop();
+        }
+
+        const nextNonSelectedRowUp: number = this.findFirstNotSelectedRowAbove(nextRowUp);
+
+        if (nextNonSelectedRowUp >= 0) {
+            return nextNonSelectedRowUp;
+        }
+
+        return -1;
+    }
+
+    getRowToToggleWhenShiftingDown(totalItems: number): number {
+        if (this.selected.length === 0) {
+            return -1;
+        }
+
+        const lastSelectedRow: number = this.selected[this.selected.length - 1];
+        const nextRowDown: number = lastSelectedRow + 1;
+
+        if (nextRowDown >= totalItems) {
+            return -1;
+        }
+
+        if (!this.isSelected(nextRowDown)) {
+            return nextRowDown;
+        }
+
+        const nextRowUp: number = lastSelectedRow - 1;
+
+        if (!this.isSelected(nextRowUp)) {
+            return this.selected.pop();
+        }
+
+        const nextNonSelectedRowDown: number = this.findFirstNotSelectedRowUnder(nextRowDown, totalItems);
+
+        if (nextNonSelectedRowDown < totalItems) {
+            return nextNonSelectedRowDown;
+        }
+
+        return -1;
+    }
+
+    getRowToSingleSelectUp(): number {
+        if (this.selected.length === 0) {
+            return -1;
+        }
+
+        return this.selected[0] - 1;
+    }
+
+    getRowToSingleSelectDown(totalItems: number): number {
+        const row: number = this.selected.length >= 1
+            ? Math.min(this.selected[this.selected.length - 1] + 1, totalItems - 1)
+            : 0;
+
+        return row;
+    }
 }

--- a/src/main/resources/assets/admin/common/js/ui/selector/DropdownTreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/DropdownTreeGrid.ts
@@ -69,7 +69,6 @@ export class DropdownTreeGrid<OPTION_DISPLAY_VALUE>
     }
 
     markSelections(selectedOptions: Option<OPTION_DISPLAY_VALUE>[], ignoreEmpty: boolean = false) {
-        this.optionsTreeGrid.getRoot().clearStashedSelection();
         super.markSelections(selectedOptions, ignoreEmpty);
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -580,7 +580,7 @@ export class TreeGrid<DATA>
 
     deselectAll(unhighlight: boolean = true) {
         if (unhighlight) {
-            this.removeHighlighting(true);
+            this.removeHighlighting();
         }
 
         this.selection.reset();

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGridSelection.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGridSelection.ts
@@ -1,0 +1,61 @@
+export class TreeGridSelection {
+
+    private selectedItems: string[] = [];
+
+    private selectionChanged: boolean = false;
+
+    add(id: string) {
+        if (this.selectedItems.indexOf(id) < 0) {
+            this.selectedItems.push(id);
+            this.selectionChanged = true;
+        }
+    }
+
+    remove(id: string) {
+        const totalSelected: number = this.selectedItems.length;
+
+        this.selectedItems = this.selectedItems.filter((itemId: string) => itemId !== id);
+
+        this.selectionChanged = totalSelected !== this.selectedItems.length;
+    }
+
+    reset() {
+        if (this.selectedItems.length > 0) {
+            this.selectionChanged = true;
+        }
+
+        this.selectedItems = [];
+    }
+
+    resetSelectionChanged() {
+        this.selectionChanged = false;
+    }
+
+    isSelectionChanged(): boolean {
+        return this.selectionChanged;
+    }
+
+    total(): number {
+        return this.selectedItems.length;
+    }
+
+    getFirstItem(): string {
+        return this.selectedItems[0];
+    }
+
+    hasSelectedItems(): boolean {
+        return this.selectedItems.length > 0;
+    }
+
+    isEmpty(): boolean {
+        return this.selectedItems.length === 0;
+    }
+
+    contains(id: string): boolean {
+        return this.selectedItems.indexOf(id) >= 0;
+    }
+
+    getItems(): string[] {
+        return this.selectedItems.slice();
+    }
+}

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
@@ -8,20 +8,11 @@ export class TreeRoot<DATA> {
 
     private filtered: boolean;
 
-    private currentSelection: TreeNode<DATA>[];
-
-    private stashedSelection: TreeNode<DATA>[];
-
     constructor() {
-
         this.defaultRoot = new TreeNodeBuilder<DATA>().setExpanded(true).build();
         this.filteredRoot = new TreeNodeBuilder<DATA>().setExpanded(true).build();
 
         this.filtered = false;
-
-        this.currentSelection = [];
-
-        this.stashedSelection = [];
     }
 
     getDefaultRoot(): TreeNode<DATA> {
@@ -67,65 +58,24 @@ export class TreeRoot<DATA> {
         if (filtered) {
             // reset the filter on switch to filter
             this.filteredRoot = new TreeNodeBuilder<DATA>().setExpanded(true).build();
-            this.stashSelection();
-        } else if (this.filtered && !filtered) {
-            // stash selection on switch from filter to default
-            this.stashSelection();
         }
 
         this.filtered = filtered;
     }
 
-    getCurrentSelection(): TreeNode<DATA>[] {
-        return this.currentSelection;
-    }
+    getNodeByDataId(dataId: string): TreeNode<DATA> {
+        if (this.isFiltered()) {
+            const node: TreeNode<DATA> = this.filteredRoot.findNode(dataId);
 
-    setCurrentSelection(selection: TreeNode<DATA>[]) {
-        this.currentSelection = selection;
-
-        this.cleanStashedSelection();
-    }
-
-    getStashedSelection(): TreeNode<DATA>[] {
-        return this.stashedSelection;
-    }
-
-    stashSelection() {
-        this.stashedSelection = this.stashedSelection.concat(this.currentSelection);
-        this.currentSelection = [];
-
-        this.cleanStashedSelection();
-    }
-
-    getFullSelection(uniqueOnly: boolean = true): TreeNode<DATA>[] {
-        let fullSelection = this.currentSelection.concat(this.stashedSelection);
-        if (uniqueOnly) {
-            let fullIds = fullSelection.map((el) => {
-                return el.getDataId();
-            });
-            fullSelection = fullSelection.filter((value, index) => {
-                return fullIds.indexOf(value.getDataId()) === index;
-            });
+            if (node) {
+                return node;
+            }
         }
 
-        fullSelection = fullSelection.filter((value) => {
-            return !!value.getDataId();
-        });
-
-        return fullSelection;
+        return this.defaultRoot.findNode(dataId);
     }
 
-    clearStashedSelection() {
-        this.stashedSelection = [];
-    }
-
-    private cleanStashedSelection() {
-        const currentIds: string[] = this.currentSelection.map(el => el.getDataId());
-        const stashedIds: string[] = this.stashedSelection.map(el => el.getDataId());
-
-        this.stashedSelection = this.stashedSelection.filter((value, index) => {
-            // remove duplicated nodes and those, that are already in `currentSelection`
-            return (currentIds.indexOf(value.getDataId()) < 0) && (stashedIds.indexOf(value.getDataId()) === index);
-        });
+    getNodeByDataIdFromCurrent(dataId: string): TreeNode<DATA> {
+        return this.getCurrentRoot().findNode(dataId);
     }
 }

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionController.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionController.ts
@@ -29,7 +29,6 @@ export class SelectionController
         this.treeGrid.onSelectionChanged(() => this.updateState());
         this.treeGrid.onLoaded(() => this.updateState());
         this.onClicked((event) => {
-
             event.preventDefault();
 
             if (this.isDisabled()) {
@@ -37,8 +36,7 @@ export class SelectionController
             }
 
             if (this.isChecked() || this.isPartial()) {
-                this.treeGrid.getRoot().clearStashedSelection();
-                this.treeGrid.getGrid().clearSelection();
+                this.treeGrid.deselectAll();
             } else {
                 this.treeGrid.selectAll();
             }
@@ -47,10 +45,6 @@ export class SelectionController
         this.onRendered(() => {
             this.setChecked(false, true);
         });
-    }
-
-    protected isEntireSelectionStashed(): boolean {
-        return this.treeGrid.getTotalCurrentSelected() === 0 && this.treeGrid.getTotalStashedSelected() !== 0;
     }
 
     protected updateState() {
@@ -77,7 +71,7 @@ export class SelectionController
     }
 
     private isAnySelected(): boolean {
-        return this.treeGrid.getTotalCurrentSelected() !== 0 || this.treeGrid.getTotalStashedSelected() !== 0;
+        return this.treeGrid.getTotalSelected() > 0;
     }
 
     private isAllSelected(): boolean {

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionPanelToggler.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/actions/SelectionPanelToggler.ts
@@ -23,8 +23,8 @@ export class SelectionPanelToggler
 
         treeGrid.onSelectionChanged(() => {
             const oldLabel: string = this.getLabel();
-            const totalFullSelected: number = treeGrid.getTotalFullSelected();
-            const newLabel: string = totalFullSelected ? totalFullSelected.toString() : '';
+            const totalSelected: number = treeGrid.getTotalSelected();
+            const newLabel: string = totalSelected ? totalSelected.toString() : '';
 
             if (oldLabel === newLabel) {
                 return;
@@ -39,9 +39,9 @@ export class SelectionPanelToggler
             if (newLabel !== '') {
                 this.addClass(`size-${newLabel.length}`);
                 this.addClass('updated');
-                if (totalFullSelected >= 1) {
+                if (totalSelected >= 1) {
                     this.addClass('any-selected');
-                    const description = i18n(`field.item.${totalFullSelected === 1 ? 'single' : 'multiple'}`);
+                    const description = i18n(`field.item.${totalSelected === 1 ? 'single' : 'multiple'}`);
                     this.counterDescription.getEl().setAttribute('data-label', description);
                 }
                 setTimeout(() => {


### PR DESCRIPTION
…to keep list of current and stashed selection and filter duplicated nodes when getting selected nodes

-BrowsePanel: treeNodesToBrowseItems -> dataItemsToBrowseItems since only node data was used in browse panels
-Left 1 function to deselect all rows instead of 3!
-RootNode and TreeNode is internal grid structure thing, should not be exposed to non-inheritors; Updated so non-inheritors get data items directly instead of nodes (most of them just needed to count items). Still a lot to be done