### PR TITLE
Upgrade Java version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ base {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of( 11 )
+        languageVersion = JavaLanguageVersion.of( 21 )
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "jquery-simulate": "^1.0.2",
     "jquery-ui": "^1.14.1",
     "mousetrap": "^1.6.5",
-    "nanoid": "^5.1.5",
-    "nanostores": "^1.0.1",
     "q": "^1.5.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,6 @@ importers:
       mousetrap:
         specifier: ^1.6.5
         version: 1.6.5
-      nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
-      nanostores:
-        specifier: ^1.0.1
-        version: 1.0.1
       q:
         specifier: ^1.5.1
         version: 1.5.1
@@ -1027,15 +1021,6 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
-  nanostores@1.0.1:
-    resolution: {integrity: sha512-kNZ9xnoJYKg/AfxjrVL4SS0fKX++4awQReGqWnwTRHxeHGZ1FJFVgTqr/eMrNQdp0Tz7M7tG/TDaX8QfHDwVCw==}
-    engines: {node: ^20.0.0 || >=22.0.0}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -2393,10 +2378,6 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
-
-  nanoid@5.1.5: {}
-
-  nanostores@1.0.1: {}
 
   natural-compare@1.4.0: {}
 


### PR DESCRIPTION
Switched Java from 11 to 21, as the most recent Java used by apps.
Removed unused dependencies (were added by mistake from Enonic UI epic)