### PR TITLE
Focus jumps to the next disabled input after saving a content with op…

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -510,12 +510,8 @@ export class ComboBox<OPTION_DISPLAY_VALUE>
         this.comboBoxDropdown.markSelections([], ignoreEmpty);
 
         if (giveInputFocus) {
-            this.input.openForTypingAndFocus();
-        } else {
-            this.input.openForTyping();
+            this.input.giveFocus();
         }
-
-        this.dropdownHandle.setEnabled(true);
 
         if (this.hideComboBoxWhenMaxReached) {
             this.show();


### PR DESCRIPTION
…tion set #2986

-removing side effects, 'clear' method should just clear and not enable/disable inputs

NB: potentially can break some behavior if some inputs rely on side effects provided by  repaired `clear` method