### PR TITLE
[IE 11] Page Component View is not reacting on click #1308

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/menu/TreeContextMenu.ts
+++ b/src/main/resources/assets/admin/common/js/ui/menu/TreeContextMenu.ts
@@ -31,7 +31,6 @@ export class TreeContextMenu
         this.onClicked((e: MouseEvent) => {
             // menu itself was clicked so do nothing
             e.preventDefault();
-            e.stopPropagation();
         });
     }
 


### PR DESCRIPTION
-Not stopping event propagation so DOM elements in IE receive click events