### PR TITLE
Help Text right padding if show counter is true (#2594)

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/input-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/input-common.less
@@ -177,6 +177,12 @@
         }
       }
 
+      &.show-counter {
+        + .help-text {
+          padding-right: 100px;
+        }
+      }
+
       &.max-length-limited.show-counter {
         .separator {
           display: inline;


### PR DESCRIPTION
@alansemenov 

is it ok to use setTimeout as I did in this case? Doesn't seems right, but does the trick. 

The thing is that I need to execute `adjustHelpTextPadding` only after not only the parents are rendered, but also the child ones. What's the best way to do that?

Also, 100px of right padding is enough space for a counter of `<= 9999` characters, because 5 digits would overlap again. Should we take care of 5 digits?