### PR TITLE
Fix lazy loading in BaseRichCombobox

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
@@ -11,6 +11,7 @@ import {GridOnClickData} from './GridOnClickData';
 import {DataView} from './DataView';
 import {EventBus} from '../../event/EventBus';
 import {GridSelectionHelper} from './GridSelectionHelper';
+import {ElementHelper} from '../../dom/ElementHelper';
 
 export class Grid<T extends Slick.SlickData>
     extends DivEl {
@@ -493,6 +494,11 @@ export class Grid<T extends Slick.SlickData>
 
     subscribeOnMouseLeave(callback: (e: any, args: any) => void) {
         this.slickGrid.onMouseLeave.subscribe(callback);
+    }
+
+    getViewportEl(): HTMLElement {
+        const canvas = this.getCanvasNode();
+        return new ElementHelper(canvas.parentElement).getHTMLElement();
     }
 
     protected createOptions(): GridOptions<any> {

--- a/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/grid/Grid.ts
@@ -497,7 +497,7 @@ export class Grid<T extends Slick.SlickData>
     }
 
     getViewportEl(): HTMLElement {
-        const canvas = this.getCanvasNode();
+        const canvas: HTMLCanvasElement = this.getCanvasNode();
         return new ElementHelper(canvas.parentElement).getHTMLElement();
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/BaseRichComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/BaseRichComboBox.ts
@@ -13,7 +13,6 @@ import {CompositeFormInputEl} from '../../../dom/CompositeFormInputEl';
 import {BaseLoader} from '../../../util/loader/BaseLoader';
 import {DivEl} from '../../../dom/DivEl';
 import {ObjectHelper} from '../../../ObjectHelper';
-import {ElementHelper} from '../../../dom/ElementHelper';
 import {DefaultErrorHandler} from '../../../DefaultErrorHandler';
 import {LoadingDataEvent} from '../../../util/loader/event/LoadingDataEvent';
 import {LoadedDataEvent} from '../../../util/loader/event/LoadedDataEvent';
@@ -35,7 +34,6 @@ export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
     private identifierMethod: string;
     private loadingListeners: { (): void; }[];
     private loadedListeners: { (items: OPTION_DATA_TYPE[], postLoaded?: boolean): void; }[];
-    private interval: number;
 
     constructor(builder: BaseRichComboBoxBuilder<OPTION_DATA_TYPE, LOADER_DATA_TYPE>) {
         super();
@@ -336,18 +334,18 @@ export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
         return this.reload(this.comboBox.getInput().getValue());
     }
 
-    protected reload(inputValue: string): Q.Promise<any> {
+    protected reload(inputValue: string, force: boolean = false): Q.Promise<any> {
         let loadPromise;
-        if (!this.loader.isLoaded()) {
+        if (force || !this.loader.isLoaded()) {
             this.loader.setSearchString(inputValue);
             loadPromise = this.loader.load();
         } else {
             loadPromise = Q(null);
         }
 
-        return loadPromise.then(() => {
-            return this.loader.search(inputValue);
-        }).catch(DefaultErrorHandler.handle);
+        return loadPromise
+            .then(() => this.loader.search(inputValue))
+            .catch(DefaultErrorHandler.handle);
     }
 
     protected notifyLoaded(items: OPTION_DATA_TYPE[], postLoaded?: boolean) {
@@ -366,32 +364,17 @@ export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
         return comboBox;
     }
 
-    private handleLastRange(handler: () => void) {
-        let grid = this.getComboBox().getComboBoxDropdownGrid().getGrid();
+    private loadNextRangeIfNeeded(containerEl: HTMLElement, handler: () => void): void {
+        if (Math.ceil(containerEl.scrollHeight - containerEl.scrollTop) <= 2 * containerEl.clientHeight) {
+            handler();
+        }
+    }
 
-        grid.onShown(() => {
-            if (this.interval) {
-                clearInterval(this.interval);
-            }
-            this.interval = setInterval(() => {
-                grid = this.getComboBox().getComboBoxDropdownGrid().getGrid();
-                let canvas = grid.getCanvasNode();
-                let canvasEl = new ElementHelper(canvas);
-                let viewportEl = new ElementHelper(canvas.parentElement);
+    private handleRangeLoad(handler: () => void) {
+        const viewportEl = this.comboBox.getComboBoxDropdownGrid().getGrid().getViewportEl();
 
-                let isLastRange = viewportEl.getScrollTop() >= canvasEl.getHeight() - 3 * viewportEl.getHeight();
-
-                if (isLastRange) {
-                    handler();
-                }
-            }, 200);
-        });
-
-        grid.onHidden(() => {
-            if (this.interval) {
-                clearInterval(this.interval);
-            }
-        });
+        viewportEl.addEventListener('scroll', () => this.loadNextRangeIfNeeded(viewportEl, handler));
+        this.onLoaded(() => this.loadNextRangeIfNeeded(viewportEl, handler));
     }
 
     private setupLoader(loader: BaseLoader<LOADER_DATA_TYPE>) {
@@ -417,7 +400,13 @@ export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
         });
 
         if (ObjectHelper.iFrameSafeInstanceOf(this.loader, PostLoader)) {
-            this.handleLastRange((<PostLoader<LOADER_DATA_TYPE>>this.loader).postLoad.bind(this.loader));
+            const grid = this.comboBox.getComboBoxDropdownGrid().getGrid();
+            const loader: PostLoader<LOADER_DATA_TYPE> = <PostLoader<LOADER_DATA_TYPE>>this.loader;
+            const onShownHandler = () => {
+                this.handleRangeLoad(() => loader.postLoad());
+                grid.unShown(onShownHandler);
+            };
+            grid.onShown(onShownHandler);
         }
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/BaseRichComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/BaseRichComboBox.ts
@@ -22,6 +22,7 @@ import {SelectedOptionEvent} from './SelectedOptionEvent';
 import {OptionDataHelper} from '../OptionDataHelper';
 import {BaseLoaderComboBox} from './BaseLoaderComboBox';
 import {OptionDataLoader} from '../OptionDataLoader';
+import {Grid} from '../../grid/Grid';
 
 export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
     extends CompositeFormInputEl {
@@ -365,13 +366,17 @@ export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
     }
 
     private loadNextRangeIfNeeded(containerEl: HTMLElement, handler: () => void): void {
-        if (Math.ceil(containerEl.scrollHeight - containerEl.scrollTop) <= 2 * containerEl.clientHeight) {
+        if (this.isScrolledToBottom(containerEl)) {
             handler();
         }
     }
 
+    private isScrolledToBottom(containerEl: HTMLElement): boolean {
+        return Math.ceil(containerEl.scrollHeight - containerEl.scrollTop) <= 2 * containerEl.clientHeight;
+    }
+
     private handleRangeLoad(handler: () => void) {
-        const viewportEl = this.comboBox.getComboBoxDropdownGrid().getGrid().getViewportEl();
+        const viewportEl: HTMLElement = this.comboBox.getComboBoxDropdownGrid().getGrid().getViewportEl();
 
         viewportEl.addEventListener('scroll', () => this.loadNextRangeIfNeeded(viewportEl, handler));
         this.onLoaded(() => this.loadNextRangeIfNeeded(viewportEl, handler));
@@ -400,12 +405,14 @@ export class BaseRichComboBox<OPTION_DATA_TYPE, LOADER_DATA_TYPE>
         });
 
         if (ObjectHelper.iFrameSafeInstanceOf(this.loader, PostLoader)) {
-            const grid = this.comboBox.getComboBoxDropdownGrid().getGrid();
+            const grid: Grid<any> = this.comboBox.getComboBoxDropdownGrid().getGrid();
             const loader: PostLoader<LOADER_DATA_TYPE> = <PostLoader<LOADER_DATA_TYPE>>this.loader;
+
             const onShownHandler = () => {
                 this.handleRangeLoad(() => loader.postLoad());
                 grid.unShown(onShownHandler);
             };
+
             grid.onShown(onShownHandler);
         }
     }

--- a/src/main/resources/assets/admin/common/js/util/loader/BaseLoader.ts
+++ b/src/main/resources/assets/admin/common/js/util/loader/BaseLoader.ts
@@ -86,9 +86,12 @@ export class BaseLoader<OBJECT> {
         this.searchString = searchString;
 
         if (this.results) {
-            let filtered = this.results.filter(this.filterFn, this);
-            this.notifyLoadedData(filtered);
-            return Q(this.results);
+            const totalCount = this.results.length;
+            const filtered = this.results.filter(this.filterFn, this);
+            if (filtered.length < totalCount) {
+                this.notifyLoadedData(filtered);
+            }
+            return Q(filtered);
         }
         return Q([]);
     }

--- a/src/main/resources/assets/admin/common/js/util/loader/BaseLoader.ts
+++ b/src/main/resources/assets/admin/common/js/util/loader/BaseLoader.ts
@@ -82,18 +82,15 @@ export class BaseLoader<OBJECT> {
     }
 
     search(searchString: string): Q.Promise<OBJECT[]> {
-
         this.searchString = searchString;
 
-        if (this.results) {
-            const totalCount = this.results.length;
-            const filtered = this.results.filter(this.filterFn, this);
-            if (filtered.length < totalCount) {
-                this.notifyLoadedData(filtered);
-            }
-            return Q(filtered);
+        const searchResult: OBJECT[] = this.results ? this.results.filter(this.filterFn, this) : [];
+
+        if (searchResult.length < this.results?.length) {
+            this.notifyLoadedData(searchResult);
         }
-        return Q([]);
+
+        return Q(searchResult);
     }
 
     getResults(): OBJECT[] {


### PR DESCRIPTION
* Calculate scrolled distance inside dropdown on `loaded` and `scroll` events instead of using `setInterval`
* Don't trigger `loaded` event in `BaseLoader` if data hasn't changed
* Support forced reload in `BaseRichComboBox`