### PR TITLE
Disable swc minification

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -12,16 +12,7 @@
         },
         "target": "es5",
         "keepClassNames": true,
-        "loose": true,
-        "minify": {
-            "compress": {
-                "keep_classnames": true
-            },
-            "mangle": {
-                "keepClassNames": true,
-                "keepFnNames": true
-            }
-        }
+        "loose": true
     },
     "exclude": [
         ".*\\.d\\.ts$",


### PR DESCRIPTION
Minification should not be defined in swc config, because it is handled by the Terser if bundled with webpack, or by tsc for production builds. Non-webpack development code must not be mangled or minified.