### PR TITLE
OriginalValue has invalid initial value #3509

### DIFF
--- a/src/main/resources/assets/admin/common/js/dom/FormInputEl.ts
+++ b/src/main/resources/assets/admin/common/js/dom/FormInputEl.ts
@@ -19,7 +19,7 @@ export class FormInputEl
         this.addClass('form-input');
 
         this.originalValue = originalValue;
-        this.oldValue = originalValue;
+        this.oldValue = '';
         this.dirty = false;
 
         if (FormInputEl.debug) {


### PR DESCRIPTION
Restored `oldValue` to default empty string.