### PR TITLE
Input with a mix of valid and invalid occurrences is considered valid…

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/AdditionalValidationRecord.ts
+++ b/src/main/resources/assets/admin/common/js/form/AdditionalValidationRecord.ts
@@ -1,9 +1,12 @@
 export class AdditionalValidationRecord {
 
-    private message: string;
+    private readonly message: string;
+
+    private readonly custom: boolean;
 
     constructor(builder: Builder) {
         this.message = builder.message;
+        this.custom = builder.custom || false;
     }
 
     public static create(): Builder {
@@ -14,20 +17,27 @@ export class AdditionalValidationRecord {
         return this.message;
     }
 
-    equals(that: AdditionalValidationRecord): boolean {
-        if (this.message !== that.message) {
-            return false;
-        }
+    isCustom(): boolean {
+        return this.custom;
+    }
 
-        return true;
+    equals(that: AdditionalValidationRecord): boolean {
+        return this.message === that.message && this.custom === that.custom;
     }
 }
 
 export class Builder {
     message: string;
 
+    custom: boolean;
+
     setMessage(value: string): Builder {
         this.message = value;
+        return this;
+    }
+
+    setCustom(value: boolean): Builder {
+        this.custom = value;
         return this;
     }
 

--- a/src/main/resources/assets/admin/common/js/form/InputView.ts
+++ b/src/main/resources/assets/admin/common/js/form/InputView.ts
@@ -133,12 +133,10 @@ export class InputView
                 this.toggleHasInvalidInputClass(inputTypeViewNotManagingAdd);
             } else {
                 this.inputTypeView.onValidityChanged(() => {
-                    console.log('onValidityChanged');
                     this.toggleHasInvalidInputClass(<BaseInputType>this.inputTypeView);
                 });
 
                 this.inputTypeView.onValueChanged(() => {
-                    console.log('value changed');
                     this.toggleHasInvalidInputClass(<BaseInputType>this.inputTypeView);
                 });
             }

--- a/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
+++ b/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
@@ -1,8 +1,5 @@
 import {ValidationRecordingPath} from './ValidationRecordingPath';
-import {AdditionalValidationRecord} from './AdditionalValidationRecord';
 import {Equitable} from '../Equitable';
-import {ObjectHelper} from '../ObjectHelper';
-import {StringHelper} from '../util/StringHelper';
 
 export class ValidationRecording {
 
@@ -10,7 +7,7 @@ export class ValidationRecording {
 
     private breaksMaximumOccurrencesArray: ValidationRecordingPath[] = [];
 
-    private errorMessage: string;
+    private validationErrors: Map<string, string> = new Map<string, string>();
 
     breaksMinimumOccurrences(path: ValidationRecordingPath) {
         if (!this.exists(path, this.breaksMinimumOccurrencesArray)) {
@@ -24,8 +21,8 @@ export class ValidationRecording {
         }
     }
 
-    setErrorMessage(value: string): void {
-        this.errorMessage = value;
+    addValidationError(id: string, errorMessage): void {
+        this.validationErrors.set(id, errorMessage);
     }
 
     isValid(): boolean {
@@ -33,7 +30,7 @@ export class ValidationRecording {
     }
 
     hasError(): boolean {
-        return !StringHelper.isBlank(this.errorMessage);
+        return this.validationErrors.size > 0;
     }
 
     isMinimumOccurrencesValid(): boolean {
@@ -52,10 +49,6 @@ export class ValidationRecording {
         return this.breaksMaximumOccurrencesArray;
     }
 
-    getErrorMessage(): string {
-        return this.errorMessage;
-    }
-
     flatten(recording: ValidationRecording) {
 
         recording.breaksMinimumOccurrencesArray.forEach((path: ValidationRecordingPath) => {
@@ -66,7 +59,9 @@ export class ValidationRecording {
             this.breaksMaximumOccurrences(path);
         });
 
-        this.setErrorMessage(recording.getErrorMessage());
+        recording.validationErrors.forEach((value: string, key: string) => {
+            this.addValidationError(key, value);
+        });
     }
 
     /**
@@ -77,6 +72,7 @@ export class ValidationRecording {
     removeByPath(path: ValidationRecordingPath, strict?: boolean, includeChildren?: boolean) {
         this.removeUnreachedMinimumOccurrencesByPath(path, strict, includeChildren);
         this.removeBreachedMaximumOccurrencesByPath(path, strict, includeChildren);
+        this.validationErrors.delete(path.toString());
     }
 
     removeUnreachedMinimumOccurrencesByPath(path: ValidationRecordingPath, strict?: boolean, includeChildren?: boolean) {
@@ -131,7 +127,7 @@ export class ValidationRecording {
             }
         }
 
-        return ObjectHelper.stringEquals(this.errorMessage, other.errorMessage);
+        return this.validationErrors.size === other.validationErrors.size;
     }
 
     validityChanged(previous: ValidationRecording): boolean {

--- a/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
+++ b/src/main/resources/assets/admin/common/js/form/ValidationRecording.ts
@@ -21,7 +21,7 @@ export class ValidationRecording {
         }
     }
 
-    addValidationError(id: string, errorMessage): void {
+    addValidationError(id: string, errorMessage: string): void {
         this.validationErrors.set(id, errorMessage);
     }
 

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -261,7 +261,7 @@ export abstract class BaseInputTypeNotManagingAdd
         const newValidationRecord: InputValidationRecording = new InputValidationRecording(this.input.getOccurrences(), totalValid);
 
         if (hasCustomError) {
-            newValidationRecord.setErrorMessage(i18n('field.invalid'));
+            newValidationRecord.setErrorMessage(i18n('field.occurrence.invalid'));
         }
 
         if (newValidationRecord.validityChanged(this.previousValidationRecording)) {

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -22,6 +22,7 @@ import {OccurrenceValidationRecord} from './OccurrenceValidationRecord';
 import {BaseInputType} from './BaseInputType';
 import {ValidationError} from '../../../ValidationError';
 import {AdditionalValidationRecord} from '../../AdditionalValidationRecord';
+import {i18n} from '../../../util/Messages';
 
 export abstract class BaseInputTypeNotManagingAdd
     extends BaseInputType {
@@ -256,13 +257,33 @@ export abstract class BaseInputTypeNotManagingAdd
 
     private updateValidationRecordAndNotifyIfChanged() {
         const totalValid: number = this.getTotalValidOccurrences();
+        const hasCustomError: boolean = this.hasCustomError();
         const newValidationRecord: InputValidationRecording = new InputValidationRecording(this.input.getOccurrences(), totalValid);
+
+        if (hasCustomError) {
+            newValidationRecord.setErrorMessage(i18n('field.custom.error'));
+        }
 
         if (newValidationRecord.validityChanged(this.previousValidationRecording)) {
             this.notifyValidityChanged(new InputValidityChangedEvent(newValidationRecord));
         }
 
         this.previousValidationRecording = newValidationRecord;
+    }
+
+    private hasCustomError(): boolean {
+        let hasCustomError: boolean = false;
+
+        this.occurrenceValidationState.forEach((occurrenceValidationRecord: OccurrenceValidationRecord) => {
+            const isCustomError: boolean =
+                occurrenceValidationRecord.getAdditionalValidationRecords().some((rec: AdditionalValidationRecord) => rec.isCustom());
+
+            if (isCustomError) {
+                hasCustomError = true;
+            }
+        });
+
+        return hasCustomError;
     }
 
     private updateValidationRecord() {
@@ -352,7 +373,7 @@ export abstract class BaseInputTypeNotManagingAdd
         this.getContext().formContext.getValidationErrors().forEach((error: ValidationError) => {
             if (occurrenceDataPath === error.getPropertyPath()) {
                 this.occurrenceValidationState.get(occurrenceId).addAdditionalValidation(
-                    AdditionalValidationRecord.create().setMessage(error.getMessage()).build());
+                    AdditionalValidationRecord.create().setMessage(error.getMessage()).setCustom(true).build());
             }
         });
     }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -261,7 +261,7 @@ export abstract class BaseInputTypeNotManagingAdd
         const newValidationRecord: InputValidationRecording = new InputValidationRecording(this.input.getOccurrences(), totalValid);
 
         if (hasCustomError) {
-            newValidationRecord.setErrorMessage(i18n('field.custom.error'));
+            newValidationRecord.setErrorMessage(i18n('field.invalid'));
         }
 
         if (newValidationRecord.validityChanged(this.previousValidationRecording)) {
@@ -349,6 +349,10 @@ export abstract class BaseInputTypeNotManagingAdd
         throw new Error('Must be implemented by inheritor: ' + ClassHelper.getClassName(this));
     }
 
+    hideValidationDetailsByDefault(): boolean {
+        return true;
+    }
+
     private validateOccurrences() {
         this.inputOccurrences.getOccurrenceViews().forEach((occurrenceView: InputOccurrenceView) => {
             this.validateOccurrence(occurrenceView);
@@ -372,6 +376,9 @@ export abstract class BaseInputTypeNotManagingAdd
 
         this.getContext().formContext.getValidationErrors().forEach((error: ValidationError) => {
             if (occurrenceDataPath === error.getPropertyPath()) {
+                occurrenceView.getInputElement().addClass('invalid');
+                occurrenceView.getInputElement().removeClass('valid');
+
                 this.occurrenceValidationState.get(occurrenceId).addAdditionalValidation(
                     AdditionalValidationRecord.create().setMessage(error.getMessage()).setCustom(true).build());
             }

--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -198,8 +198,7 @@
     }
   }
 
-  &.has-invalid-user-input,
-  &.error-details-hidden-by-default {
+  &.has-invalid-user-input:not(.single-occurrence) {
     .validation-block {
       .validation-toggler {
         display: block;

--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -193,7 +193,7 @@
       margin-top: 7px;
     }
 
-    &.visible + .validation-viewer {
+    &.visible + .validation-block {
       margin-top: 7px;
     }
   }

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -108,6 +108,7 @@ field.value.chars.total={0} character(s)
 field.value.required=This field is required
 field.email.invalid=Invalid email address
 field.password.invalid=Invalid password
+field.custom.error=Custom validation errors
 field.occurrence.breaks.min=Min {0} valid occurrence(s) required
 field.occurrence.breaks.max.one=Max 1 occurrence allowed
 field.occurrence.breaks.max.many=Max {0} occurrences allowed

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -108,7 +108,6 @@ field.value.chars.total={0} character(s)
 field.value.required=This field is required
 field.email.invalid=Invalid email address
 field.password.invalid=Invalid password
-field.custom.error=Custom validation errors
 field.occurrence.breaks.min=Min {0} valid occurrence(s) required
 field.occurrence.breaks.max.one=Max 1 occurrence allowed
 field.occurrence.breaks.max.many=Max {0} occurrences allowed

--- a/src/main/resources/i18n/common.properties
+++ b/src/main/resources/i18n/common.properties
@@ -111,6 +111,7 @@ field.password.invalid=Invalid password
 field.occurrence.breaks.min=Min {0} valid occurrence(s) required
 field.occurrence.breaks.max.one=Max 1 occurrence allowed
 field.occurrence.breaks.max.many=Max {0} occurrences allowed
+field.occurrence.invalid=One or more occurrences are invalid
 field.optionset.breaks.min.one=At least one option must be selected
 field.optionset.breaks.min.many=At least {0} options must be selected
 field.optionset.breaks.max.one=Max one option can be selected


### PR DESCRIPTION
… #2275

-Setting error message for custom errors in occurrences so input becomes invalid when custom error presents

First I thought of not putting any message for Input validation viewer since input occurrences with failed server validation  has a personal error message under it, however it was not clear why input is invalid since it has enough valid occurrences, so I've added special message indicating why input is still invalid with enough valid occurrenes