### PR TITLE
Fix focus loss on dropdown handle click

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -437,7 +437,9 @@ export class Dropdown<OPTION_DISPLAY_VALUE>
             }
         });
 
-        this.dropdownHandle.onClicked(() => {
+        this.dropdownHandle.onClicked((event) => {
+            event.stopPropagation();
+            event.preventDefault();
 
             if (this.isDropdownShown()) {
                 this.hideDropdown();


### PR DESCRIPTION
When Dropdown is in the Form with validation enabled, clicking on dropdown handle may create a focus loss, which will cause the validation and focus switch to the empty fields, that should not be empty.