### PR TITLE
Fix key-value url regex #3113

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/form/Validators.ts
+++ b/src/main/resources/assets/admin/common/js/ui/form/Validators.ts
@@ -104,7 +104,7 @@ export class Validators {
     }
 
     private static getQueryRegExp(): RegExp {
-        return /(\?([^&=]+)=([^&=]*))?(?:&([^&=]+)=([^&=]*))*/;
+        return /(\?([^&]+))?(?:&([^&]+))*/;
     }
 
     private static getFragmentRegExp(): RegExp {


### PR DESCRIPTION
As requested, url query params with only "key" (i.e, without "value") are now valid. 