### PR TITLE
Added focus trap to ModalDialog (#2319)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dompurify": "^2.3.4",
     "fine-uploader": "^5.16.2",
     "flag-icon-css": "^3.5.0",
+    "focus-trap": "^6.7.1",
     "jquery": "^3.6.0",
     "jquery-simulate": "^1.0.2",
     "jquery-ui": "^1.13.0",

--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -1,4 +1,5 @@
 import * as Q from 'q';
+import * as Ft from 'focus-trap';
 import {DivEl} from '../../dom/DivEl';
 import {Action} from '../Action';
 import {Element} from '../../dom/Element';
@@ -82,9 +83,12 @@ export abstract class ModalDialog
 
     private pendingMasks: number = 0;
 
+    private focusTrap: Ft.FocusTrap;
+
     protected constructor(config: ModalDialogConfig = <ModalDialogConfig>{}) {
         super('modal-dialog', StyleHelper.COMMON_PREFIX);
         this.config = config;
+        this.focusTrap = Ft.createFocusTrap(this.getHTMLElement());
 
         this.initElements();
         this.postInitElements();
@@ -344,6 +348,8 @@ export abstract class ModalDialog
     }
 
     close() {
+        this.focusTrap.deactivate();
+
         if (this.isSingleDialogGroup()) {
             BodyMask.get().hide();
         }
@@ -481,6 +487,7 @@ export abstract class ModalDialog
     }
 
     open() {
+        setTimeout(() => this.focusTrap.activate(), 100);
 
         BodyMask.get().show();
 


### PR DESCRIPTION
This is a quick accessibility fix using the lib [focus-trap](https://github.com/focus-trap/focus-trap). 

If accepted it'll trap the tab navigation to tabbable elements within the modal dialog, and therefore for all modals that extends that class (`NewContentDialog` in the app-contentstudio for example).

This would fix some content studio accessibility issues listed [here](https://github.com/enonic/app-contentstudio/issues/2988).