### PR TITLE
Site Configurator dialog -Html area lost the focus after clicking in …

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/src/main/resources/assets/admin/common/js/ui/dialog/ModalDialog.ts
@@ -222,16 +222,29 @@ export abstract class ModalDialog
         const focusOutTimeout: number = 10;
 
         AppHelper.focusInOut(this, (lastFocused: HTMLElement) => {
-            if (this.isOpen() && this.hasTabbable() && !this.hasSubDialog() && !this.isMasked()) {
-                const lastTabbable: Element = this.getLastTabbable();
-
-                if (lastFocused === lastTabbable.getHTMLElement()) { // last element lost focus
-                    this.focusFirstTabbable();
-                } else {
-                    lastTabbable.giveFocus();
-                }
+            if (this.isFocusOutEventToBeProcessed()) {
+                this.bringFocusBackToDialog(lastFocused);
             }
         }, focusOutTimeout, false);
+    }
+
+    private isFocusOutEventToBeProcessed(): boolean {
+        return this.isOpen() && this.hasTabbable() && !this.hasSubDialog() && !this.isMasked() && !this.isIframeHavingFocus();
+    }
+
+    // html editor might have gotten focus
+    private isIframeHavingFocus(): boolean {
+        return document.activeElement?.tagName.toLowerCase() === 'iframe';
+    }
+
+    private bringFocusBackToDialog(lastFocused: HTMLElement): void {
+        const lastTabbable: Element = this.getLastTabbable();
+
+        if (lastFocused === lastTabbable.getHTMLElement()) { // last element lost focus
+            this.focusFirstTabbable();
+        } else {
+            lastTabbable.giveFocus();
+        }
     }
 
     private getLastTabbable(): Element {


### PR DESCRIPTION
…the area, toolbar blinks #2364

-HtmlArea input has an iframe inside of it. When focus within dialog was coming to a htmlarea then dialog didn't know that focus is still within dialog and was trying to focus some tabbable element inside