### PR TITLE
Migrate to newer version of JS #3908

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -10,7 +10,7 @@
             "legacyDecorator": true,
             "decoratorMetadata": true
         },
-        "target": "es5",
+        "target": "es2020",
         "keepClassNames": true,
         "loose": true
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "ES2020",
         "lib": [
-            "es2015",
-            "dom"
+            "ES2020",
+            "DOM"
         ],
         "outDir": "build/resources/main/dev/lib-admin-ui/",
         "moduleResolution": "node",


### PR DESCRIPTION
Wait with this PR until all core apps (cloud is already using 2018) migrated to ES2020.