### PR TITLE
Expanded node gets highlighted in Content Selector #1998

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/OptionsTreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/OptionsTreeGrid.ts
@@ -62,13 +62,13 @@ export class OptionsTreeGrid<OPTION_DISPLAY_VALUE>
         this.setActive(true);
     }
 
-    protected expandOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<Option<OPTION_DISPLAY_VALUE>>) {
+    protected expandOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<Option<OPTION_DISPLAY_VALUE>>): void {
         super.expandOnClick(elem, data);
 
         this.getGrid().resetActiveCell();
     }
 
-    protected collapseOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<Option<OPTION_DISPLAY_VALUE>>) {
+    protected collapseOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<Option<OPTION_DISPLAY_VALUE>>): void {
         super.collapseOnClick(elem, data);
 
         this.getGrid().resetActiveCell();

--- a/src/main/resources/assets/admin/common/js/ui/selector/OptionsTreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/OptionsTreeGrid.ts
@@ -12,6 +12,7 @@ import {OptionDataLoader, OptionDataLoaderData} from './OptionDataLoader';
 import {OptionDataHelper} from './OptionDataHelper';
 import {OptionsFactory} from './OptionsFactory';
 import {Option} from './Option';
+import {ElementHelper} from '../../dom/ElementHelper';
 
 export class OptionsTreeGrid<OPTION_DISPLAY_VALUE>
     extends TreeGrid<Option<OPTION_DISPLAY_VALUE>> {
@@ -59,6 +60,18 @@ export class OptionsTreeGrid<OPTION_DISPLAY_VALUE>
         this.optionsFactory = new OptionsFactory(this.loader, this.treeDataHelper);
 
         this.setActive(true);
+    }
+
+    protected expandOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<Option<OPTION_DISPLAY_VALUE>>) {
+        super.expandOnClick(elem, data);
+
+        this.getGrid().resetActiveCell();
+    }
+
+    protected collapseOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<Option<OPTION_DISPLAY_VALUE>>) {
+        super.collapseOnClick(elem, data);
+
+        this.getGrid().resetActiveCell();
     }
 
     removeAllOptions() {

--- a/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/src/main/resources/assets/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1231,8 +1231,8 @@ export class TreeGrid<DATA extends IDentifiable>
         KeyBindings.get().unshelveBindings(this.keyBindings);
     }
 
-    private bindClickEvents(toggleClickEnabled: boolean) {
-        let clickHandler = ((event, data) => {
+    private bindClickEvents(toggleClickEnabled: boolean): void {
+        const clickHandler = ((event, data) => {
             if (!this.isActive()) {
                 return;
             }
@@ -1257,12 +1257,12 @@ export class TreeGrid<DATA extends IDentifiable>
 
             if (toggleClickEnabled) {
                 if (elem.hasClass('expand')) {
-                    this.onExpand(elem, data);
+                    this.expandOnClick(elem, data);
                     return;
                 }
 
                 if (elem.hasClass('collapse')) {
-                    this.onCollapse(elem, data);
+                    this.collapseOnClick(elem, data);
                     return;
                 }
             }
@@ -1333,8 +1333,8 @@ export class TreeGrid<DATA extends IDentifiable>
         this.toggleRow(data.row);
     }
 
-    private onExpand(elem: ElementHelper, data: Slick.OnClickEventArgs<DATA>) {
-        const node = this.gridData.getItem(data.row);
+    protected expandOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<DATA>): void {
+        const node: TreeNode<DATA> = this.gridData.getItem(data.row);
         elem.removeClass('expand').addClass('collapse');
         this.expandNode(node).then(() => {
             this.highlightCurrentNode();
@@ -1358,8 +1358,8 @@ export class TreeGrid<DATA extends IDentifiable>
 
     }
 
-    private onCollapse(elem: ElementHelper, data: Slick.OnClickEventArgs<DATA>) {
-        const node = this.gridData.getItem(data.row);
+    protected collapseOnClick(elem: ElementHelper, data: Slick.OnClickEventArgs<DATA>): void {
+        const node: TreeNode<DATA> = this.gridData.getItem(data.row);
         elem.removeClass('collapse').addClass('expand');
         this.collapseNode(node);
     }


### PR DESCRIPTION
-resetting active grid cell after click on expand/collapse