### PR TITLE
Browse panel gets empty after clicking on Show/Hide Search Panel #2083

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1134,9 +1134,10 @@ export class TreeGrid<DATA extends IDentifiable>
                 updateColumns();
                 this.getGrid().syncGridSelection(true);
             } else {
-                this.getGrid().resizeCanvas();
                 this.highlightCurrentNode();
             }
+
+            this.getGrid().resizeCanvas();
         };
 
         const onBecameActive = (active: boolean) => {


### PR DESCRIPTION
-helping slickgrid to redraw it's items on resize