### PR TITLE
Support custom validation errors for input types #2262

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormContext.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormContext.ts
@@ -56,7 +56,7 @@ export class FormContext {
         return this.language;
     }
 
-    getCustomValidationErrors(): ValidationError[] {
+    getValidationErrors(): ValidationError[] {
         return this.validationErrors.slice(0);
     }
 

--- a/src/main/resources/assets/admin/common/js/form/FormContext.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormContext.ts
@@ -56,6 +56,10 @@ export class FormContext {
         return this.language;
     }
 
+    setValidationErrors(validationErrors: ValidationError[]): void {
+        this.validationErrors = validationErrors;
+    }
+
     getValidationErrors(): ValidationError[] {
         return this.validationErrors.slice(0);
     }

--- a/src/main/resources/assets/admin/common/js/form/InputView.ts
+++ b/src/main/resources/assets/admin/common/js/form/InputView.ts
@@ -119,18 +119,18 @@ export class InputView
                 this.appendChild(this.bottomButtonRow);
                 this.bottomButtonRow.appendChild(this.addButton);
 
-                this.toggleClass('one-and-only',
+                this.toggleClass('single-occurrence',
                     this.input.getOccurrences().getMinimum() === 1 && this.input.getOccurrences().getMaximum() === 1);
 
                 inputTypeViewNotManagingAdd.onOccurrenceValueChanged(() => {
-                    this.toggleClass('has-invalid-user-input', !inputTypeViewNotManagingAdd.hasValidUserInput());
+                    this.toggleHasInvalidInputClass(inputTypeViewNotManagingAdd);
                 });
 
                 inputTypeViewNotManagingAdd.onValidityChanged((event: InputValidityChangedEvent) => {
-                    this.toggleClass('has-invalid-user-input', !inputTypeViewNotManagingAdd.hasValidUserInput());
+                    this.toggleHasInvalidInputClass(inputTypeViewNotManagingAdd);
                 });
 
-                this.toggleClass('has-invalid-user-input', !inputTypeViewNotManagingAdd.hasValidUserInput());
+                this.toggleHasInvalidInputClass(inputTypeViewNotManagingAdd);
             }
 
             this.validationViewer = new InputViewValidationViewer();
@@ -161,6 +161,10 @@ export class InputView
 
             return Q(null);
         });
