### PR TITLE
SWC upgrade breaks dev build #3461

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:prod": "run-p build:prod:js build:lib",
     "build:prod:js": "tsc",
     "build:dev": "run-p build:dev:types build:dev:js build:lib",
-    "build:dev:js": "swc src --out-dir build/tmp/src",
+    "build:dev:js": "swc src --out-dir build/tmp/",
     "build:dev:types": "tsc --skipLibCheck --emitDeclarationOnly --declaration",
     "build:lib": "webpack --color",
     "typecheck": "tsc --pretty --skipLibCheck --noEmit",


### PR DESCRIPTION
Fixed swc/cli stopped dropping leading path from v0.3.0.