### PR TITLE
Help text: move related styles to a separate .less file  #4021

### DIFF
--- a/src/main/resources/assets/admin/common/styles/api/form-common.less
+++ b/src/main/resources/assets/admin/common/styles/api/form-common.less
@@ -8,21 +8,6 @@
     display: none;
   }
 
-  .help-text {
-    font-size: 11px;
-    padding-top: 5px;
-
-    &:not(.visible) {
-      display: none;
-    }
-
-    p {
-      color: @admin-font-gray2;
-      font-style: italic;
-      text-align: justify;
-    }
-  }
-
   &.display-validation-errors {
     .input-view,
     .form-item-set-view .input-view,
@@ -77,29 +62,6 @@
 
   .CodeMirror {
     float: left;
-  }
-
-  .help-text-toggler {
-    float: right;
-    cursor: pointer;
-    position: relative;
-    z-index: 1;
-    width: 17px;
-    height: 17px;
-    line-height: 17px;
-    text-align: center;
-    font-size: 12px;
-    color: white;
-    background: @form-button-bg-hover;
-    border-radius: 50%;
-
-    &:hover:not(.on) {
-      color: @admin-dark-gray;
-    }
-
-    &.on {
-      background: @admin-button-blue1;
-    }
   }
 
   .drag-control {

--- a/src/main/resources/assets/admin/common/styles/api/ui/help-text.less
+++ b/src/main/resources/assets/admin/common/styles/api/ui/help-text.less
@@ -1,0 +1,37 @@
+.help-text {
+  font-size: 11px;
+  padding-top: 5px;
+
+  &:not(.visible) {
+    display: none;
+  }
+
+  p {
+    color: @admin-font-gray2;
+    font-style: italic;
+    text-align: justify;
+  }
+}
+
+.help-text-toggler {
+  float: right;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  width: 17px;
+  height: 17px;
+  line-height: 17px;
+  text-align: center;
+  font-size: 12px;
+  color: white;
+  background: @form-button-bg-hover;
+  border-radius: 50%;
+
+  &:hover:not(.on) {
+    color: @admin-dark-gray;
+  }
+
+  &.on {
+    background: @admin-button-blue1;
+  }
+}

--- a/src/main/resources/assets/admin/common/styles/main.less
+++ b/src/main/resources/assets/admin/common/styles/main.less
@@ -24,6 +24,7 @@
 @import "api/ui/toolbar";
 @import "api/ui/fold-button";
 @import "api/ui/tooltip";
+@import "api/ui/help-text";
 @import "api/ui/progress-bar";
 @import "api/ui/text/text-input";
 @import "api/ui/text/password-input";

--- a/src/main/resources/assets/admin/common/styles/main.lite.less
+++ b/src/main/resources/assets/admin/common/styles/main.lite.less
@@ -35,6 +35,7 @@
 @import "api/app/names-view";
 @import "api/app/names-and-icon-view";
 @import "api/ui/tooltip";
+@import "api/ui/help-text";
 @import "api/ui/menu/menu";
 @import "api/ui/menu/context-menu";
 //modal-dialogs


### PR DESCRIPTION
- Leaving help-text container as it is to not break backward compatibility