### PR TITLE
Custom validation is not working for Selector inputs #2701

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormContext.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormContext.ts
@@ -56,6 +56,10 @@ export class FormContext {
         return this.language;
     }
 
+    hasValidationErrors(): boolean {
+        return this.validationErrors?.length > 0;
+    }
+
     setValidationErrors(validationErrors: ValidationError[]): void {
         this.validationErrors = validationErrors;
     }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/InputValidationRecording.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/InputValidationRecording.ts
@@ -46,7 +46,7 @@ export class InputValidationRecording
     }
 
     equals(that: InputValidationRecording): boolean {
-        return this.isValid() === that.isValid();
+        return this.isValid() === that.isValid() && this.errorMessage == that.errorMessage;
     }
 
     validityChanged(other: InputValidationRecording) {

--- a/src/main/resources/assets/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -18,6 +18,7 @@ import {Class} from '../../../Class';
 import {ComboBoxOption} from './ComboBoxOption';
 import {ComboBoxDisplayValueViewer} from './ComboBoxDisplayValueViewer';
 import {ValueTypeConverter} from '../../../data/ValueTypeConverter';
+import {InputValidationRecording} from '../InputValidationRecording';
 
 export class ComboBox
     extends BaseInputTypeManagingAdd {
@@ -29,8 +30,7 @@ export class ComboBox
     private selectedOptionsView: SelectedOptionsView<string>;
 
     constructor(context: InputTypeViewContext) {
-        super('');
-        this.readConfig(context.inputConfig);
+        super(context, 'combobox-input-type-view');
     }
 
     getComboBox(): ComboBoxEl<string> {
@@ -117,7 +117,7 @@ export class ComboBox
             }
 
             this.ignorePropertyChange(false);
-            this.validate(false);
+            this.handleValueChanged(false);
 
             this.fireFocusSwitchEvent(event);
         });
@@ -127,7 +127,7 @@ export class ComboBox
             this.getPropertyArray().remove(event.getSelectedOption().getIndex());
 
             this.ignorePropertyChange(false);
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         return comboBox;
@@ -164,16 +164,17 @@ export class ComboBox
         return this.getPropertyArray().getSize();
     }
 
-    private readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
-        let options: ComboBoxOption[] = [];
+    protected readInputConfig(): void {
+        const options: ComboBoxOption[] = [];
+        const optionValues: { [name: string]: string }[] = this.context.inputConfig['option'] || [];
+        const l: number = optionValues.length;
+        let optionValue: { [name: string]: string };
 
-        let optionValues = inputConfig['option'] || [];
-        let l = optionValues.length;
-        let optionValue;
         for (let i = 0; i < l; i++) {
             optionValue = optionValues[i];
             options.push({label: optionValue['value'], value: optionValue['@value']});
         }
+
         this.comboBoxOptions = options;
     }
 

--- a/src/main/resources/assets/admin/common/js/form/inputtype/principal/PrincipalSelector.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/principal/PrincipalSelector.ts
@@ -26,10 +26,8 @@ export class PrincipalSelector
 
     private comboBox: PrincipalComboBox;
 
