### PR TITLE
'Show all help texts' icon doesn't work for sets #2392

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/HelpTextContainer.ts
+++ b/src/main/resources/assets/admin/common/js/form/HelpTextContainer.ts
@@ -5,38 +5,43 @@ import {StringHelper} from '../util/StringHelper';
 
 export class HelpTextContainer {
 
-    private readonly helpTextDiv: DivEl;
+    private helpTextDiv?: DivEl;
 
-    private readonly helpTextToggler: DivEl;
+    private helpTextToggler: DivEl;
 
     private toggleListeners: { (show: boolean): void }[] = [];
 
     constructor(value: string) {
+        this.initHelpTextToggler();
+        this.initHelpTextDiv(value);
+    }
+
+    private initHelpTextToggler(): void {
         this.helpTextToggler = new DivEl('help-text-toggler');
         this.helpTextToggler.setHtml('?').setTitle(i18n('tooltip.helptext.show'));
 
-        if (!StringHelper.isBlank(value)) {
-            this.helpTextDiv = new DivEl('help-text');
-
-            let pEl = new PEl();
-            pEl.getEl().setText(value);
-
-            this.helpTextDiv.appendChild(pEl);
-        }
-
-        let isActive = false;
         this.helpTextToggler.onClicked((event: MouseEvent) => {
-            isActive = !isActive;
-            this.toggleHelpText(isActive);
-            this.notifyHelpTextToggled(isActive);
+            const isOn: boolean = this.helpTextToggler.hasClass('on');
+
+            this.toggleHelpText(!isOn);
+            this.notifyHelpTextToggled(!isOn);
             event.stopPropagation();
         });
     }
 
-    toggleHelpText(show?: boolean) {
-        if (this.helpTextDiv) {
-            this.helpTextDiv.toggleClass('visible', show);
+    private initHelpTextDiv(value: string): void {
+        if (!StringHelper.isBlank(value)) {
+            this.helpTextDiv = new DivEl('help-text');
+
+            const pEl: PEl = new PEl();
+            pEl.getEl().setText(value);
+
+            this.helpTextDiv.appendChild(pEl);
         }
+    }
+
+    toggleHelpText(show?: boolean): void {
+        this.helpTextDiv?.toggleClass('visible', show);
         this.helpTextToggler.toggleClass('on', show);
         this.helpTextToggler.setTitle(show ? i18n('tooltip.helptext.hide') : i18n('tooltip.helptext.show'));
     }
@@ -49,17 +54,17 @@ export class HelpTextContainer {
         return this.helpTextDiv;
     }
 
-    onHelpTextToggled(listener: (show: boolean) => void) {
+    onHelpTextToggled(listener: (show: boolean) => void): void {
         this.toggleListeners.push(listener);
     }
 
-    unHelpTextToggled(listener: (show: boolean) => void) {
+    unHelpTextToggled(listener: (show: boolean) => void): void {
         this.toggleListeners = this.toggleListeners.filter((curr) => {
             return curr !== listener;
         });
     }
 
-    private notifyHelpTextToggled(show: boolean) {
+    private notifyHelpTextToggled(show: boolean): void {
         this.toggleListeners.forEach(listener => listener(show));
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetHeader.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetHeader.ts
@@ -36,9 +36,11 @@ export class FormSetHeader
         });
     }
 
-    public onHelpTextToggled(listener: (show: boolean) => void) {
-        if (this.helpTextContainer) {
-            this.helpTextContainer.onHelpTextToggled(listener);
-        }
+    public onHelpTextToggled(listener: (show: boolean) => void): void {
+        this.helpTextContainer?.onHelpTextToggled(listener);
+    }
+
+    toggleHelpText(show?: boolean): void {
+        this.helpTextContainer?.toggleHelpText(show);
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetView.ts
@@ -150,7 +150,7 @@ export abstract class FormSetView<V extends FormSetOccurrenceView>
         this.initOccurrences().layout(validate).then(() => {
             // formItemOccurrences should be ready to check for nested help text by hasHelpText
             this.header = new FormSetHeader(this.formSet, this.hasHelpText());
-            this.header.onHelpTextToggled((show) => this.toggleHelpText(show));
+            this.header.onHelpTextToggled((show: boolean) => this.toggleHelpText(show));
             this.prependChild(this.header);
 
             this.subscribeFormSetOccurrencesOnEvents();
@@ -298,6 +298,7 @@ export abstract class FormSetView<V extends FormSetOccurrenceView>
 
     toggleHelpText(show?: boolean) {
         this.formItemOccurrences.toggleHelpText(show);
+        this.header.toggleHelpText(show);
     }
 
     hasHelpText(): boolean {

--- a/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -77,9 +77,7 @@ export class FormOptionSetOptionView
 
     toggleHelpText(show?: boolean) {
         this.formItemLayer.toggleHelpText(show);
-        if (this.helpText) {
-            this.helpText.toggleHelpText(show);
-        }
+        this.helpText?.toggleHelpText(show);
     }
 
     refresh() {


### PR DESCRIPTION
-Showing FieldSetView's own help text also