### PR TITLE
IsAuthenticatedRequest: cache LoginResult? #1648

### DIFF
--- a/src/main/resources/assets/admin/common/js/security/auth/IsAuthenticatedRequest.ts
+++ b/src/main/resources/assets/admin/common/js/security/auth/IsAuthenticatedRequest.ts
@@ -1,3 +1,4 @@
+import * as Q from 'q';
 import {JsonResponse} from '../../rest/JsonResponse';
 import {AuthResourceRequest} from './AuthResourceRequest';
 import {LoginResult} from './LoginResult';
@@ -6,13 +7,21 @@ import {LoginResultJson} from './LoginResultJson';
 export class IsAuthenticatedRequest
     extends AuthResourceRequest<LoginResult> {
 
+    private static CACHE: LoginResult;
+
     constructor() {
         super();
         this.addRequestPathElements('authenticated');
     }
 
     protected parseResponse(response: JsonResponse<LoginResultJson>): LoginResult {
-        return new LoginResult(response.getResult());
+        IsAuthenticatedRequest.CACHE = new LoginResult(response.getResult());
+
+        return IsAuthenticatedRequest.CACHE;
+    }
+
+    sendAndParse(): Q.Promise<LoginResult> {
+        return !!IsAuthenticatedRequest.CACHE ? Q(IsAuthenticatedRequest.CACHE) : super.sendAndParse();
     }
 
 }

--- a/src/main/resources/assets/admin/common/js/security/auth/IsAuthenticatedRequest.ts
+++ b/src/main/resources/assets/admin/common/js/security/auth/IsAuthenticatedRequest.ts
@@ -7,7 +7,7 @@ import {LoginResultJson} from './LoginResultJson';
 export class IsAuthenticatedRequest
     extends AuthResourceRequest<LoginResult> {
 
-    private static CACHE: LoginResult;
+    private static cachedRequestPromise: Q.Promise<LoginResult>;
 
     constructor() {
         super();
@@ -15,13 +15,12 @@ export class IsAuthenticatedRequest
     }
 
     protected parseResponse(response: JsonResponse<LoginResultJson>): LoginResult {
-        IsAuthenticatedRequest.CACHE = new LoginResult(response.getResult());
-
-        return IsAuthenticatedRequest.CACHE;
+        return new LoginResult(response.getResult());
     }
 
     sendAndParse(): Q.Promise<LoginResult> {
-        return !!IsAuthenticatedRequest.CACHE ? Q(IsAuthenticatedRequest.CACHE) : super.sendAndParse();
+        IsAuthenticatedRequest.cachedRequestPromise = IsAuthenticatedRequest.cachedRequestPromise || super.sendAndParse();
+        return IsAuthenticatedRequest.cachedRequestPromise;
     }
 
 }


### PR DESCRIPTION
-Using cache in auth request to prevent extra requests. Can be removed any time when auth meta will be propagated into live session