### PR TITLE
[Regression] Content Wizard form is missing left padding on higher re…

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/app/wizard/wizard-steps-panel.less
+++ b/src/main/resources/assets/admin/common/styles/api/app/wizard/wizard-steps-panel.less
@@ -1,9 +1,19 @@
-.wizard-steps-panel-responsive(0, 15px);
+.form-panel {
+  .wizard-steps-panel-responsive(0, 110px);
 
-._0-240,
-._240-360,
-._360-540 {
-  .wizard-steps-panel-responsive(0, 0);
+  &._720-960 {
+    .wizard-steps-panel-responsive(0, 15px);
+  }
+
+  &._540-720 {
+    .wizard-steps-panel-responsive(15px, 15px);
+  }
+
+  &._0-240,
+  &._240-360,
+  &._360-540 {
+    .wizard-steps-panel-responsive(0, 0);
+  }
 }
 
 .wizard-steps-panel-responsive(@padding-right, @padding-left) {


### PR DESCRIPTION
…solutions #2376

-Bringing back padding used some time ago
-wrapping wizard-steps-panel styles with form-panel to avoid ambiguity since any parent with corresponding size classes could affect wizard-steps-panel padding