### PR TITLE
Can't reset search string in BaseLoader

### DIFF
--- a/src/main/resources/assets/admin/common/js/security/PrincipalLoader.ts
+++ b/src/main/resources/assets/admin/common/js/security/PrincipalLoader.ts
@@ -6,7 +6,6 @@ import {IdProviderKey} from './IdProviderKey';
 import {Principal} from './Principal';
 import {PrincipalKey} from './PrincipalKey';
 import {GetPrincipalsByKeysRequest} from './GetPrincipalsByKeysRequest';
-import {BaseLoader} from '../util/loader/BaseLoader';
 
 export class PrincipalLoader
     extends PostLoader<Principal> {


### PR DESCRIPTION
Compare search results with previously filtered dataset instead of the full one