### PR TITLE
Invalid Option Set is not highlighted when saved in a new content

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormOccurrenceDraggableLabel.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormOccurrenceDraggableLabel.ts
@@ -11,7 +11,7 @@ export class FormOccurrenceDraggableLabel
     private titleText: string;
     private subTitleText: string;
 
-    constructor(label: string, subTitle?: string) {
+    constructor(label?: string, subTitle?: string) {
         super('form-occurrence-draggable-label');
 
         let nodes: Node[] = [];

--- a/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/itemset/FormItemSetOccurrenceView.ts
@@ -13,33 +13,6 @@ export class FormItemSetOccurrenceView
         super('form-item-set-', config);
     }
 
-    protected extraValidation(_validationRecording: ValidationRecording) {
-        // No extra validation for item-sets
-    }
-
-    protected subscribeOnItemEvents() {
-        this.formItemViews.forEach((formItemView: FormItemView) => {
-            formItemView.onValidityChanged((event: RecordingValidityChangedEvent) => {
-
-                if (!this.currentValidationState) {
-                    return; // currentValidationState is initialized on validate() call which may not be triggered in some cases
-                }
-
-                let previousValidState = this.currentValidationState.isValid();
-                if (event.isValid()) {
-                    this.currentValidationState.removeByPath(event.getOrigin(), false, event.isIncludeChildren());
-                } else {
-                    this.currentValidationState.flatten(event.getRecording());
-                }
-
-                if (previousValidState !== this.currentValidationState.isValid()) {
-                    this.notifyValidityChanged(new RecordingValidityChangedEvent(this.currentValidationState,
-                        this.resolveValidationRecordingPath()).setIncludeChildren(true));
-                }
-            });
-        });
-    }
-
     protected getLabelSubTitle(): string {
         const propArrays = this.propertySet.getPropertyArrays();
         const selectedValues = [];

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOccurrenceViewMultiOptions.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOccurrenceViewMultiOptions.ts
@@ -1,0 +1,6 @@
+import {FormOptionSetOccurrenceView} from './FormOptionSetOccurrenceView';
+
+export class FormOptionSetOccurrenceViewMultiOptions
+    extends FormOptionSetOccurrenceView {
+
+}

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOccurrenceViewSingleOption.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOccurrenceViewSingleOption.ts
@@ -1,0 +1,173 @@
+import {PropertySet} from '../../../data/PropertySet';
+import {PropertyArray} from '../../../data/PropertyArray';
+import {i18n} from '../../../util/Messages';
+import {DivEl} from '../../../dom/DivEl';
+import {FormOptionSet} from './FormOptionSet';
+import {FormSetOccurrenceViewConfig} from '../FormSetOccurrenceView';
+import {FormOptionSetOptionView} from './FormOptionSetOptionView';
+import {FormOptionSetOption} from './FormOptionSetOption';
+import {FormOptionSetOptionViewer} from './FormOptionSetOptionViewer';
+import {Dropdown} from '../../../ui/selector/dropdown/Dropdown';
+import {Option, OptionBuilder} from '../../../ui/selector/Option';
+import {Action} from '../../../ui/Action';
+import * as Q from 'q';
+import {Element} from '../../../dom/Element';
+import {OptionSelectedEvent} from '../../../ui/selector/OptionSelectedEvent';
+import {FormOptionSetOccurrenceView} from './FormOptionSetOccurrenceView';
+
+export class FormOptionSetOccurrenceViewSingleOption
+    extends FormOptionSetOccurrenceView {
+
+    private singleSelectionHeader: DivEl;
+
+    private singleSelectionDropdown: Dropdown<FormOptionSetOption>;
+
+    private resetAction: Action;
+
+    constructor(config: FormSetOccurrenceViewConfig<FormOptionSetOccurrenceView>) {
+        super(config);
+    }
+
+    update(dataSet: PropertySet, unchangedOnly?: boolean): Q.Promise<void> {
+        return super.update(dataSet, unchangedOnly).then(() => {
+            this.layoutSingleSelection();
+
+            return Q(null);
+        });
+    }
+
+    layout(validate: boolean = true): Q.Promise<void> {
+        return super.layout(validate).then(rendered => {
+            this.addClass('single-selection');
+            this.moreButton.prependMenuActions([this.resetAction]);
+            this.layoutSingleSelection();
+
+            return rendered;
+        });
+    }
+
+    protected initElements() {
+        super.initElements();
+
+        this.resetAction = new Action(i18n('action.reset')).setEnabled(false);
+        this.singleSelectionHeader = new DivEl('single-selection-header');
+        this.singleSelectionDropdown = new Dropdown<FormOptionSetOption>(this.formSet.getName(), {
+            optionDisplayValueViewer: new FormOptionSetOptionViewer()
+        });
+
+        this.selectionValidationMessage = new DivEl('selection-message');
+    }
+
+    protected postInitElements() {
+        super.postInitElements();
+
+        this.singleSelectionDropdown.setOptions((<FormOptionSet>this.formSet).getOptions()
+            .map(fop => new OptionBuilder<FormOptionSetOption>()
+                .setValue(fop.getName())    // this is the option ID !
+                .setDisplayValue(fop)
+                .build()));
+    }
+
+    private layoutSingleSelection() {
+        const selectedValue: string = this.getSelectedOptionsArray().get(0)?.getString() ||
+                                      (<FormOptionSet>this.formSet).getOptions().find(op => op.isDefaultOption())?.getName();
+
+
+        if (selectedValue) {
+            // doing this after parent layout to make sure all formItemViews are ready
+            this.singleSelectionDropdown.setValue(selectedValue);
+        } else {
+            // showing/hiding instead of css to trigger FormSetOccurrences onShow/onHide listeners
+            this.formSetOccurrencesContainer.hide();
+            this.singleSelectionDropdown.deselectOptions();
+            this.resetAction.setEnabled(false);
+        }
+    }
+
+    protected initListeners() {
+        super.initListeners();
+
+        this.resetAction.onExecuted(() => {
+            this.singleSelectionDropdown.deselectOptions();
+            this.singleSelectionDropdown.resetActiveSelection();
+        });
+
+        this.singleSelectionDropdown.onOptionSelected((event: OptionSelectedEvent<FormOptionSetOption>) => {
+            const optionIdx: number = event.getIndex();
+            this.getFormItemViews().forEach((view, idx) => view.setVisible(idx === optionIdx));
+
+            const optionView: FormOptionSetOptionView = <FormOptionSetOptionView>this.getFormItemViews()[event.getIndex()];
+
+            if (optionView) {
+                optionView.enableAndExpand();
+            }
+
+            this.singleSelectionHeader.addClass('selected');
+            this.refresh();
+            this.handleSelectionChanged(optionView);
+            this.notifyOccurrenceChanged();
+        });
+
+        this.singleSelectionDropdown.onOptionDeselected((option: Option<FormOptionSetOption>) => {
+            const idx: number = this.singleSelectionDropdown.getOptions().indexOf(option);
+            const optionView: FormOptionSetOptionView = <FormOptionSetOptionView>this.getFormItemViews()[idx];
+
+            if (optionView) {
+                optionView.setSelected(false);
+                optionView.disableAndCollapse();
+            }
+
+            this.singleSelectionHeader.removeClass('selected');
+            this.refresh();
+            this.handleSelectionChanged(optionView);
+        });
+    }
+
+    clean() {
+        super.clean();
+
+        const selectedOptionsArray: PropertyArray = this.getSelectedOptionsArray();
+
+        if (!selectedOptionsArray || selectedOptionsArray.isEmpty()) {
+            this.propertySet.removeAllProperties();
+        }
+    }
+
+    setEnabled(enable: boolean) {
+        super.setEnabled(enable);
+
+        this.singleSelectionDropdown.setEnabled(enable);
+    }
+
+    refresh() {
+        super.refresh();
+
+        this.resetAction.setEnabled(this.singleSelectionDropdown.hasSelectedOption());
+    }
+
+    protected handleSelectionChanged(optionView: FormOptionSetOptionView) {
+        this.formSetOccurrencesContainer.setVisible(
+            this.singleSelectionDropdown.hasSelectedOption() && optionView.getFormItemViews().length !== 0);
+
+        super.handleSelectionChanged(optionView);
+    }
+
+    isExpandable(): boolean {
+        const option: Option<FormOptionSetOption> = this.singleSelectionDropdown?.getSelectedOption();
+
+        if (!option) {
+            return false;
+        }
+
+        const idx: number = this.singleSelectionDropdown.getOptions().indexOf(option);
+        const view: FormOptionSetOptionView = <FormOptionSetOptionView>this.formItemViews[idx];
+        return view?.isExpandable();
+    }
+
+    protected layoutElements() {
+        this.singleSelectionHeader.appendChildren<Element>(new DivEl('drag-control'), this.singleSelectionDropdown, this.label,
+            this.moreButton);
+        this.appendChild(this.singleSelectionHeader);
+        this.appendChild(this.selectionValidationMessage);
+    }
+}

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOccurrences.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOccurrences.ts
@@ -2,12 +2,23 @@ import {FormOptionSetOccurrenceView} from './FormOptionSetOccurrenceView';
 import {FormSetOccurrences} from '../FormSetOccurrences';
 import {FormSetOccurrenceViewConfig} from '../FormSetOccurrenceView';
 import {FormSetOccurrence} from '../FormSetOccurrence';
+import {Occurrences} from '../../Occurrences';
+import {FormOptionSet} from './FormOptionSet';
+import {FormOptionSetOccurrenceViewSingleOption} from './FormOptionSetOccurrenceViewSingleOption';
+import {FormOptionSetOccurrenceViewMultiOptions} from './FormOptionSetOccurrenceViewMultiOptions';
 
 export class FormOptionSetOccurrences
     extends FormSetOccurrences<FormOptionSetOccurrenceView> {
 
     protected createOccurrenceView(config: FormSetOccurrenceViewConfig<FormOptionSetOccurrenceView>): FormOptionSetOccurrenceView {
-        return new FormOptionSetOccurrenceView(config);
+        return this.isSingleSelection() ?
+               new FormOptionSetOccurrenceViewSingleOption(config) :
+               new FormOptionSetOccurrenceViewMultiOptions(config);
+    }
+
+    private isSingleSelection(): boolean {
+        const multi: Occurrences = (<FormOptionSet>this.getFormSet()).getMultiselection();
+        return multi.getMinimum() === 1 && multi.getMaximum() === 1;
     }
 
     createAndAddOccurrence(insertAtIndex: number = this.countOccurrences(),

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -384,16 +384,15 @@ export class FormOptionSetOptionView
     }
 
     select(silent: boolean = false) {
-        if (this.isSelected()) {
-            return;
-        }
-
         this.checkbox?.setChecked(true, true);
-        this.setSelected(true);
         this.selectHandle();
 
-        if (!silent) {
-            this.notifySelectionChanged();
+        if (!this.isSelected()) {
+            this.setSelected(true);
+
+            if (!silent) {
+                this.notifySelectionChanged();
+            }
         }
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -198,7 +198,7 @@ export class Dropdown<OPTION_DISPLAY_VALUE>
     }
 
     hideDropdown() {
-        if (this.selectedOptionView.getOption()) {
+        if (this.selectedOptionView.hasOption()) {
             this.input.hide();
             this.selectedOptionView.show();
         } else if (this.typeAhead) {
@@ -303,7 +303,7 @@ export class Dropdown<OPTION_DISPLAY_VALUE>
         this.dropdownList.markSelections([]);
         this.selectedOptionView.resetOption();
 
-        if (!silent) {
+        if (previousOption && !silent) {
             this.notifyOptionDeselected(previousOption);
         }
 
@@ -312,6 +312,10 @@ export class Dropdown<OPTION_DISPLAY_VALUE>
 
     getSelectedOption(): Option<OPTION_DISPLAY_VALUE> {
         return this.selectedOptionView.getOption();
+    }
+
+    hasSelectedOption(): boolean {
+        return this.selectedOptionView.hasOption();
     }
 
     getSelectedOptionView(): SelectedOptionView<OPTION_DISPLAY_VALUE> {

--- a/src/main/resources/assets/admin/common/js/ui/selector/dropdown/SelectedOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/dropdown/SelectedOptionView.ts
@@ -50,6 +50,10 @@ export class SelectedOptionView<T>
         return this.option;
     }
 
+    hasOption(): boolean {
+        return !!this.option;
+    }
+
     resetOption() {
         this.option = null;
     }


### PR DESCRIPTION
-FormOptionSetOccurrenceView was refactored and descendants were created to differentiate between
single/multi selection options and to avoid pervasive usage of isSingleSelection check
-FormSetOccurrenceView was refactored to divide form items layout and instantiation of it's own required elements
-Removed duplicated code