+    }
+
+    private toggleHasInvalidInputClass(inputTypeViewNotManagingAdd: BaseInputTypeNotManagingAdd) {
+        this.toggleClass('has-invalid-user-input', !inputTypeViewNotManagingAdd.hasValidUserInput());
     }
 
     public update(propertySet: PropertySet, unchangedOnly?: boolean): Q.Promise<void> {

--- a/src/main/resources/assets/admin/common/js/form/InputViewValidationViewer.ts
+++ b/src/main/resources/assets/admin/common/js/form/InputViewValidationViewer.ts
@@ -5,9 +5,6 @@ import {AEl} from '../dom/AEl';
 
 export class InputViewValidationViewer extends Viewer<InputValidationRecording> {
 
-    private static ERROR_DETAILS_VISIBLE_CLS: string = 'error-details-visible';
-    private static ERROR_DETAILS_TOGGLER_CLS: string = 'error-details-toggler';
-
     constructor() {
         super('validation-viewer');
     }
@@ -16,35 +13,8 @@ export class InputViewValidationViewer extends Viewer<InputValidationRecording> 
         super.doLayout(recording);
 
         if (recording) {
-            this.setHtml(recording.isValidationMessageToBeRendered() ? this.getText() : '');
-            if (recording.isValidationMessageToBeRendered() && recording.hasToggleErrorDetailsCallback()) {
-                this.appendErrorDetailsToggler(recording, this.hasClass(InputViewValidationViewer.ERROR_DETAILS_VISIBLE_CLS));
-            }
+            this.setHtml(this.getText());
         }
-    }
-
-    private appendErrorDetailsToggler(recording: InputValidationRecording, isErrorDetailsVisible: boolean) {
-        const toggleLink = new AEl(InputViewValidationViewer.ERROR_DETAILS_TOGGLER_CLS);
-
-        toggleLink.whenRendered(() =>
-            toggleLink.setHtml(
-        isErrorDetailsVisible ? i18n('field.validation.hideDetails') : i18n('field.validation.showDetails')
-            )
-        );
-
-        toggleLink.onClicked((e: MouseEvent) => {
-            const errorDetailsVisible = this.hasClass(InputViewValidationViewer.ERROR_DETAILS_VISIBLE_CLS);
-            this.toggleClass(InputViewValidationViewer.ERROR_DETAILS_VISIBLE_CLS, !errorDetailsVisible);
-            toggleLink.setHtml(errorDetailsVisible ?
-                i18n('field.validation.showDetails') : i18n('field.validation.hideDetails')
-            );
-            recording.getToggleErrorDetailsCallback()();
-
-            e.stopPropagation();
-            e.preventDefault();
-        });
-
-        this.appendChild(toggleLink);
     }
 
     private getText(): string {

--- a/src/main/resources/assets/admin/common/js/form/inputtype/InputTypeView.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/InputTypeView.ts
@@ -45,6 +45,10 @@ export interface InputTypeView {
 
     getInputValidationRecording(): InputValidationRecording;
 
+    hideValidationDetailsByDefault(): boolean;
+
+    isValidationErrorToBeRendered(): boolean;
+
     onValidityChanged(listener: (event: InputValidityChangedEvent) => void);
 
     unValidityChanged(listener: (event: InputValidityChangedEvent) => void);

--- a/src/main/resources/assets/admin/common/js/form/inputtype/InputValidationRecording.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/InputValidationRecording.ts
@@ -9,19 +9,11 @@ export class InputValidationRecording
 
     private readonly totalValid: number;
 
-    private validationErrorToBeRendered: boolean;
-
-    private validationMessageToBeRendered: boolean;
-
     private errorMessage: string;
-
-    private toggleErrorDetailsCallback: () => void;
 
     constructor(occurrences: Occurrences, totalValid: number) {
         this.occurrences = occurrences;
         this.totalValid = totalValid;
-        this.validationErrorToBeRendered = true;
-        this.validationMessageToBeRendered = true;
     }
 
     isValid(): boolean {
@@ -39,22 +31,6 @@ export class InputValidationRecording
 
     isMaximumOccurrencesBreached(): boolean {
         return this.occurrences.maximumBreached(this.totalValid);
-    }
-
-    setValidationErrorToBeRendered(value: boolean) {
-        this.validationErrorToBeRendered = value;
-    }
-
-    isValidationErrorToBeRendered(): boolean {
-        return this.validationErrorToBeRendered;
-    }
-
-    setValidationMessageToBeRendered(value: boolean) {
-        this.validationMessageToBeRendered = value;
-    }
-
-    isValidationMessageToBeRendered(): boolean {
-        return this.validationMessageToBeRendered;
     }
 
     setErrorMessage(value: string): void {
@@ -75,17 +51,5 @@ export class InputValidationRecording
 
     validityChanged(other: InputValidationRecording) {
         return other == null || other == null || !other.equals(this);
-    }
-
-    setToggleErrorDetailsCallback(callbackFn: () => void): void {
-        this.toggleErrorDetailsCallback = callbackFn;
-    }
-
-    getToggleErrorDetailsCallback(): () => void {
-        return this.toggleErrorDetailsCallback;
-    }
-
-    hasToggleErrorDetailsCallback(): boolean {
-        return !!this.toggleErrorDetailsCallback;
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputType.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputType.ts
@@ -79,6 +79,9 @@ export abstract class BaseInputType extends DivEl
         });
     }
 
+    hideValidationDetailsByDefault(): boolean {
+        return false;
+    }
 
     abstract onValueChanged(listener: (event: ValueChangedEvent) => void);
 

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeManagingAdd.ts
@@ -75,7 +75,6 @@ export abstract class BaseInputTypeManagingAdd
     protected doValidate(): InputValidationRecording {
         const totalValid: number = this.getNumberOfValids();
         const recording: InputValidationRecording = new InputValidationRecording(this.input.getOccurrences(), totalValid);
-        recording.setValidationErrorToBeRendered(this.isValidationErrorToBeRendered());
 
         return recording;
     }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -345,7 +345,7 @@ export abstract class BaseInputTypeNotManagingAdd
         }
     }
 
-    protected validateCustomErrors(occurrenceView: InputOccurrenceView) {
+    protected validateCustomErrors(occurrenceView: InputOccurrenceView): void {
         this.getContext().formContext.getValidationErrors().forEach((error: ValidationError) => {
             if (occurrenceView.getDataPath().asRelative().toString() === error.getPropertyPath()) {
                 this.occurrenceValidationState.get(occurrenceView.getInputElement().getId()).addAdditionalValidation(

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -346,9 +346,12 @@ export abstract class BaseInputTypeNotManagingAdd
     }
 
     protected validateCustomErrors(occurrenceView: InputOccurrenceView): void {
+        const occurrenceDataPath: string = occurrenceView.getDataPath().asRelative().toString();
+        const occurrenceId: string = occurrenceView.getInputElement().getId();
+
         this.getContext().formContext.getValidationErrors().forEach((error: ValidationError) => {
-            if (occurrenceView.getDataPath().asRelative().toString() === error.getPropertyPath()) {
-                this.occurrenceValidationState.get(occurrenceView.getInputElement().getId()).addAdditionalValidation(
+            if (occurrenceDataPath === error.getPropertyPath()) {
+                this.occurrenceValidationState.get(occurrenceId).addAdditionalValidation(
                     AdditionalValidationRecord.create().setMessage(error.getMessage()).build());
             }
         });

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/InputOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/InputOccurrenceView.ts
@@ -194,8 +194,8 @@ export class InputOccurrenceView
     }
 
     displayValidationError(occurrenceValidationRecord: OccurrenceValidationRecord) {
-        this.validationErrorBlock.setVisible(occurrenceValidationRecord && !occurrenceValidationRecord.isValueValid());
-        const errorMessage: string = occurrenceValidationRecord?.getAdditionalValidationRecord()?.getMessage() || '';
+        const errorMessage: string = occurrenceValidationRecord?.getAdditionalValidationRecords()[0]?.getMessage() || '';
         this.validationErrorBlock.setHtml(errorMessage);
+        this.toggleClass('invalid', !!errorMessage);
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/OccurrenceValidationRecord.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/OccurrenceValidationRecord.ts
@@ -22,8 +22,8 @@ export class OccurrenceValidationRecord {
         return !this.isRequiredContractBroken() && this.isValueValid();
     }
 
-    getAdditionalValidationRecord(): AdditionalValidationRecord {
-        return this.additionalValidation[0];
+    getAdditionalValidationRecords(): AdditionalValidationRecord[] {
+        return this.additionalValidation;
     }
 
     addAdditionalValidation(record: AdditionalValidationRecord) {

--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -148,4 +148,74 @@
       margin-top: 7px;
     }
   }
+
+  .validation-block {
+    display: flex;
+    align-items: center;
+
+    .validation-viewer {
+      margin-right: 10px;
+    }
+
+    .validation-toggler {
+      padding: 0;
+      background-color: @admin-white;
+      outline: none;
+      display: none;
+
+      span {
+        text-decoration: underline;
+        color: @admin-blue;
+      }
+
+      &:hover {
+        background-color: @admin-white;
+
+        span {
+          color: @admin-button-blue2;
+        }
+      }
+    }
+  }
+
+  &.has-invalid-user-input,
+  &.error-details-hidden-by-default {
+    .validation-block {
+      .validation-toggler {
+        display: block;
+      }
+    }
+  }
+
+  &.valid {
+    .validation-block {
+      display: none;
+    }
+  }
+
+  .input-occurrence-view {
+    .error-block {
+      display: none;
+    }
+
+    &.invalid {
+      .error-block {
+        display: block;
+      }
+    }
+  }
+
+  &.error-details-hidden {
+    .input-occurrence-view {
+      .error-block {
+        display: none;
+      }
+    }
+  }
+
+  &.one-and-only.has-invalid-user-input {
+    .validation-viewer {
+      display: none;
+    }
+  }
 }

--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -68,6 +68,35 @@
     }
   }
 
+  .validation-block {
+    display: flex;
+    align-items: center;
+
+    .validation-viewer {
+      margin-right: 10px;
+    }
+
+    .validation-toggler {
+      padding: 0;
+      background-color: @admin-white;
+      outline: none;
+      display: none;
+
+      span {
+        text-decoration: underline;
+        color: @admin-blue;
+      }
+
+      &:hover {
+        background-color: @admin-white;
+
+        span {
+          color: @admin-button-blue2;
+        }
+      }
+    }
+  }
+
   &.label-inline {
     > label,
     > .input-label {
@@ -89,6 +118,18 @@
 
     > .help-text-toggler {
       margin-left: 5px;
+    }
+  }
+
+  .input-occurrence-view {
+    .error-block {
+      display: none;
+    }
+
+    &.invalid {
+      .error-block {
+        display: block;
+      }
     }
   }
 
@@ -149,35 +190,6 @@
     }
   }
 
-  .validation-block {
-    display: flex;
-    align-items: center;
-
-    .validation-viewer {
-      margin-right: 10px;
-    }
-
-    .validation-toggler {
-      padding: 0;
-      background-color: @admin-white;
-      outline: none;
-      display: none;
-
-      span {
-        text-decoration: underline;
-        color: @admin-blue;
-      }
-
-      &:hover {
-        background-color: @admin-white;
-
-        span {
-          color: @admin-button-blue2;
-        }
-      }
-    }
-  }
-
   &.has-invalid-user-input,
   &.error-details-hidden-by-default {
     .validation-block {
@@ -190,18 +202,6 @@
   &.valid {
     .validation-block {
       display: none;
-    }
-  }
-
-  .input-occurrence-view {
-    .error-block {
-      display: none;
-    }
-
-    &.invalid {
-      .error-block {
-        display: block;
-      }
     }
   }
 

--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -213,7 +213,7 @@
     }
   }
 
-  &.one-and-only.has-invalid-user-input {
+  &.single-occurrence.has-invalid-user-input {
     .validation-viewer {
       display: none;
     }

--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -133,6 +133,14 @@
     }
   }
 
+  &.error-details-hidden {
+    .input-occurrence-view {
+      .error-block {
+        display: none;
+      }
+    }
+  }
+
   .input-type-view {
     .image-uploader-el {
       width: 100%;
@@ -202,14 +210,6 @@
   &.valid {
     .validation-block {
       display: none;
-    }
-  }
-
-  &.error-details-hidden {
-    .input-occurrence-view {
-      .error-block {
-        display: none;
-      }
     }
   }
 


### PR DESCRIPTION
-Added isValidationErrorToBeRendered to InputTypeView to move InputView related logic (to render or not render validation error) to it. 
-Cleaned InputValidationRecording from validationErrorToBeRendered and validationMessageToBeRendered that are totally do not belong to this class
-Added hideValidationDetailsByDefault to InputTypeView to let input type decide rather to show or not validation details under each input by default
-Updated validation details toggler
-Showing custom validation errors for each input occurrence
-Using styles wherever possible to handle show/hide of validation 
