### PR TITLE
Added keyboard accessibility to AppIcon

### DIFF
--- a/src/main/resources/assets/admin/common/js/app/bar/AppBar.ts
+++ b/src/main/resources/assets/admin/common/js/app/bar/AppBar.ts
@@ -45,7 +45,11 @@ export class AppBar
         return [this.showAppLauncherAction];
     }
 
-    setHomeIconAction() {
+    setHomeIconAction(): void {
         this.appIcon.setAction(AppBarActions.SHOW_BROWSE_PANEL);
+    }
+
+    unsetHomeIconAction(): void {
+        this.appIcon.removeAction();
     }
 }

--- a/src/main/resources/assets/admin/common/js/app/bar/AppIcon.ts
+++ b/src/main/resources/assets/admin/common/js/app/bar/AppIcon.ts
@@ -13,11 +13,14 @@ export class AppIcon
 
     private nameEl: SpanEl;
 
+    private clickListener: () => void;
+
+    private enterListener: (e: KeyboardEvent) => void;
+
     constructor(app: Application, action?: Action) {
         super('home-button');
 
         this.initElements(app);
-        this.getEl().setTabIndex(0);
 
         if (action) {
             this.setAction(action);
@@ -39,13 +42,29 @@ export class AppIcon
     }
 
     setAction(action: Action): void {
+        if(!this.clickListener || !this.enterListener){
+            this.initListeners(action);
+        }
         this.addClass('clickable');
-        this.onClicked(() => action.execute());
-        this.onKeyDown((e: KeyboardEvent) => KeyHelper.isEnterKey(e) && action.execute());
+        this.getEl().setTabIndex(0);
+        this.onClicked(this.clickListener);
+        this.onKeyDown(this.enterListener);
+    }
+
+    removeAction(): void {
+        this.removeClass('clickable');
+        this.getEl().removeAttribute('tabindex');
+        this.unClicked(this.clickListener);
+        this.onKeyDown(this.enterListener);
     }
 
     setAppName(name: string) {
         this.nameEl.setHtml(name);
+    }
+
+    private initListeners(action): void {
+        this.clickListener = () => { action.execute(); };
+        this.enterListener = (e: KeyboardEvent) => { KeyHelper.isEnterKey(e) && action.execute(); };
     }
 
     protected initElements(app: Application): void {

--- a/src/main/resources/assets/admin/common/js/app/bar/AppIcon.ts
+++ b/src/main/resources/assets/admin/common/js/app/bar/AppIcon.ts
@@ -4,6 +4,7 @@ import {Action} from '../../ui/Action';
 import {ImgEl} from '../../dom/ImgEl';
 import {SpanEl} from '../../dom/SpanEl';
 import {Application} from '../Application';
+import {KeyHelper} from '../../ui/KeyHelper';
 
 export class AppIcon
     extends DivEl {
@@ -16,6 +17,7 @@ export class AppIcon
         super('home-button');
 
         this.initElements(app);
+        this.getEl().setTabIndex(0);
 
         if (action) {
             this.setAction(action);
@@ -39,6 +41,7 @@ export class AppIcon
     setAction(action: Action): void {
         this.addClass('clickable');
         this.onClicked(() => action.execute());
+        this.onKeyDown((e: KeyboardEvent) => KeyHelper.isEnterKey(e) && action.execute());
     }
 
     setAppName(name: string) {

--- a/src/main/resources/assets/admin/common/js/app/bar/TabbedAppBar.ts
+++ b/src/main/resources/assets/admin/common/js/app/bar/TabbedAppBar.ts
@@ -10,7 +10,7 @@ export class TabbedAppBar
 
     private tabMenu: AppBarTabMenu;
 
-    constructor(application: Application) {
+    constructor(application: Application, managedHomeIconAction: boolean = false) {
         super(application);
 
         this.tabMenu = new AppBarTabMenu();
@@ -23,8 +23,10 @@ export class TabbedAppBar
         // Responsive events to update homeButton styles
         ResponsiveManager.onAvailableSizeChanged(this, () => {
             if (this.tabMenu.countVisible() > 0) {
+                managedHomeIconAction && super.setHomeIconAction();
                 this.addClass('tabs-present');
             } else {
+                managedHomeIconAction && super.unsetHomeIconAction();
                 this.removeClass('tabs-present');
             }
         });


### PR DESCRIPTION
@ashklianko 

Does it makes sense to let the app icon be reachable by keyboard if it does contain any action? 

This PR allows that. It was the behavior requested by Thomas Heartman in this [issue](https://github.com/enonic/app-users/issues/647)

If we don't want to allow that, i.e, only make app icon reachable by keyboard if there is an action attached to it, then we'll need to move line 20 to inside the conditional on line 22.