### PR TITLE
Option Set - labels should be sanitized (3.2.1)

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormOccurrenceDraggableLabel.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormOccurrenceDraggableLabel.ts
@@ -33,6 +33,7 @@ export class FormOccurrenceDraggableLabel
 
     setText(label: string) {
         this.title.textContent = label.trim();
+        this.toggleClass('custom-label', this.subTitleText !== label);
     }
 
     setExpandable(expandable: boolean) {


### PR DESCRIPTION
-HtmlArea has markup html saved in a property that is not to be used as a label definitely, thus filtering potential label string from html tags
-Setting label via textContent property to prevent XSS
-Fixing small issue in Element.fromString

(cherry picked from commit 9f83504cb733136fc79c2f58c1d2eb8a0947f336)