### PR TITLE
Dropzone icon remains visible after the image is removed from one of …

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/uploader/UploaderEl.ts
+++ b/src/main/resources/assets/admin/common/js/ui/uploader/UploaderEl.ts
@@ -151,11 +151,13 @@ export class UploaderEl<MODEL extends Equitable>
         if (value) {
             if (this.config.showResult) {
                 this.setResultVisible();
-            } else {
+            } else if (!this.config.hideDefaultDropZone) {
                 this.setDefaultDropzoneVisible();
             }
         } else {
-            this.setDefaultDropzoneVisible();
+            if (!this.config.hideDefaultDropZone) {
+                this.setDefaultDropzoneVisible();
+            }
             return this;
         }
 
@@ -227,8 +229,8 @@ export class UploaderEl<MODEL extends Equitable>
         return this;
     }
 
-    setDefaultDropzoneVisible(visible: boolean = true, isDrag: boolean = false) {
-        if (visible && this.config.hideDefaultDropZone && !isDrag) {
+    setDefaultDropzoneVisible(visible: boolean = true) {
+        if (visible && this.isItemsUploadLimitReached()) {
             return;
         }
 


### PR DESCRIPTION
…several image selectors #1932

-No showing drag dropzone if items limit is reached
-removed redundant param in setDefaultDropzoneVisible()