### PR TITLE
Set data-path attribute on inputs #3488

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ src/main/resources/assets/spec/coverage/
 
 # Visual Studio Code
 /bin/
+.vscode/

--- a/src/main/resources/assets/admin/common/js/form/FormItemOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemOccurrenceView.ts
@@ -1,11 +1,11 @@
 import * as Q from 'q';
-import {DivEl} from '../dom/DivEl';
 import {PropertyPath} from '../data/PropertyPath';
+import {DivEl} from '../dom/DivEl';
+import {Element} from '../dom/Element';
+import {JukeAiHelper} from '../juke/JukeAiHelper';
 import {FormItemOccurrence} from './FormItemOccurrence';
 import {HelpTextContainer} from './HelpTextContainer';
 import {RemoveButtonClickedEvent} from './RemoveButtonClickedEvent';
-import {SagaHelper} from '../saga/SagaHelper';
-import {Element} from '../dom/Element';
 
 export interface FormItemOccurrenceViewConfig {
     className: string;
@@ -36,7 +36,7 @@ export abstract class FormItemOccurrenceView
     }
 
     protected initListeners(): void {
-        if (this.isSagaEditableType()) {
+        if (this.isManagedType()) {
             const updatePathCall = setInterval(() => {
                 this.updateInputElDataPath();
             }, 1000);
@@ -144,10 +144,10 @@ export abstract class FormItemOccurrenceView
     }
 
     protected updateInputElDataPath(): void {
-        this.getDataPathElement().getEl().setAttribute(SagaHelper.DATA_ATTR, this.getDataPath()?.toString().replace(/\./g, '/'));
+        this.getDataPathElement().getEl().setAttribute(JukeAiHelper.DATA_ATTR, this.getDataPath()?.toString().replace(/\./g, '/'));
     }
 
-    protected isSagaEditableType(): boolean {
+    protected isManagedType(): boolean {
         return false;
     }
 

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -1,28 +1,28 @@
 import * as $ from 'jquery';
 import * as Q from 'q';
+import {ClassHelper} from '../../../ClassHelper';
+import {ObjectHelper} from '../../../ObjectHelper';
+import {ValidationError} from '../../../ValidationError';
 import {Property} from '../../../data/Property';
 import {PropertyArray} from '../../../data/PropertyArray';
 import {Value} from '../../../data/Value';
-import {FormInputEl} from '../../../dom/FormInputEl';
-import {InputTypeViewContext} from '../InputTypeViewContext';
-import {Input} from '../../Input';
-import {InputValidityChangedEvent} from '../InputValidityChangedEvent';
 import {Element} from '../../../dom/Element';
-import {InputValidationRecording} from '../InputValidationRecording';
+import {FormInputEl} from '../../../dom/FormInputEl';
+import {assertNotNull} from '../../../util/Assert';
+import {i18n} from '../../../util/Messages';
+import {AdditionalValidationRecord} from '../../AdditionalValidationRecord';
+import {Input} from '../../Input';
 import {OccurrenceAddedEvent} from '../../OccurrenceAddedEvent';
-import {OccurrenceRenderedEvent} from '../../OccurrenceRenderedEvent';
 import {OccurrenceRemovedEvent} from '../../OccurrenceRemovedEvent';
+import {OccurrenceRenderedEvent} from '../../OccurrenceRenderedEvent';
+import {InputTypeViewContext} from '../InputTypeViewContext';
+import {InputValidationRecording} from '../InputValidationRecording';
+import {InputValidityChangedEvent} from '../InputValidityChangedEvent';
 import {ValueChangedEvent} from '../ValueChangedEvent';
-import {ClassHelper} from '../../../ClassHelper';
-import {ObjectHelper} from '../../../ObjectHelper';
+import {BaseInputType} from './BaseInputType';
 import {InputOccurrenceView} from './InputOccurrenceView';
 import {InputOccurrences} from './InputOccurrences';
-import {assertNotNull} from '../../../util/Assert';
 import {OccurrenceValidationRecord} from './OccurrenceValidationRecord';
-import {BaseInputType} from './BaseInputType';
-import {ValidationError} from '../../../ValidationError';
-import {AdditionalValidationRecord} from '../../AdditionalValidationRecord';
-import {i18n} from '../../../util/Messages';
 
 export abstract class BaseInputTypeNotManagingAdd
     extends BaseInputType {
@@ -398,7 +398,7 @@ export abstract class BaseInputTypeNotManagingAdd
         });
     }
 
-    isSagaEditable(): boolean {
+    isManaged(): boolean {
         return false;
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/inputtype/support/InputOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/support/InputOccurrenceView.ts
@@ -1,15 +1,15 @@
 import * as Q from 'q';
-import {Property} from '../../../data/Property';
-import {PropertyValueChangedEvent} from '../../../data/PropertyValueChangedEvent';
-import {FormItemOccurrenceView, FormItemOccurrenceViewConfig} from '../../FormItemOccurrenceView';
-import {Element} from '../../../dom/Element';
-import {DivEl} from '../../../dom/DivEl';
-import {Value} from '../../../data/Value';
-import {PropertyPath} from '../../../data/PropertyPath';
-import {InputOccurrence} from './InputOccurrence';
-import {BaseInputTypeNotManagingAdd} from './BaseInputTypeNotManagingAdd';
-import {ButtonEl} from '../../../dom/ButtonEl';
-import {OccurrenceValidationRecord} from './OccurrenceValidationRecord';
+import { Property } from '../../../data/Property';
+import { PropertyPath } from '../../../data/PropertyPath';
+import { PropertyValueChangedEvent } from '../../../data/PropertyValueChangedEvent';
+import { Value } from '../../../data/Value';
+import { ButtonEl } from '../../../dom/ButtonEl';
+import { DivEl } from '../../../dom/DivEl';
+import { Element } from '../../../dom/Element';
+import { FormItemOccurrenceView, FormItemOccurrenceViewConfig } from '../../FormItemOccurrenceView';
+import { BaseInputTypeNotManagingAdd } from './BaseInputTypeNotManagingAdd';
+import { InputOccurrence } from './InputOccurrence';
+import { OccurrenceValidationRecord } from './OccurrenceValidationRecord';
 
 export interface InputOccurrenceViewConfig extends FormItemOccurrenceViewConfig {
     inputTypeView: BaseInputTypeNotManagingAdd;
@@ -214,8 +214,8 @@ export class InputOccurrenceView
         this.toggleClass('invalid', !!errorMessage);
     }
 
-    protected isSagaEditableType(): boolean {
-        return this.inputTypeView.isSagaEditable();
+    protected isManagedType(): boolean {
+        return this.inputTypeView.isManaged();
     }
 
     protected getDataPathElement(): Element {

--- a/src/main/resources/assets/admin/common/js/form/inputtype/text/TextInputType.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/text/TextInputType.ts
@@ -1,21 +1,21 @@
-import {NumberHelper} from '../../../util/NumberHelper';
-import {FormInputEl} from '../../../dom/FormInputEl';
-import {ValueTypes} from '../../../data/ValueTypes';
-import {i18n} from '../../../util/Messages';
-import {BaseInputTypeNotManagingAdd} from '../support/BaseInputTypeNotManagingAdd';
-import {InputTypeViewContext} from '../InputTypeViewContext';
-import {Property} from '../../../data/Property';
-import {AdditionalValidationRecord} from '../../AdditionalValidationRecord';
-import {InputValueLengthCounterEl} from './InputValueLengthCounterEl';
 import * as Q from 'q';
-import {Value} from '../../../data/Value';
-import {StringHelper} from '../../../util/StringHelper';
-import {Element, LangDirection} from '../../../dom/Element';
-import {ValueTypeConverter} from '../../../data/ValueTypeConverter';
-import {ValueChangedEvent} from '../../../ValueChangedEvent';
-import {ValueType} from '../../../data/ValueType';
-import {TextInput} from '../../../ui/text/TextInput';
-import {Locale} from '../../../locale/Locale';
+import { Property } from '../../../data/Property';
+import { Value } from '../../../data/Value';
+import { ValueType } from '../../../data/ValueType';
+import { ValueTypeConverter } from '../../../data/ValueTypeConverter';
+import { ValueTypes } from '../../../data/ValueTypes';
+import { Element, LangDirection } from '../../../dom/Element';
+import { FormInputEl } from '../../../dom/FormInputEl';
+import { Locale } from '../../../locale/Locale';
+import { TextInput } from '../../../ui/text/TextInput';
+import { i18n } from '../../../util/Messages';
+import { NumberHelper } from '../../../util/NumberHelper';
+import { StringHelper } from '../../../util/StringHelper';
+import { ValueChangedEvent } from '../../../ValueChangedEvent';
+import { AdditionalValidationRecord } from '../../AdditionalValidationRecord';
+import { InputTypeViewContext } from '../InputTypeViewContext';
+import { BaseInputTypeNotManagingAdd } from '../support/BaseInputTypeNotManagingAdd';
+import { InputValueLengthCounterEl } from './InputValueLengthCounterEl';
 
 export abstract class TextInputType
     extends BaseInputTypeNotManagingAdd {
@@ -162,7 +162,7 @@ export abstract class TextInputType
         });
     }
 
-    isSagaEditable(): boolean {
+    isManaged(): boolean {
         return true;
     }
 }

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
@@ -1,41 +1,41 @@
-import * as Q from 'q';
-import {PropertySet} from '../../data/PropertySet';
-import {PropertyArray} from '../../data/PropertyArray';
-import {PropertyValueChangedEvent} from '../../data/PropertyValueChangedEvent';
-import {i18n} from '../../util/Messages';
-import {Value} from '../../data/Value';
-import {DivEl} from '../../dom/DivEl';
-import {PropertyPath} from '../../data/PropertyPath';
-import {FormItemOccurrenceView, FormItemOccurrenceViewConfig} from '../FormItemOccurrenceView';
-import {FormItemView} from '../FormItemView';
-import {RecordingValidityChangedEvent} from '../RecordingValidityChangedEvent';
-import {FormOccurrenceDraggableLabel} from '../FormOccurrenceDraggableLabel';
-import {ValidationRecording} from '../ValidationRecording';
-import {FormItemLayer} from '../FormItemLayer';
-import {ValidationRecordingPath} from '../ValidationRecordingPath';
-import {FormSet} from './FormSet';
-import {FormItem} from '../FormItem';
-import {FormContext} from '../FormContext';
-import {FormSetOccurrence} from './FormSetOccurrence';
-import {Action} from '../../ui/Action';
-import {MoreButton} from '../../ui/button/MoreButton';
-import {ConfirmationMask} from '../../ui/mask/ConfirmationMask';
-import {Element} from '../../dom/Element';
-import {KeyBindings} from '../../ui/KeyBindings';
-import {KeyBinding} from '../../ui/KeyBinding';
-import {Property} from '../../data/Property';
-import {ValueType} from '../../data/ValueType';
-import {ValueTypes} from '../../data/ValueTypes';
-import {PropertyAddedEvent} from '../../data/PropertyAddedEvent';
-import {PropertyRemovedEvent} from '../../data/PropertyRemovedEvent';
-import {FormOptionSet} from './optionset/FormOptionSet';
-import {FormOptionSetOption} from './optionset/FormOptionSetOption';
-import {FormItemSet} from './itemset/FormItemSet';
-import {Input} from '../Input';
-import {RadioButton} from '../inputtype/radiobutton/RadioButton';
-import {ObjectHelper} from '../../ObjectHelper';
-import {SagaHelper} from '../../saga/SagaHelper';
-import {FormItemOccurrence} from '../FormItemOccurrence';
+import * as Q from "q";
+import {Property} from "../../data/Property";
+import {PropertyAddedEvent} from "../../data/PropertyAddedEvent";
+import {PropertyArray} from "../../data/PropertyArray";
+import {PropertyPath} from "../../data/PropertyPath";
+import {PropertyRemovedEvent} from "../../data/PropertyRemovedEvent";
+import {PropertySet} from "../../data/PropertySet";
+import {PropertyValueChangedEvent} from "../../data/PropertyValueChangedEvent";
+import {Value} from "../../data/Value";
+import {ValueType} from "../../data/ValueType";
+import {ValueTypes} from "../../data/ValueTypes";
+import {DivEl} from "../../dom/DivEl";
+import {Element} from "../../dom/Element";
+import {ObjectHelper} from "../../ObjectHelper";
+import {Action} from "../../ui/Action";
+import {MoreButton} from "../../ui/button/MoreButton";
+import {KeyBinding} from "../../ui/KeyBinding";
+import {KeyBindings} from "../../ui/KeyBindings";
+import {ConfirmationMask} from "../../ui/mask/ConfirmationMask";
+import {i18n} from "../../util/Messages";
+import {FormContext} from "../FormContext";
+import {FormItem} from "../FormItem";
+import {FormItemLayer} from "../FormItemLayer";
+import {FormItemOccurrence} from "../FormItemOccurrence";
+import {
+    FormItemOccurrenceView,
+    FormItemOccurrenceViewConfig,
+} from "../FormItemOccurrenceView";
+import {FormItemView} from "../FormItemView";
+import {FormOccurrenceDraggableLabel} from "../FormOccurrenceDraggableLabel";
+import {Input} from "../Input";
+import {RecordingValidityChangedEvent} from "../RecordingValidityChangedEvent";
+import {ValidationRecording} from "../ValidationRecording";
+import {ValidationRecordingPath} from "../ValidationRecordingPath";
+import {FormSet} from "./FormSet";
+import {FormItemSet} from "./itemset/FormItemSet";
+import {FormOptionSet} from "./optionset/FormOptionSet";
+import {FormOptionSetOption} from "./optionset/FormOptionSetOption";
 
 export interface FormSetOccurrenceViewConfig<V extends FormSetOccurrenceView> {
     context: FormContext;
@@ -51,16 +51,18 @@ export interface FormSetOccurrenceViewConfig<V extends FormSetOccurrenceView> {
     dataSet: PropertySet;
 }
 
-export interface FormSetOccurrenceViewConfigExtended extends FormSetOccurrenceViewConfig<FormSetOccurrenceView>, FormItemOccurrenceViewConfig {
+export interface FormSetOccurrenceViewConfigExtended
+    extends FormSetOccurrenceViewConfig<FormSetOccurrenceView>,
+        FormItemOccurrenceViewConfig {
     classPrefix: string;
 }
 
-export abstract class FormSetOccurrenceView
-    extends FormItemOccurrenceView {
-
+export abstract class FormSetOccurrenceView extends FormItemOccurrenceView {
     protected formItemViews: FormItemView[];
 
-    protected validityChangedListeners: ((event: RecordingValidityChangedEvent) => void)[] = [];
+    protected validityChangedListeners: ((
+        event: RecordingValidityChangedEvent
+    ) => void)[] = [];
 
     protected moreButton: MoreButton;
 
@@ -90,11 +92,18 @@ export abstract class FormSetOccurrenceView
 
     private formDataChangedListener: (event: PropertyValueChangedEvent) => void;
 
-    private formDataAddedOrRemovedListener: (_event: (PropertyAddedEvent | PropertyRemovedEvent)) => void;
+    private formDataAddedOrRemovedListener: (
+        _event: PropertyAddedEvent | PropertyRemovedEvent
+    ) => void;
 
-    private expandRequestedListeners: ((view: FormSetOccurrenceView) => void)[] = [];
+    private expandRequestedListeners: ((
+        view: FormSetOccurrenceView
+    ) => void)[] = [];
 
-    protected constructor(classPrefix: string, config: FormSetOccurrenceViewConfig<FormSetOccurrenceView>) {
+    protected constructor(
+        classPrefix: string,
+        config: FormSetOccurrenceViewConfig<FormSetOccurrenceView>
+    ) {
         super({
             ...config,
             className: `${classPrefix}occurrence-view`,
@@ -109,7 +118,10 @@ export abstract class FormSetOccurrenceView
     protected abstract getLabelSubTitle(): string;
 
     hasHelpText(): boolean {
-        return super.hasHelpText() || this.getFormItemViews().some((view) => view.hasHelpText());
+        return (
+            super.hasHelpText() ||
+            this.getFormItemViews().some((view) => view.hasHelpText())
+        );
     }
 
     isExpandable(): boolean {
@@ -149,15 +161,21 @@ export abstract class FormSetOccurrenceView
 
         this.formItemViews = [];
         this.occurrenceContainerClassName = `${this.config.classPrefix}occurrences-container`;
-        this.formSetOccurrencesContainer = new DivEl(this.occurrenceContainerClassName);
+        this.formSetOccurrencesContainer = new DivEl(
+            this.occurrenceContainerClassName
+        );
         this.formSet = this.config.formSet;
         this.propertySet = this.config.dataSet;
         this.formItemLayer = this.config.layer;
         this.moreButton = this.createMoreButton();
         this.label = new FormOccurrenceDraggableLabel();
         this.formSetOccurrencesContainer.setVisible(false);
-        this.confirmDeleteAction = new Action(i18n('action.delete')).setClass('red large delete-button');
-        this.noAction = new Action(i18n('action.cancel')).setClass('black large');
+        this.confirmDeleteAction = new Action(i18n("action.delete")).setClass(
+            "red large delete-button"
+        );
+        this.noAction = new Action(i18n("action.cancel")).setClass(
+            "black large"
+        );
         this.deleteConfirmationMask = ConfirmationMask.create()
             .setElement(this)
             .setHideOnScroll(true)
@@ -173,14 +191,16 @@ export abstract class FormSetOccurrenceView
         this.label.setExpandable(this.isExpandable());
 
         if (!this.isExpandable()) {
-            this.label.setTitle(i18n('tooltip.header.collapse'));
+            this.label.setTitle(i18n("tooltip.header.collapse"));
         }
     }
 
     protected initListeners() {
         super.initListeners();
 
-        this.label.onClicked(() => this.setContainerVisible(!this.isContainerVisible()));
+        this.label.onClicked(() =>
+            this.setContainerVisible(!this.isContainerVisible())
+        );
 
         this.confirmDeleteAction.onExecuted(() => {
             this.notifyRemoveButtonClicked();
@@ -193,7 +213,9 @@ export abstract class FormSetOccurrenceView
 
         const bindings: KeyBindings = KeyBindings.get();
         const maskBindings: KeyBinding[] = [
-            new KeyBinding('esc', () => this.noAction.execute()).setGlobal(true),
+            new KeyBinding("esc", () => this.noAction.execute()).setGlobal(
+                true
+            ),
         ];
 
         let shelvedBindings: KeyBinding[];
@@ -215,21 +237,31 @@ export abstract class FormSetOccurrenceView
             const propertyPathAsString: string = event.getPath().toString();
 
             if (!!this.dirtyFormItemViewsMap[propertyPathAsString]) {
-                if (newValue.equals(this.dirtyFormItemViewsMap[propertyPathAsString]['originalValue'])) {
+                if (
+                    newValue.equals(
+                        this.dirtyFormItemViewsMap[propertyPathAsString][
+                            "originalValue"
+                        ]
+                    )
+                ) {
                     delete this.dirtyFormItemViewsMap[propertyPathAsString];
                 } else {
-                    this.dirtyFormItemViewsMap[propertyPathAsString]['currentValue'] = newValue;
+                    this.dirtyFormItemViewsMap[propertyPathAsString][
+                        "currentValue"
+                    ] = newValue;
                 }
             } else {
                 this.dirtyFormItemViewsMap[propertyPathAsString] = {
                     originalValue: event.getPreviousValue(),
-                    currentValue: newValue
+                    currentValue: newValue,
                 };
             }
             this.updateLabel();
         };
 
-        this.formDataAddedOrRemovedListener = (_event: PropertyAddedEvent | PropertyRemovedEvent) => this.updateLabel();
+        this.formDataAddedOrRemovedListener = (
+            _event: PropertyAddedEvent | PropertyRemovedEvent
+        ) => this.updateLabel();
 
         this.onRemoved(() => {
             if (this.propertySet) {
@@ -243,15 +275,23 @@ export abstract class FormSetOccurrenceView
     }
 
     protected layoutElements() {
-        this.appendChildren<Element>(this.label, this.moreButton, this.formSetOccurrencesContainer);
+        this.appendChildren<Element>(
+            this.label,
+            this.moreButton,
+            this.formSetOccurrencesContainer
+        );
     }
 
     hasNonDefaultValues(): boolean {
-        return this.formItemViews.some(formItemView => formItemView.hasNonDefaultValues());
+        return this.formItemViews.some((formItemView) =>
+            formItemView.hasNonDefaultValues()
+        );
     }
 
     isEmpty(): boolean {
-        return this.formItemViews.every((formItemView: FormItemView) => formItemView.isEmpty());
+        return this.formItemViews.every((formItemView: FormItemView) =>
+            formItemView.isEmpty()
+        );
     }
 
     getDataPath(): PropertyPath {
@@ -263,24 +303,34 @@ export abstract class FormSetOccurrenceView
         let hideValidationErrors: boolean = true;
 
         this.formItemViews.forEach((formItemView: FormItemView) => {
-            const currRecording: ValidationRecording = formItemView.validate(silent);
-            hideValidationErrors = hideValidationErrors && (currRecording.isValid() || currRecording.isValidationErrorsHidden());
+            const currRecording: ValidationRecording =
+                formItemView.validate(silent);
+            hideValidationErrors =
+                hideValidationErrors &&
+                (currRecording.isValid() ||
+                    currRecording.isValidationErrorsHidden());
             allRecordings.flatten(currRecording);
         });
 
-        hideValidationErrors = allRecordings.isInvalid() && hideValidationErrors;
+        hideValidationErrors =
+            allRecordings.isInvalid() && hideValidationErrors;
 
         this.extraValidation(allRecordings);
 
         if (!silent) {
             if (allRecordings.validityChanged(this.currentValidationState)) {
-                this.notifyValidityChanged(new RecordingValidityChangedEvent(allRecordings, this.resolveValidationRecordingPath()));
+                this.notifyValidityChanged(
+                    new RecordingValidityChangedEvent(
+                        allRecordings,
+                        this.resolveValidationRecordingPath()
+                    )
+                );
             }
         }
 
         this.currentValidationState = allRecordings;
-        this.toggleClass('invalid', !this.isValid());
-        this.toggleClass('hide-validation-errors', hideValidationErrors);
+        this.toggleClass("invalid", !this.isValid());
+        this.toggleClass("hide-validation-errors", hideValidationErrors);
         return allRecordings;
     }
 
@@ -325,29 +375,37 @@ export abstract class FormSetOccurrenceView
             this.initOccurrencesContainer();
         }
         this.formSetOccurrencesContainer.setVisible(visible);
-        this.toggleClass('collapsed', !visible);
-        this.label.setTitle(i18n(visible ? 'tooltip.header.collapse' : 'tooltip.header.expand'));
+        this.toggleClass("collapsed", !visible);
+        this.label.setTitle(
+            i18n(visible ? "tooltip.header.collapse" : "tooltip.header.expand")
+        );
     }
 
     isContainerVisible(): boolean {
         // container may be on, but will be not visible
         // if the whole occurrence is hidden (i.e. single select unselected option)
         // so check the style directly
-        return !this.formSetOccurrencesContainer ? false : this.formSetOccurrencesContainer.getEl().getDisplay() !== 'none';
+        return !this.formSetOccurrencesContainer
+            ? false
+            : this.formSetOccurrencesContainer.getEl().getDisplay() !== "none";
     }
 
     refresh() {
-        this.moreButton.getMenuActions().forEach(action => {
+        this.moreButton.getMenuActions().forEach((action) => {
             switch (action.getLabel()) {
-            case i18n('action.reset'):
-                break;
-            case i18n('action.addAbove'):
-            case i18n('action.addBelow'):
-                action.setEnabled(!this.formItemOccurrence.maximumOccurrencesReached());
-                break;
-            case i18n('action.delete'):
-                action.setEnabled(this.formItemOccurrence.isRemoveButtonRequired());
-                break;
+                case i18n("action.reset"):
+                    break;
+                case i18n("action.addAbove"):
+                case i18n("action.addBelow"):
+                    action.setEnabled(
+                        !this.formItemOccurrence.maximumOccurrencesReached()
+                    );
+                    break;
+                case i18n("action.delete"):
+                    action.setEnabled(
+                        this.formItemOccurrence.isRemoveButtonRequired()
+                    );
+                    break;
             }
         });
 
@@ -357,7 +415,7 @@ export abstract class FormSetOccurrenceView
     }
 
     refreshViews() {
-        this.formItemViews.forEach(itemView => {
+        this.formItemViews.forEach((itemView) => {
             itemView.refresh();
         });
     }
@@ -369,7 +427,7 @@ export abstract class FormSetOccurrenceView
     }
 
     setEnabled(enable: boolean) {
-        this.formItemViews.forEach(itemView => {
+        this.formItemViews.forEach((itemView) => {
             itemView.setEnabled(enable);
         });
     }
@@ -412,14 +470,22 @@ export abstract class FormSetOccurrenceView
         });
     }
 
-    onValidityChanged(listener: (event: RecordingValidityChangedEvent) => void) {
+    onValidityChanged(
+        listener: (event: RecordingValidityChangedEvent) => void
+    ) {
         this.validityChangedListeners.push(listener);
     }
 
-    unValidityChanged(listener: (event: RecordingValidityChangedEvent) => void) {
-        this.validityChangedListeners.filter((currentListener: (event: RecordingValidityChangedEvent) => void) => {
-            return listener === currentListener;
-        });
+    unValidityChanged(
+        listener: (event: RecordingValidityChangedEvent) => void
+    ) {
+        this.validityChangedListeners.filter(
+            (
+                currentListener: (event: RecordingValidityChangedEvent) => void
+            ) => {
+                return listener === currentListener;
+            }
+        );
     }
 
     onFocus(listener: (event: FocusEvent) => void) {
@@ -463,13 +529,18 @@ export abstract class FormSetOccurrenceView
     }
 
     unExpandRequested(listener: (view: FormSetOccurrenceView) => void): void {
-        this.expandRequestedListeners.filter((currentListener: (view: FormSetOccurrenceView) => void) => {
-            return currentListener !== listener;
-        });
+        this.expandRequestedListeners.filter(
+            (currentListener: (view: FormSetOccurrenceView) => void) => {
+                return currentListener !== listener;
+            }
+        );
     }
 
     protected notifyExpandRequested(view?: FormSetOccurrenceView) {
-        this.expandRequestedListeners.forEach((listener: (view: FormSetOccurrenceView) => void) => listener(view || this));
+        this.expandRequestedListeners.forEach(
+            (listener: (view: FormSetOccurrenceView) => void) =>
+                listener(view || this)
+        );
     }
 
     protected updateLabel() {
@@ -483,33 +554,48 @@ export abstract class FormSetOccurrenceView
 
     protected subscribeOnItemEvents() {
         this.formItemViews.forEach((formItemView: FormItemView) => {
-            formItemView.onValidityChanged((event: RecordingValidityChangedEvent) => {
+            formItemView.onValidityChanged(
+                (event: RecordingValidityChangedEvent) => {
+                    if (!this.currentValidationState) {
+                        return; // currentValidationState is initialized on validate() call which may not be triggered in some cases
+                    }
 
-                if (!this.currentValidationState) {
-                    return; // currentValidationState is initialized on validate() call which may not be triggered in some cases
-                }
+                    let previousValidState =
+                        this.currentValidationState.isValid();
+                    if (event.isValid()) {
+                        this.currentValidationState.removeByPath(
+                            event.getOrigin(),
+                            false,
+                            event.isIncludeChildren()
+                        );
+                    } else {
+                        this.currentValidationState.flatten(
+                            event.getRecording()
+                        );
+                    }
 
-                let previousValidState = this.currentValidationState.isValid();
-                if (event.isValid()) {
-                    this.currentValidationState.removeByPath(event.getOrigin(), false, event.isIncludeChildren());
-                } else {
-                    this.currentValidationState.flatten(event.getRecording());
+                    if (
+                        previousValidState !==
+                        this.currentValidationState.isValid()
+                    ) {
+                        this.notifyValidityChanged(
+                            new RecordingValidityChangedEvent(
+                                this.currentValidationState,
+                                this.resolveValidationRecordingPath()
+                            ).setIncludeChildren(true)
+                        );
+                    }
                 }
-
-                if (previousValidState !== this.currentValidationState.isValid()) {
-                    this.notifyValidityChanged(new RecordingValidityChangedEvent(this.currentValidationState,
-                        this.resolveValidationRecordingPath()).setIncludeChildren(true));
-                }
-            });
+            );
         });
     }
 
     protected getFormSet(): FormSet {
-        throw new Error('Must be implemented by inheritor');
+        throw new Error("Must be implemented by inheritor");
     }
 
     protected getFormItems(): FormItem[] {
-        throw new Error('Must be implemented by inheritor');
+        throw new Error("Must be implemented by inheritor");
     }
 
     protected resolveValidationRecordingPath(): ValidationRecordingPath {
@@ -517,9 +603,11 @@ export abstract class FormSetOccurrenceView
     }
 
     protected notifyValidityChanged(event: RecordingValidityChangedEvent) {
-        this.validityChangedListeners.forEach((listener: (event: RecordingValidityChangedEvent) => void) => {
-            listener(event);
-        });
+        this.validityChangedListeners.forEach(
+            (listener: (event: RecordingValidityChangedEvent) => void) => {
+                listener(event);
+            }
+        );
     }
 
     private isAllowedValueAndType(property: Property) {
@@ -528,57 +616,77 @@ export abstract class FormSetOccurrenceView
         }
         const propertyType: ValueType = property.getType();
 
-        if (ValueTypes.LOCAL_TIME.equals(propertyType) && property.getString() === '00:00') {
+        if (
+            ValueTypes.LOCAL_TIME.equals(propertyType) &&
+            property.getString() === "00:00"
+        ) {
             return false;
         }
 
         const isAllowedType = [
-                ValueTypes.STRING,
-                ValueTypes.DOUBLE,
-                ValueTypes.LONG,
-                ValueTypes.LOCAL_DATE,
-                ValueTypes.LOCAL_TIME
-            ].some(valueType => valueType.equals(propertyType));
+            ValueTypes.STRING,
+            ValueTypes.DOUBLE,
+            ValueTypes.LONG,
+            ValueTypes.LOCAL_DATE,
+            ValueTypes.LOCAL_TIME,
+        ].some((valueType) => valueType.equals(propertyType));
 
         return isAllowedType && property.getString().length > 0;
     }
 
-    private getRadioButtonTextByValue(radioGroup: Input, selectedValue: string): string {
-        const radioButtons: object[] = radioGroup.getInputTypeConfig()['option'];
+    private getRadioButtonTextByValue(
+        radioGroup: Input,
+        selectedValue: string
+    ): string {
+        const radioButtons: object[] =
+            radioGroup.getInputTypeConfig()["option"];
         if (!radioButtons) {
-            return '';
+            return "";
         }
 
-        const selectedRadioButton: Object = radioButtons.find((option: Object) => option['@value'] === selectedValue);
-        return selectedRadioButton['value'];
+        const selectedRadioButton: Object = radioButtons.find(
+            (option: Object) => option["@value"] === selectedValue
+        );
+        return selectedRadioButton["value"];
     }
 
     private isRadioButtonInput(formItem: FormItem): boolean {
-        return (ObjectHelper.iFrameSafeInstanceOf(formItem, Input) &&
-                (formItem as Input).getInputType().toString() === 'RadioButton');
+        return (
+            ObjectHelper.iFrameSafeInstanceOf(formItem, Input) &&
+            (formItem as Input).getInputType().toString() === "RadioButton"
+        );
     }
 
     private getPropertyValue(prop: Property, formItem: FormItem): string {
         if (!formItem) {
-            return '';
+            return "";
         }
 
         // Special treatment of RadioButton as it stores button value, not label in the property
         if (this.isRadioButtonInput(formItem)) {
-            return this.getRadioButtonTextByValue(formItem as Input, prop.getString());
+            return this.getRadioButtonTextByValue(
+                formItem as Input,
+                prop.getString()
+            );
         }
 
         return prop.getString();
     }
 
-    protected fetchPropertyValues(propArray: PropertyArray, propValues: string[], firstOnly?: boolean): void {
+    protected fetchPropertyValues(
+        propArray: PropertyArray,
+        propValues: string[],
+        firstOnly?: boolean
+    ): void {
         propArray.some((prop: Property) => {
             const formItem: FormItem = this.getFormItemByProperty(prop);
             if (!formItem) {
                 return false;
             }
             if (this.isAllowedValueAndType(prop)) {
-                const propValue: string = this.sanitizeValue(this.getPropertyValue(prop, formItem));
+                const propValue: string = this.sanitizeValue(
+                    this.getPropertyValue(prop, formItem)
+                );
 
                 if (propValue.length > 0) {
                     propValues.push(propValue);
@@ -586,37 +694,65 @@ export abstract class FormSetOccurrenceView
             } else if (ValueTypes.DATA.equals(prop.getType())) {
                 const propertySet = prop.getPropertySet();
                 if (formItem instanceof FormOptionSet) {
-                    this.fetchPropertyValuesFromOptionSet(propertySet, formItem, propValues, firstOnly);
+                    this.fetchPropertyValuesFromOptionSet(
+                        propertySet,
+                        formItem,
+                        propValues,
+                        firstOnly
+                    );
                 } else {
-                    this.fetchPropertyValuesFromSet(propertySet, propValues, firstOnly);
+                    this.fetchPropertyValuesFromSet(
+                        propertySet,
+                        propValues,
+                        firstOnly
+                    );
                 }
             }
             return firstOnly && propValues.length > 0;
         });
     }
 
-    private fetchPropertyValuesFromSet(propertySet: PropertySet, propValues: string[], firstOnly: boolean) {
-        propertySet.getPropertyArrays().some(array => {
-            if ('_selected' === array.getName()) {
-                return false;   // skip technical _selected array
+    private fetchPropertyValuesFromSet(
+        propertySet: PropertySet,
+        propValues: string[],
+        firstOnly: boolean
+    ) {
+        propertySet.getPropertyArrays().some((array) => {
+            if ("_selected" === array.getName()) {
+                return false; // skip technical _selected array
             }
             this.fetchPropertyValues(array, propValues, firstOnly);
             return firstOnly && propValues.length > 0;
         });
     }
 
-    private fetchPropertyValuesFromOptionSet(propertySet: PropertySet, formItem: FormOptionSet, propValues: string[], firstOnly: boolean) {
-        const selectionArray = propertySet.getPropertyArray('_selected');
+    private fetchPropertyValuesFromOptionSet(
+        propertySet: PropertySet,
+        formItem: FormOptionSet,
+        propValues: string[],
+        firstOnly: boolean
+    ) {
+        const selectionArray = propertySet.getPropertyArray("_selected");
 
         if (selectionArray && !selectionArray.isEmpty()) {
-            this.fetchPropertyValuesFromOptions(formItem, selectionArray, propValues);
+            this.fetchPropertyValuesFromOptions(
+                formItem,
+                selectionArray,
+                propValues
+            );
 
             if (propValues.length === 0) {
                 // should not happen, but in case no labels were found go inside selected options forms
                 selectionArray.some((selectedProp) => {
-                    const selectedOptionArray = propertySet.getPropertyArray(selectedProp.getString());
+                    const selectedOptionArray = propertySet.getPropertyArray(
+                        selectedProp.getString()
+                    );
                     if (selectedOptionArray && !selectedOptionArray.isEmpty()) {
-                        this.fetchPropertyValues(selectedOptionArray, propValues, firstOnly);
+                        this.fetchPropertyValues(
+                            selectedOptionArray,
+                            propValues,
+                            firstOnly
+                        );
                     }
                     return firstOnly && propValues.length > 0;
                 });
@@ -624,33 +760,60 @@ export abstract class FormSetOccurrenceView
         }
     }
 
-    private fetchPropertyValuesFromOptions(formItem: FormOptionSet, selectionArray: PropertyArray, propValues: string[]) {
+    private fetchPropertyValuesFromOptions(
+        formItem: FormOptionSet,
+        selectionArray: PropertyArray,
+        propValues: string[]
+    ) {
         const nameLabelMap = new Map<string, any>(
-            formItem.getFormItems()
+            formItem
+                .getFormItems()
                 .filter((fi: FormItem) => fi instanceof FormOptionSetOption)
                 .map((fo: FormOptionSetOption, index: number) => {
-                    return [fo.getName(), {label: fo.getLabel(), index: index}] as [string, any];
+                    return [
+                        fo.getName(),
+                        { label: fo.getLabel(), index: index },
+                    ] as [string, any];
                 })
         );
 
-        const selectedLabels = selectionArray.getProperties()
+        const selectedLabels = selectionArray
+            .getProperties()
             .sort((one: Property, two: Property) => {
-                return nameLabelMap.get(one.getString()).index - nameLabelMap.get(two.getString()).index;
+                return (
+                    nameLabelMap.get(one.getString()).index -
+                    nameLabelMap.get(two.getString()).index
+                );
             })
-            .map((selectedProp: Property) => nameLabelMap.get(selectedProp.getString()).label);
+            .map(
+                (selectedProp: Property) =>
+                    nameLabelMap.get(selectedProp.getString()).label
+            );
 
         propValues.push(...selectedLabels);
     }
 
-    private getFormItemByProperty(prop: Property, formItems?: FormItem[]): FormItem {
+    private getFormItemByProperty(
+        prop: Property,
+        formItems?: FormItem[]
+    ): FormItem {
         let formItem: FormItem;
         const propertyName: string = prop.getName();
         const parentPropertyName: string = prop.getParentProperty().getName();
         (formItems || this.getFormItems()).find((item: FormItem) => {
-            if (item.getName() === propertyName && item.getParent().getName() === parentPropertyName) {
+            if (
+                item.getName() === propertyName &&
+                item.getParent().getName() === parentPropertyName
+            ) {
                 formItem = item;
-            } else if (item instanceof FormOptionSetOption || item instanceof FormItemSet) {
-                formItem = this.getFormItemByProperty(prop, item.getFormItems());
+            } else if (
+                item instanceof FormOptionSetOption ||
+                item instanceof FormItemSet
+            ) {
+                formItem = this.getFormItemByProperty(
+                    prop,
+                    item.getFormItems()
+                );
             }
             return !!formItem;
         });
@@ -660,10 +823,10 @@ export abstract class FormSetOccurrenceView
 
     private sanitizeValue(label: string): string {
         return label
-            .replace(/<\/?[^>]+(>|$)/g, '') // removing tags
-            .replace(/&nbsp;/g, '') // removing spaces
-            .replace(/\s{2,}/g, ' ') // removing spaces
-            .replace(/\n/g, ' ') // removing linebreaks
+            .replace(/<\/?[^>]+(>|$)/g, "") // removing tags
+            .replace(/&nbsp;/g, "") // removing spaces
+            .replace(/\s{2,}/g, " ") // removing spaces
+            .replace(/\n/g, " ") // removing linebreaks
             .trim();
     }
 
@@ -684,31 +847,43 @@ export abstract class FormSetOccurrenceView
     }
 
     private createMoreButton(): MoreButton {
-        const addAboveAction = new Action(i18n('action.addAbove')).onExecuted(_action => {
-            void this.formItemOccurrence.addOccurrenceAbove().then((view: FormItemOccurrenceView) => {
-                const setView = view as FormSetOccurrenceView;
-                this.notifyExpandRequested(setView);
-            });
-        });
-        const addBelowAction = new Action(i18n('action.addBelow')).onExecuted(_action => {
-            void this.formItemOccurrence.addOccurrenceBelow().then((view: FormItemOccurrenceView) => {
-                const setView = view as FormSetOccurrenceView;
-                this.notifyExpandRequested(setView);
-            });
-        });
-        const removeAction = new Action(i18n('action.delete')).onExecuted(_action => {
-            if (this.isDirty() || this.hasNonDefaultValues()) {
-                this.setContainerVisible(true);
-                this.notifyExpandRequested();
-                const label = this.formSet.getLabel();
-                if (label) {
-                    this.confirmDeleteAction.setLabel(i18n('dialog.confirm.occurrences.delete', label));
-                }
-                this.deleteConfirmationMask.show();
-            } else {
-                this.notifyRemoveButtonClicked();
+        const addAboveAction = new Action(i18n("action.addAbove")).onExecuted(
+            (_action) => {
+                void this.formItemOccurrence
+                    .addOccurrenceAbove()
+                    .then((view: FormItemOccurrenceView) => {
+                        const setView = view as FormSetOccurrenceView;
+                        this.notifyExpandRequested(setView);
+                    });
             }
-        });
+        );
+        const addBelowAction = new Action(i18n("action.addBelow")).onExecuted(
+            (_action) => {
+                void this.formItemOccurrence
+                    .addOccurrenceBelow()
+                    .then((view: FormItemOccurrenceView) => {
+                        const setView = view as FormSetOccurrenceView;
+                        this.notifyExpandRequested(setView);
+                    });
+            }
+        );
+        const removeAction = new Action(i18n("action.delete")).onExecuted(
+            (_action) => {
+                if (this.isDirty() || this.hasNonDefaultValues()) {
+                    this.setContainerVisible(true);
+                    this.notifyExpandRequested();
+                    const label = this.formSet.getLabel();
+                    if (label) {
+                        this.confirmDeleteAction.setLabel(
+                            i18n("dialog.confirm.occurrences.delete", label)
+                        );
+                    }
+                    this.deleteConfirmationMask.show();
+                } else {
+                    this.notifyRemoveButtonClicked();
+                }
+            }
+        );
 
         return new MoreButton([addAboveAction, addBelowAction, removeAction]);
     }
@@ -717,7 +892,7 @@ export abstract class FormSetOccurrenceView
         return this;
     }
 
-    protected isSagaEditableType(): boolean {
+    protected isManagedType(): boolean {
         return true;
     }
 }

--- a/src/main/resources/assets/admin/common/js/juke/JukeAiHelper.ts
+++ b/src/main/resources/assets/admin/common/js/juke/JukeAiHelper.ts
@@ -1,0 +1,3 @@
+export class JukeAiHelper {
+    public static DATA_ATTR = "data-path";
+}

--- a/src/main/resources/assets/admin/common/js/saga/SagaHelper.ts
+++ b/src/main/resources/assets/admin/common/js/saga/SagaHelper.ts
@@ -1,4 +1,0 @@
-export class SagaHelper {
-
-    public static DATA_ATTR = 'data-path';
-}


### PR DESCRIPTION
Input element's path is a dynamic thing, it changes when occurrences are moved/added/removed, so it is only valid when someone asks for it in a particular moment. However this path is required by the AI Assistant to be able to find the input with selector query, thus need to update the data-path attribute constantly to keep it actual