-    constructor(config?: InputTypeViewContext) {
-        super('principal-selector');
-        this.addClass('input-type-view');
-        this.readConfig(config.inputConfig);
+    constructor(context: InputTypeViewContext) {
+        super(context, 'principal-selector');
     }
 
     static getName(): InputTypeName {
@@ -107,8 +105,9 @@ export class PrincipalSelector
         return this.getPropertyArray().getSize();
     }
 
-    private readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
-        const principalTypeConfig = inputConfig['principalType'] || [];
+    protected readInputConfig(): void {
+        const principalTypeConfig: { [name: string]: string }[] = this.context.inputConfig['principalType'] || [];
+
         this.principalTypes = [].concat(principalTypeConfig)
             .map((cfg: any) => {
                 let val: string;
@@ -121,7 +120,8 @@ export class PrincipalSelector
             })
             .filter((val) => val !== null);
 
-        const skipPrincipalsConfig = inputConfig['skipPrincipals'] || [];
+        const skipPrincipalsConfig: { [name: string]: string }[] = this.context.inputConfig['skipPrincipals'] || [];
+
         this.skipPrincipals = [].concat(skipPrincipalsConfig)
             .map((cfg: any) => {
                 let val: string;
@@ -156,7 +156,7 @@ export class PrincipalSelector
 
         comboBox.onOptionDeselected((event: SelectedOptionEvent<Principal>) => {
             this.getPropertyArray().remove(event.getSelectedOption().getIndex());
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         comboBox.onOptionSelected((event: SelectedOptionEvent<Principal>) => {
@@ -169,7 +169,7 @@ export class PrincipalSelector
             }
             let selectedOptionView: PrincipalSelectedOptionView = <PrincipalSelectedOptionView>selectedOption.getOptionView();
             this.saveToSet(selectedOptionView.getOption(), selectedOption.getIndex());
-            this.validate(false);
+            this.handleValueChanged(false);
         });
 
         comboBox.onOptionMoved((selectedOption: SelectedOption<Principal>, fromIndex: number) => {

--- a/src/main/resources/assets/admin/common/js/form/inputtype/radiobutton/RadioButton.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/radiobutton/RadioButton.ts
@@ -27,7 +27,6 @@ export class RadioButton
 
     constructor(config: InputTypeViewContext) {
         super(config, 'radio-button');
-        this.readConfig(config.inputConfig);
     }
 
     getValueType(): ValueType {
@@ -102,9 +101,9 @@ export class RadioButton
         this.selector.unBlur(listener);
     }
 
-    private readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
+    protected readInputConfig():  void {
         const options: RadioButtonOption[] = [];
-        const optionValues: { [name: string]: string }[] = inputConfig['option'] || [];
+        const optionValues: { [name: string]: string }[] = this.context.inputConfig['option'] || [];
         const l: number = optionValues.length;
         let optionValue: { [name: string]: string };
 

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputType.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputType.ts
@@ -10,15 +10,29 @@ import {ClassHelper} from '../../../ClassHelper';
 import {ValueType} from '../../../data/ValueType';
 import {InputValidationRecording} from '../InputValidationRecording';
 import {ValueChangedEvent} from '../ValueChangedEvent';
+import {InputTypeViewContext} from '../InputTypeViewContext';
 
 export abstract class BaseInputType extends DivEl
     implements InputTypeView {
 
     protected input: Input;
 
+    protected context: InputTypeViewContext;
+
     protected previousValidationRecording: InputValidationRecording;
 
     private inputValidityChangedListeners: { (event: InputValidityChangedEvent): void }[] = [];
+
+    protected constructor(context: InputTypeViewContext, className?: string) {
+        super('input-type-view' + (className ? ' ' + className : ''));
+
+        this.context = context;
+        this.readInputConfig();
+    }
+
+    protected readInputConfig(): void {
+    //
+    }
 
     availableSizeChanged() {
         // must be implemented by children

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -31,7 +31,6 @@ export abstract class BaseInputTypeNotManagingAdd
     protected propertyArray: PropertyArray;
     protected ignorePropertyChange: boolean;
     protected occurrenceValidationState: Map<string, OccurrenceValidationRecord> = new Map<string, OccurrenceValidationRecord>();
-    private context: InputTypeViewContext;
     private inputOccurrences: InputOccurrences;
     private occurrenceValueChangedListeners: { (occurrence: Element, value: Value): void }[] = [];
     /**
@@ -40,9 +39,8 @@ export abstract class BaseInputTypeNotManagingAdd
     private draggingIndex: number;
 
     constructor(context: InputTypeViewContext, className?: string) {
-        super('input-type-view' + (className ? ' ' + className : ''));
+        super(context, className);
         assertNotNull(context, 'context cannot be null');
-        this.context = context;
 
         $(this.getHTMLElement()).sortable({
             axis: 'y',

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeSingleOccurrence.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeSingleOccurrence.ts
@@ -15,15 +15,13 @@ export abstract class BaseInputTypeSingleOccurrence
     extends BaseInputType {
 
     protected ignorePropertyChange: boolean;
-    private context: InputTypeViewContext;
     private property: Property;
     private propertyListener: (event: PropertyValueChangedEvent) => void;
     private inputValueChangedListeners: { (event: ValueChangedEvent): void }[] = [];
 
-    constructor(ctx: InputTypeViewContext, className?: string) {
-        super('input-type-view' + (className ? ' ' + className : ''));
+    protected constructor(ctx: InputTypeViewContext, className?: string) {
+        super(ctx, className);
         assertNotNull(ctx, 'CONTEXT cannot be null');
-        this.context = ctx;
 
         this.initListeners();
     }


### PR DESCRIPTION
-BaseInputTypeManagingAdd didn't implement taking care of a custom validation errors, fixing it
-Most of the BaseInputType.ts inheritors use context object and read config out of it; moved context and readConfig() to their common parent