### PR TITLE
Filtering selector by parent display name doesn't work if the name contains spaces

### DIFF
--- a/src/main/resources/assets/admin/common/js/query/PathMatchExpression.ts
+++ b/src/main/resources/assets/admin/common/js/query/PathMatchExpression.ts
@@ -43,6 +43,8 @@ export class PathMatchExpression
             searchString = searchString.slice(1);
         }
 
+        searchString = searchString.trim().replace(/\s+/g,'*');
+
         return '/content/*' + searchString + '*';
     }
 }


### PR DESCRIPTION
…not working in Image Selector #1846

-Replacing white spaces in the search string with wildcard to handle cases:
1. When content has path where spaces in display name are represented with '-' symbol
2. When spaces in path are multiple (E.g. path like "/content/features/date   time")

The only drawback is in potential extra hits due to wildcard usage