### PR TITLE
Optimise performance of item-/option-set rendering

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayer.ts
@@ -38,7 +38,7 @@ export class FormItemLayer {
 
     private lazyRender: boolean = true;
 
-    private formItemLayerFactory: FormItemLayerFactory;
+    private readonly formItemLayerFactory: FormItemLayerFactory;
 
     constructor(context: FormContext, layerFactory: FormItemLayerFactory) {
         this.context = context;
@@ -50,8 +50,13 @@ export class FormItemLayer {
         return this;
     }
 
+    hasParentElement(): boolean {
+        return !!this.parentEl;
+    }
+
     setParentElement(parentEl: Element): FormItemLayer {
         this.parentEl = parentEl;
+        this.appendFormItemViews();
         return this;
     }
 
@@ -60,11 +65,18 @@ export class FormItemLayer {
         return this;
     }
 
+    private appendFormItemViews(): void {
+        if (!this.parentEl) {
+            return;
+        }
+        this.parentEl.appendChildren(...this.formItemViews);
+    }
+
     layout(propertySet: PropertySet, validate: boolean = true): Q.Promise<FormItemView[]> {
         this.formItemViews = [];
 
         return this.doLayoutPropertySet(propertySet, validate).then(() => {
-            this.formItemViews.map(formItemView => this.parentEl.appendChild(formItemView));
+            this.appendFormItemViews();
 
             return Q<FormItemView[]>(this.formItemViews);
         });

--- a/src/main/resources/assets/admin/common/js/form/FormOccurrenceDraggableLabel.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormOccurrenceDraggableLabel.ts
@@ -14,21 +14,18 @@ export class FormOccurrenceDraggableLabel
     constructor(label?: string, subTitle?: string) {
         super('form-occurrence-draggable-label');
 
-        let nodes: Node[] = [];
+        const dragHandle = new DivEl('drag-control');
 
-        let dragHandle = new DivEl('drag-control');
-        nodes.push(dragHandle.getHTMLElement());
+        this.title = document.createTextNode(label || '');
 
-        this.title = document.createTextNode(label);
-        nodes.push(this.title);
-
-        this.subTitleText = subTitle;
         this.subTitle = new PEl('note');
-        this.subTitle.setHtml(subTitle);
-        nodes.push(this.subTitle.getHTMLElement());
-        this.refreshCustomClass();
+        if (subTitle) {
+            this.subTitleText = subTitle;
+            this.subTitle.setHtml(subTitle);
+            this.refreshCustomClass();
+        }
 
-        this.getEl().appendChildren(nodes);
+        this.getEl().appendChildren([dragHandle.getHTMLElement(), this.title, this.subTitle.getHTMLElement()]);
     }
 
     setText(label: string) {

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
@@ -99,8 +99,6 @@ export abstract class FormSetOccurrenceView
         this.postInitElements();
         this.initListeners();
         this.layoutElements();
-
-        this.appendChild(this.formSetOccurrencesContainer);
     }
 
     protected abstract getLabelText(): string;
@@ -118,7 +116,6 @@ export abstract class FormSetOccurrenceView
     public layout(validate: boolean = true): Q.Promise<void> {
         return this.formItemLayer
             .setFormItems(this.getFormItems())
-            .setParentElement(this.formSetOccurrencesContainer)
             .setParent(this)
             .layout(this.propertySet, validate)
             .then((formItemViews: FormItemView[]) => {
@@ -137,10 +134,6 @@ export abstract class FormSetOccurrenceView
 
         this.bindPropertySet(this.propertySet);
 
-        if (!this.isExpandable()) {
-            this.setContainerVisible(false);
-        }
-
         this.label.setText(this.getLabelText());
         this.label.setSubTitle(this.getLabelSubTitle());
 
@@ -152,6 +145,7 @@ export abstract class FormSetOccurrenceView
         this.moreButton = this.createMoreButton();
         this.label = new FormOccurrenceDraggableLabel();
         this.formSetOccurrencesContainer = new DivEl(this.occurrenceContainerClassName);
+        this.formSetOccurrencesContainer.setVisible(false);
         this.confirmDeleteAction = new Action(i18n('action.delete')).setClass('red large delete-button');
         this.noAction = new Action(i18n('action.cancel')).setClass('black large');
         this.deleteConfirmationMask = ConfirmationMask.create()
@@ -230,8 +224,12 @@ export abstract class FormSetOccurrenceView
         });
     }
 
+    private initOccurrencesContainer(): void {
+        this.formItemLayer.setParentElement(this.formSetOccurrencesContainer);
+    }
+
     protected layoutElements() {
-        this.appendChildren<Element>(this.label, this.moreButton);
+        this.appendChildren<Element>(this.label, this.moreButton, this.formSetOccurrencesContainer);
     }
 
     hasNonDefaultValues(): boolean {
@@ -301,6 +299,9 @@ export abstract class FormSetOccurrenceView
     setContainerVisible(visible: boolean) {
         if (!this.isExpandable()) {
             return;
+        }
+        if (visible && !this.formItemLayer.hasParentElement()) {
+            this.initOccurrencesContainer();
         }
         this.formSetOccurrencesContainer.setVisible(visible);
         this.toggleClass('collapsed', !visible);

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetView.ts
@@ -171,8 +171,8 @@ export abstract class FormSetView<V extends FormSetOccurrenceView>
                 this.validate(true);
             }
 
-            if (this.shouldCollapseOccurrences()) {
-                this.toggleOccurrencesVisibility(false, true);
+            if (this.shouldExpandOccurrences()) {
+                this.toggleOccurrencesVisibility(true);
             }
 
             deferred.resolve(null);
@@ -181,15 +181,16 @@ export abstract class FormSetView<V extends FormSetOccurrenceView>
         return deferred.promise;
     }
 
-    private shouldCollapseOccurrences(): boolean {
+    private shouldExpandOccurrences(): boolean {
         if (this.getContext().getFormState().isNew()) {
-            return false;
-        }
-        if (this.formItemOccurrences.getOccurrences().length === 1) {
-            return false;
+            return true;
         }
 
-        return true;
+        if (this.formItemOccurrences.getOccurrences().length === 1) {
+            return true;
+        }
+
+        return false;
     }
 
     validate(silent: boolean = true, viewToSkipValidation: FormItemOccurrenceView = null): ValidationRecording {

--- a/src/main/resources/assets/admin/common/styles/api/form-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/form-common.less
@@ -35,6 +35,8 @@
     .form-option-set-view .input-view {
       &.invalid {
         .input-view-error(10px);
+        margin-top: 10px;
+        margin-bottom: 10px;
 
         .help-text p {
           color: @admin-black;

--- a/src/main/resources/assets/admin/common/styles/api/form/set/form-set-view.less
+++ b/src/main/resources/assets/admin/common/styles/api/form/set/form-set-view.less
@@ -8,6 +8,7 @@
         &:not(.hide-validation-errors).invalid {
           border: 3px solid @admin-red;
           box-shadow: none;
+          padding: 7px 7px 7px 10px;
         }
       }
     }
@@ -67,16 +68,20 @@
         }
       }
 
+      > .form-item-set-occurrence-view {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
       > .form-item-set-occurrence-view,
       > .form-option-set-occurrence-view {
-        clear: left;
         margin: 0;
         box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.2);
+        padding: 10px 10px 10px 13px;
 
         .more-button {
-          width: 40px;
-          height: 40px;
-          float: right;
+          width: 26px;
+          height: 26px;
 
           &[disabled] {
             display: none;
@@ -88,15 +93,12 @@
         }
 
         .form-occurrence-draggable-label {
-          display: inline-block;
+          padding-top: 2px;
+          line-height: 24px;
+          flex-grow: 1;
           font-size: 16px;
           width: calc(100% - 55px);
-          padding: 10px 0 0 13px;
           .ellipsis();
-
-          &:not(.custom-label) {
-            margin-bottom: 5px;
-          }
 
           &.expandable {
             cursor: zoom-out;
@@ -104,7 +106,7 @@
 
           .drag-control {
             display: none;
-            height: 20px;
+            height: 18px;
             width: 10px;
             background-position-x: center;
             padding-right: 0;
@@ -117,7 +119,7 @@
           }
 
           &.custom-label {
-            line-height: 16px;
+            line-height: 12px;
 
             .drag-control {
               height: 27px;
@@ -126,15 +128,15 @@
             p.note {
               display: block;
               font-size: 10px;
+              line-height: 10px;
+              margin-top: 6px;
             }
           }
         }
 
         > .form-item-set-occurrences-container,
         > .form-option-set-occurrences-container {
-          &:not(.empty) {
-            padding: 0 13px 13px 13px;
-          }
+          flex-basis: 100%;
 
           > .input-view:last-child {
             margin-bottom: 0;
@@ -223,8 +225,9 @@
 
           .form-occurrence-draggable-label {
             &:not(.custom-label) {
-              line-height: 22px;
+              line-height: 16px;
               height: 20px;
+              margin-top: 4px;
             }
 
             > .drag-control {

--- a/src/main/resources/assets/admin/common/styles/api/form/set/optionset/form-option-set-view.less
+++ b/src/main/resources/assets/admin/common/styles/api/form/set/optionset/form-option-set-view.less
@@ -44,14 +44,12 @@
   }
 
   .occurrence-views-container > .form-option-set-occurrence-view {
-    &:not(.collapsed) {
-      padding-bottom: 0;
-    }
 
     .form-occurrence-draggable-label {
       flex: 1;
       font-size: 14px;
       color: @admin-font-gray2;
+      padding-top: 0;
     }
 
     > .single-selection-header {
@@ -63,7 +61,6 @@
       }
 
       > .form-occurrence-draggable-label {
-        margin-bottom: 5px;
         display: none;
       }
 


### PR DESCRIPTION
* Inverted rendering logic of an item/option-set occurrence: it will be created as collapsed by default and won't be added to DOM until expanded.
* Fixed a new item-set occurrence briefly showing "_undefined_" in its title
* Styling fixes