### PR TITLE
TreeListBox: data-level attribute is not set #3981

### DIFF
--- a/src/main/resources/assets/admin/common/js/ui/selector/list/TreeListBox.ts
+++ b/src/main/resources/assets/admin/common/js/ui/selector/list/TreeListBox.ts
@@ -125,15 +125,8 @@ export abstract class TreeListBox<I> extends LazyListBox<I> {
     }
 
     getLevel(): number {
-        let parentCounter = 0;
-        let parent = this.getParentList();
-
-        while (parent) {
-            parentCounter++;
-            parent = parent.getParentList();
-        }
-
-        return parentCounter;
+        const parent = this.getParentList();
+        return parent ? parent.getLevel() + 1 : 0;
     }
 
     doRender(): Q.Promise<boolean> {
@@ -154,7 +147,7 @@ export abstract class TreeListBox<I> extends LazyListBox<I> {
 export interface TreeListElementParams<I> {
     scrollParent: Element,
     parentItem?: I,
-    parentList?: TreeListBox<I>,
+    parentList: TreeListBox<I>,
     expandedContext?: TreeListBoxExpandedHolder,
 }
 


### PR DESCRIPTION
- calc level more efficiently
- tree list elements always supposed to have a parent list