### PR TITLE
New ItemSet occurrence gets instantly validated #2333

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
@@ -173,7 +173,7 @@ export class FormItemLayer {
                     parent: this.parent,
                     dataSet: propertySet,
                     lazyRender: this.lazyRender,
-                    validateOccurrenceOnAdded: this.validateOccurrenceOnAdd
+                    validateOccurrenceOnAdd: this.validateOccurrenceOnAdd
                 });
             }
 
@@ -217,7 +217,7 @@ export class FormItemLayer {
                     parent: this.parent,
                     parentDataSet: propertySet,
                     lazyRender: this.lazyRender,
-                    validateOccurrenceOnAdded: this.validateOccurrenceOnAdd
+                    validateOccurrenceOnAdd: this.validateOccurrenceOnAdd
                 });
             }
 

--- a/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
@@ -38,6 +38,8 @@ export class FormItemLayer {
 
     private lazyRender: boolean = true;
 
+    private validateOccurrenceOnAdd: boolean = false;
+
     private formItemLayerFactory: FormItemLayerFactory;
 
     constructor(context: FormContext, layerFactory: FormItemLayerFactory) {
@@ -113,6 +115,14 @@ export class FormItemLayer {
         });
     }
 
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        this.validateOccurrenceOnAdd = value;
+
+        this.formItemViews.forEach((formItemView: FormItemView) => {
+            formItemView.setValidateOccurrenceOnAdd(value);
+        });
+    }
+
     setLazyRender(value: boolean) {
         this.lazyRender = value;
     }
@@ -148,7 +158,8 @@ export class FormItemLayer {
                     formSet: formItemSet,
                     parent: <FormSetOccurrenceView>this.parent,
                     parentDataSet: propertySet,
-                    occurrencesLazyRender: this.lazyRender
+                    occurrencesLazyRender: this.lazyRender,
+                    validateOccurrenceOnAdd: this.validateOccurrenceOnAdd
                 });
             }
 
@@ -161,7 +172,8 @@ export class FormItemLayer {
                     fieldSet: fieldSet,
                     parent: this.parent,
                     dataSet: propertySet,
-                    lazyRender: this.lazyRender
+                    lazyRender: this.lazyRender,
+                    validateOccurrenceOnAdded: this.validateOccurrenceOnAdd
                 });
             }
 
@@ -191,7 +203,8 @@ export class FormItemLayer {
                     formSet: formOptionSet,
                     parent: <FormSetOccurrenceView>this.parent,
                     parentDataSet: propertySet,
-                    occurrencesLazyRender: this.lazyRender
+                    occurrencesLazyRender: this.lazyRender,
+                    validateOccurrenceOnAdd: this.validateOccurrenceOnAdd
                 });
             }
 
@@ -203,7 +216,8 @@ export class FormItemLayer {
                     formOptionSetOption: formOptionSetOption,
                     parent: this.parent,
                     parentDataSet: propertySet,
-                    lazyRender: this.lazyRender
+                    lazyRender: this.lazyRender,
+                    validateOccurrenceOnAdded: this.validateOccurrenceOnAdd
                 });
             }
 

--- a/src/main/resources/assets/admin/common/js/form/FormItemLayerFactory.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayerFactory.ts
@@ -5,7 +5,7 @@ import {Store} from '../store/Store';
 export interface CreatedFormItemLayerConfig {
     context: FormContext;
     lazyRender?: boolean;
-    validateOccurrenceOnAdded?: boolean;
+    validateOccurrenceOnAdd?: boolean;
 }
 
 export interface FormItemLayerFactory {
@@ -35,7 +35,7 @@ export class FormItemLayerFactoryImpl implements FormItemLayerFactory {
             layer.setLazyRender(config.lazyRender);
         }
 
-        layer.setValidateOccurrenceOnAdd(!!config.validateOccurrenceOnAdded);
+        layer.setValidateOccurrenceOnAdd(!!config.validateOccurrenceOnAdd);
 
         return layer;
     }

--- a/src/main/resources/assets/admin/common/js/form/FormItemLayerFactory.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayerFactory.ts
@@ -5,6 +5,7 @@ import {Store} from '../store/Store';
 export interface CreatedFormItemLayerConfig {
     context: FormContext;
     lazyRender?: boolean;
+    validateOccurrenceOnAdded?: boolean;
 }
 
 export interface FormItemLayerFactory {
@@ -33,6 +34,9 @@ export class FormItemLayerFactoryImpl implements FormItemLayerFactory {
         if (config.lazyRender != null) {
             layer.setLazyRender(config.lazyRender);
         }
+
+        layer.setValidateOccurrenceOnAdd(!!config.validateOccurrenceOnAdded);
+
         return layer;
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/FormItemOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemOccurrenceView.ts
@@ -106,4 +106,8 @@ export abstract class FormItemOccurrenceView
     setEnabled(enable: boolean) {
         //
     }
+
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        //
+    }
 }

--- a/src/main/resources/assets/admin/common/js/form/FormItemOccurrences.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemOccurrences.ts
@@ -157,6 +157,12 @@ export class FormItemOccurrences<V extends FormItemOccurrenceView> {
         });
     }
 
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        this.occurrenceViews.forEach((view: V) => {
+            view.setValidateOccurrenceOnAdd(value);
+        });
+    }
+
     createNewOccurrenceView(_occurrence: FormItemOccurrence<V>): V {
         throw new Error('Must be implemented by inheritor');
     }

