### PR TITLE
TextInput: don't trim value #1988

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/inputtype/text/TextInputType.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/text/TextInputType.ts
@@ -83,7 +83,7 @@ export abstract class TextInputType
 
     protected getValue(inputEl: TextInput): Value {
         const isValid: boolean = this.isUserInputValid(inputEl);
-        return isValid ? this.getValueType().newValue(inputEl.getValue().trim()) : this.newInitialValue();
+        return isValid ? this.getValueType().newValue(inputEl.getValue()) : this.newInitialValue();
     }
 
     protected abstract createInput(index: number, property: Property): FormInputEl;


### PR DESCRIPTION
-That affects comparing persisted and actual data: if persisted item data has trailing spaces then form data comparison will fail due to trim