### PR TITLE
Sanitise content queries search string

### DIFF
--- a/src/main/resources/assets/admin/common/js/query/FulltextSearchExpression.ts
+++ b/src/main/resources/assets/admin/common/js/query/FulltextSearchExpression.ts
@@ -10,23 +10,28 @@ import {QueryFields} from './QueryFields';
 export class FulltextSearchExpression {
 
     static create(searchString: string, queryFields: QueryFields): Expression {
-
         if (searchString == null) {
             return null;
         }
-        let args: ValueExpr[] = [];
+
+        const args: ValueExpr[] = [];
+        const escapedSearchString: string = FulltextSearchExpression.escapeString(searchString);
 
         args.push(ValueExpr.stringValue(queryFields.toString()));
-        args.push(ValueExpr.stringValue(searchString));
+        args.push(ValueExpr.stringValue(escapedSearchString));
         args.push(ValueExpr.stringValue('AND'));
 
-        let fulltextExp: FunctionExpr = new FunctionExpr('fulltext', args);
-        let fulltextDynamicExpr: DynamicConstraintExpr = new DynamicConstraintExpr(fulltextExp);
+        const fulltextExp: FunctionExpr = new FunctionExpr('fulltext', args);
+        const fulltextDynamicExpr: DynamicConstraintExpr = new DynamicConstraintExpr(fulltextExp);
 
-        let nGramExpr: FunctionExpr = new FunctionExpr('ngram', args);
-        let nGramDynamicExpr: DynamicConstraintExpr = new DynamicConstraintExpr(nGramExpr);
+        const nGramExpr: FunctionExpr = new FunctionExpr('ngram', args);
+        const nGramDynamicExpr: DynamicConstraintExpr = new DynamicConstraintExpr(nGramExpr);
 
         return new LogicalExpr(fulltextDynamicExpr, LogicalOperator.OR, nGramDynamicExpr);
+    }
+
+    static escapeString(value: string): string {
+        return value.replace(/((\&\&)|(\|\|)|[+-=><!(){}\[\]^"~*?:\\/])/g, `\\$1`);
     }
 }
 


### PR DESCRIPTION
-Escaping `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /` symbols mentioned in https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters to prevent backend errors