--- a/src/main/resources/assets/admin/common/js/form/FormItemView.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemView.ts
@@ -134,6 +134,10 @@ export class FormItemView
     //
     }
 
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        //
+    }
+
     doRender(): Q.Promise<boolean> {
         return super.doRender().then((rendered) => {
             this.addClass('form-item-view');

--- a/src/main/resources/assets/admin/common/js/form/FormView.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormView.ts
@@ -325,4 +325,8 @@ export class FormView
     setEnabled(enable: boolean) {
         this.formItemLayer.setEnabled(enable);
     }
+
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        this.formItemLayer.setValidateOccurrenceOnAdd(value);
+    }
 }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/appconfig/ApplicationConfiguratorDialog.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/appconfig/ApplicationConfiguratorDialog.ts
@@ -121,6 +121,7 @@ export class ApplicationConfiguratorDialog
 
             return this.formView.layout().then(() => {
                 this.addClass('animated');
+                this.formView.setValidateOccurrenceOnAdd(true);
 
                 setTimeout(() => {
                     ResponsiveManager.fireResizeEvent();

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
@@ -642,4 +642,8 @@ export abstract class FormSetOccurrenceView
 
         return new MoreButton([addAboveAction, addBelowAction, removeAction]);
     }
+
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        this.formItemLayer.setValidateOccurrenceOnAdd(value);
+    }
 }

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrences.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrences.ts
@@ -28,6 +28,8 @@ export interface FormSetOccurrencesConfig<V extends FormSetOccurrenceView> {
     propertyArray: PropertyArray;
 
     lazyRender?: boolean;
+
+    validateOccurrenceOnAdd?: boolean;
 }
 
 export class FormSetOccurrences<V extends FormSetOccurrenceView>
@@ -38,6 +40,8 @@ export class FormSetOccurrences<V extends FormSetOccurrenceView>
     private readonly formSet: FormSet;
 
     private readonly lazyRender: boolean;
+
+    private validateOccurrenceOnAdd: boolean;
 
     private layerFactory: FormItemLayerFactory;
 
@@ -58,11 +62,13 @@ export class FormSetOccurrences<V extends FormSetOccurrenceView>
         this.formSet = config.formSet;
         this.parent = config.parent;
         this.lazyRender = config.lazyRender;
+        this.validateOccurrenceOnAdd = !!config.validateOccurrenceOnAdd;
     }
 
     protected getNewOccurrenceConfig(occurrence: FormSetOccurrence<V>): FormSetOccurrenceViewConfig<V> {
         const dataSet: PropertySet = this.getOrPopulateSetFromArray(occurrence.getIndex());
-        const layer: FormItemLayer = this.layerFactory.createLayer({context: this.context, lazyRender: this.lazyRender});
+        const layer: FormItemLayer = this.layerFactory.createLayer(
+            {context: this.context, lazyRender: this.lazyRender, validateOccurrenceOnAdded: this.validateOccurrenceOnAdd});
 
         return {
             context: this.context,
@@ -84,7 +90,7 @@ export class FormSetOccurrences<V extends FormSetOccurrenceView>
     }
 
     createNewOccurrenceView(occurrence: FormSetOccurrence<V>): V {
-        const newOccurrenceView = this.createOccurrenceView(this.getNewOccurrenceConfig(occurrence));
+        const newOccurrenceView: V = this.createOccurrenceView(this.getNewOccurrenceConfig(occurrence));
 
         newOccurrenceView.onRemoveButtonClicked((event: RemoveButtonClickedEvent<V>) => this.removeOccurrenceView(event.getView()));
         newOccurrenceView.onExpandRequested(view => this.notifyExpandRequested(view));
@@ -128,6 +134,12 @@ export class FormSetOccurrences<V extends FormSetOccurrenceView>
         return this.getOccurrenceViews().every((formSetOccurrenceView: FormSetOccurrenceView) => {
             return !formSetOccurrenceView.isContainerVisible();
         });
+    }
+
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        super.setValidateOccurrenceOnAdd(value);
+
+        this.validateOccurrenceOnAdd = value;
     }
 
     moveOccurrence(index: number, destinationIndex: number) {

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrences.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrences.ts
@@ -68,7 +68,7 @@ export class FormSetOccurrences<V extends FormSetOccurrenceView>
     protected getNewOccurrenceConfig(occurrence: FormSetOccurrence<V>): FormSetOccurrenceViewConfig<V> {
         const dataSet: PropertySet = this.getOrPopulateSetFromArray(occurrence.getIndex());
         const layer: FormItemLayer = this.layerFactory.createLayer(
-            {context: this.context, lazyRender: this.lazyRender, validateOccurrenceOnAdded: this.validateOccurrenceOnAdd});
+            {context: this.context, lazyRender: this.lazyRender, validateOccurrenceOnAdd: this.validateOccurrenceOnAdd});
 
         return {
             context: this.context,

--- a/src/main/resources/assets/admin/common/js/form/set/fieldset/FieldSetView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/fieldset/FieldSetView.ts
@@ -80,6 +80,10 @@ export class FieldSetView
         this.formItemLayer.setEnabled(enable);
     }
 
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        this.formItemLayer.setValidateOccurrenceOnAdd(value);
+    }
+
     giveFocus(): boolean {
 
         let focusGiven = false;

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -538,4 +538,8 @@ export class FormOptionSetOptionView
         }
         this.formItemLayer.setEnabled(enable);
     }
+
+    setValidateOccurrenceOnAdd(value: boolean): void {
+        this.formItemLayer.setValidateOccurrenceOnAdd(value);
+    }
 }


### PR DESCRIPTION
-regression issue from fix of https://github.com/enonic/lib-admin-ui/issues/1964
-Added validateOccurrenceOnAdd param to let form items with occurrences toggle validation of newly added occurrences on demand