### PR TITLE
Increase height of selector dropdowns #1993

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/NamesAndIconViewer.ts
+++ b/src/main/resources/assets/admin/common/js/ui/NamesAndIconViewer.ts
@@ -20,7 +20,7 @@ export class NamesAndIconViewer<OBJECT>
     protected isRelativePath: boolean = false;
 
     constructor(className?: string, size: NamesAndIconViewSize = NamesAndIconViewSize.small) {
-        super(className);
+        super('names-and-icon-viewer ' + (className || ''));
 
         this.size = size;
     }
@@ -120,7 +120,7 @@ export class NamesAndIconViewer<OBJECT>
     }
 
     getPreferredHeight(): number {
-        return 50;
+        return 40;
     }
 
     getNamesAndIconView(): NamesAndIconView {

--- a/src/main/resources/assets/admin/common/js/ui/selector/OptionsTreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/OptionsTreeGrid.ts
@@ -39,7 +39,7 @@ export class OptionsTreeGrid<OPTION_DISPLAY_VALUE>
                 .setLoadBufferSize(20)
                 .setAutoLoad(false)
                 .prependClasses('dropdown-tree-grid')
-                .setRowHeight(50)
+                .setRowHeight(gridOptions.rowHeight)
                 .setHotkeysEnabled(true)
                 .setShowToolbar(false)
                 .setIdPropertyName(gridOptions.dataIdProperty);

--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -188,7 +188,7 @@ export class ComboBox<OPTION_DISPLAY_VALUE>
         }
 
         this.comboBoxDropdown = new ComboBoxDropdown(<DropdownGridConfig<OPTION_DISPLAY_VALUE>>{
-            maxHeight: config.maxHeight ? config.maxHeight : 200,
+            maxHeight: config.maxHeight ? config.maxHeight : 370,
             width: this.input.getWidth(),
             optionDisplayValueViewer: config.optionDisplayValueViewer,
             filter: config.filter,

--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/RichSelectedOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/RichSelectedOptionView.ts
@@ -54,7 +54,7 @@ export class RichSelectedOptionView<T>
 
     doRender(): Q.Promise<boolean> {
         this.appendActionButtons();
-        this.appendChild(this.createView(this.optionDisplayValue));
+        this.appendChild(this.createView(this.optionDisplayValue).addClass('option-value'));
 
         return Q(true);
     }

--- a/src/main/resources/assets/admin/common/styles/api/app/names-and-icon-view.less
+++ b/src/main/resources/assets/admin/common/styles/api/app/names-and-icon-view.less
@@ -1,6 +1,9 @@
 .names-and-icon-view {
   .reset();
 
+  display: flex;
+  align-items: center;
+
   .names-and-icon-view-styles(48px);
 
   &.small {
@@ -20,7 +23,8 @@
     overflow: hidden;
 
     .@{_COMMON_PREFIX}wrapper {
-
+      display: flex;
+      align-items: center;
       height: @size;
       width: @size;
       margin-right: @icon-names-gap;
@@ -49,10 +53,11 @@
         margin: auto;
         vertical-align: middle;
       }
-    }
 
-    .@{_COMMON_PREFIX}names-view {
-      margin: 0 0 0 @size + @icon-names-gap;
+      svg {
+        width: 100%;
+        height: 100%;
+      }
     }
 
     .@{_COMMON_PREFIX}icon-label {

--- a/src/main/resources/assets/admin/common/styles/api/ui/grid/grid.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/grid/grid.less
@@ -20,6 +20,7 @@
     display: flex;
     align-items: center;
     .default-slick-cell-styling(1px 8px 1px 0);
+
     cursor: pointer;
 
     &:first-child {

--- a/src/main/resources/assets/admin/common/styles/api/ui/grid/grid.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/grid/grid.less
@@ -14,4 +14,21 @@
   .slick-pane {
     position: static;
   }
+
+  .slick-cell {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    .default-slick-cell-styling(1px 8px 1px 0);
+    cursor: pointer;
+
+    &:first-child {
+      padding-left: 8px;
+    }
+
+    * {
+      // force same cursor on every child
+      cursor: pointer;
+    }
+  }
 }

--- a/src/main/resources/assets/admin/common/styles/api/ui/names-and-icon-viewer.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/names-and-icon-viewer.less
@@ -1,0 +1,5 @@
+.names-and-icon-viewer {
+  display: flex;
+  align-items: center;
+  .ellipsis();
+}

--- a/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/combobox.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/combobox.less
@@ -72,8 +72,6 @@
 
     .slick-row .slick-cell-checkboxsel {
       overflow: visible;
-      padding: 0;
-      padding-right: 20px;
 
       label {
         display: block;
@@ -96,7 +94,25 @@
     }
 
     .slick-cell {
-      .option-cell();
+      .viewer {
+        .names-and-icon-view {
+          .@{_COMMON_PREFIX}wrapper {
+            height: 26px;
+            width: 26px;
+            margin-right: 10px;
+          }
+
+          .@{_COMMON_PREFIX}names-view {
+            .@{_COMMON_PREFIX}main-name {
+              font-size: 13px;
+            }
+
+            .@{_COMMON_PREFIX}sub-name {
+              font-size: 11px;
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/rich-combobox.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/rich-combobox.less
@@ -33,8 +33,6 @@
       height: 45px;
 
       .names-and-icon-view {
-        margin-right: 55px;
-
         .@{_COMMON_PREFIX}main-name {
           font-weight: normal;
           color: @admin-dark-gray;

--- a/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/selected-options.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/selected-options.less
@@ -38,6 +38,7 @@
 
     .edit {
       .icon-pencil;
+
       order: 1;
       margin-right: 10px;
       position: relative;
@@ -56,6 +57,7 @@
 
     .remove {
       .icon-close;
+
       order: 2;
     }
 

--- a/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/selected-options.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/selector/combobox/selected-options.less
@@ -9,10 +9,11 @@
   }
 
   .selected-option {
+    display: flex;
+    align-items: center;
     .option-cell();
     width: 100%;
     cursor: default;
-    position: relative;
 
     &:hover {
       background: none;
@@ -31,9 +32,16 @@
       }
     }
 
+    .option-value {
+      flex-grow: 1;
+    }
+
     .edit {
       .icon-pencil;
-      right: 30px;
+      order: 1;
+      margin-right: 10px;
+      position: relative;
+      top: 1px;
     }
 
     .remove, .edit {
@@ -41,17 +49,14 @@
       .focusable();
 
       border: 1px solid transparent;
-      position: absolute;
       font-size: 12px;
       text-decoration: none;
       cursor: pointer;
-      top: 9px;
     }
 
     .remove {
       .icon-close;
-      right: 0;
-      top: 5px;
+      order: 2;
     }
 
     &.non-editable {
@@ -69,7 +74,7 @@
 }
 
 .option-cell() {
-  .default-slick-cell-styling(8px 0 0 5px);
+  .default-slick-cell-styling(1px 8px 1px 0);
 
   &:hover, &.active {
     background: @admin-bg-light-gray;

--- a/src/main/resources/assets/admin/common/styles/api/ui/selector/dropdown/dropdown.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/selector/dropdown/dropdown.less
@@ -59,9 +59,6 @@
     }
 
     .slick-cell {
-      height: 100%;
-      .default-slick-cell-styling();
-
       &:hover, &.active {
         background: @admin-bg-light-gray;
         cursor: pointer;
@@ -112,14 +109,6 @@
 .dropdown-tree-grid {
   .grid {
     .slick-row {
-      height: 50px;
-
-      .slick-cell {
-        height: 50px;
-        .viewer {
-          padding-top: 3px;
-        }
-      }
       &.readonly {
         opacity: 0.5;
         pointer-events: none;
@@ -168,9 +157,6 @@
       .slick-row {
         .toggle.icon {
           display: none;
-        }
-        .content-summary-viewer, .content-tree-selector-item-viewer {
-          padding-left: 15px;
         }
       }
     }

--- a/src/main/resources/assets/admin/common/styles/api/ui/treegrid/tree-grid.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/treegrid/tree-grid.less
@@ -33,18 +33,6 @@
       color: @admin-white;
     }
 
-    .slick-cell {
-      .default-slick-cell-styling(4px 8px 4px 0);
-      cursor: pointer;
-      line-height: 37px;
-      height: 45px; // firefox ignores SlickGrid.rowHeight
-
-      * {
-        // force same cursor on every child
-        cursor: pointer;
-      }
-    }
-
     .slick-row {
 
       background-color: @admin-white;
@@ -75,7 +63,6 @@
       .slick-cell-checkboxsel {
         min-width: 45px;
         line-height: normal;
-        padding-left: 8px;
         display: flex;
         justify-content: center;
 
@@ -99,10 +86,6 @@
           background: url("../../../../images/box-checked.gif") center no-repeat;
         }
 
-        &:last-child {
-          padding-right: 20px;
-        }
-
       }
 
       .toggle {
@@ -112,9 +95,8 @@
 
         display: inline-block;
         position: relative;
-        float: left;
         height: 100%;
-        width: 20px;
+        min-width: 20px;
         text-align: center;
         margin-right: 17px;
       }
@@ -140,8 +122,6 @@
       }
 
       .viewer {
-        display: block;
-        height: 100%;
         .names-and-icon-view {
           .@{_COMMON_PREFIX}wrapper {
             line-height: 36px;

--- a/src/main/resources/assets/admin/common/styles/main.less
+++ b/src/main/resources/assets/admin/common/styles/main.less
@@ -60,6 +60,7 @@
 @import "api/ui/panel/docked-panel";
 @import "api/ui/uploader/uploader-el";
 @import "api/ui/checkbox";
+@import "api/ui/names-and-icon-viewer";
 @import "api/ui/button/button";
 @import "api/ui/button/cycle-button";
 @import "api/ui/button/dropdown-handle";

--- a/src/main/resources/assets/admin/common/styles/main.lite.less
+++ b/src/main/resources/assets/admin/common/styles/main.lite.less
@@ -32,6 +32,7 @@
 @import "api/ui/dropzone";
 @import "api/ui/mask";
 @import "api/ui/drag-helper";
+@import "api/ui/names-and-icon-viewer";
 @import "api/app/names-view";
 @import "api/app/names-and-icon-view";
 @import "api/ui/tooltip";


### PR DESCRIPTION
-Height of a slickgrid's row must not be set via css/less but via internal slickgrid rowHeight param, we have setRowHeight in grid options object for it
-Using display: flex for grid cells and its' children elements wherever possible
-Moved common slick-cell styling to a grid.less and removed duplicated entries in other places
-Added separate names-and-icon-viewer.less for NamesAndIconViewer.ts styling
-Adjusted corresponding selected-options styling