### PR TITLE
TreeGrid: selecting/deselecting hidden or collapsed nodes spawns erro…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
@@ -222,11 +222,17 @@ export class Grid<T extends Slick.SlickData>
     }
 
     getSelectedRowItems(): T[] {
-        let rowItems: T[] = [];
-        let rows = this.getSelectedRows();
+        const rowItems: T[] = [];
+        const rows: number[] = this.getSelectedRows();
+
         rows.forEach((rowIndex: number) => {
-            rowItems.push(this.dataView.getItem(rowIndex));
+            const item: T = this.dataView.getItem(rowIndex);
+
+            if (item) {
+                rowItems.push(item);
+            }
         });
+
         return rowItems;
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -583,9 +583,14 @@ export class TreeGrid<DATA>
             this.removeHighlighting();
         }
 
-        this.selection.reset();
+        const forceSelectionHandlers: boolean = this.selection.hasSelectedItems() && !this.grid.isAnySelected();
 
+        this.selection.reset();
         this.grid.clearSelection();
+
+        if (forceSelectionHandlers) {
+            this.handleSelectionChanged([]);
+        }
     }
 
     deselectNodes(dataIds: string[]) {

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeRoot.ts
@@ -64,15 +64,7 @@ export class TreeRoot<DATA> {
     }
 
     getNodeByDataId(dataId: string): TreeNode<DATA> {
-        if (this.isFiltered()) {
-            const node: TreeNode<DATA> = this.filteredRoot.findNode(dataId);
-
-            if (node) {
-                return node;
-            }
-        }
-
-        return this.defaultRoot.findNode(dataId);
+        return this.defaultRoot.findNode(dataId) || this.filteredRoot.findNode(dataId);
     }
 
     getNodeByDataIdFromCurrent(dataId: string): TreeNode<DATA> {


### PR DESCRIPTION
…r #1287

-When selected node is not visible (it's parent is collapsed) it is not stored in native grid selection items, but is kept in our list of selected items. Have to sync these 2 lists when deselecting all nodes since some nodes might be not visible