### PR TITLE
Time is incorrectly displayed for DateTime input with timezone #4144

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/inputtype/time/DateTime.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/time/DateTime.ts
@@ -16,7 +16,6 @@ import {AdditionalValidationRecord} from '../../AdditionalValidationRecord';
 import {i18n} from '../../../util/Messages';
 import {ValueTypeDateTime} from '../../../data/ValueTypeDateTime';
 import {ObjectHelper} from '../../../ObjectHelper';
-import {FormInputEl} from '../../../dom/FormInputEl';
 
 /**
  * Uses [[ValueType]] [[ValueTypeLocalDateTime]].
@@ -44,7 +43,7 @@ export class DateTime
         const useLocalTimeZone: boolean = ObjectHelper.iFrameSafeInstanceOf(valueType, ValueTypeDateTime);
 
         const dateTimeBuilder: DateTimePickerBuilder = new DateTimePickerBuilder();
-        dateTimeBuilder.setUseLocalTimezoneIfNotPresent(useLocalTimeZone);
+        dateTimeBuilder.setUseLocalTimezone(useLocalTimeZone);
 
         const defaultDate: Date = this.getDefaultValue();
         if (defaultDate) {
@@ -58,9 +57,6 @@ export class DateTime
         if (property.hasNonNullValue()) {
             const date: DateTimeUtil | LocalDateTime = useLocalTimeZone ? property.getDateTime() : property.getLocalDateTime();
             dateTimeBuilder.setDateTime(date.toDate());
-            if (useLocalTimeZone) {
-                dateTimeBuilder.setTimezone((date as DateTimeUtil).getTimezone());
-            }
         }
 
         const dateTimePicker: DateTimePicker = dateTimeBuilder.build();

--- a/src/main/resources/assets/admin/common/js/form/inputtype/time/DateTimeRange.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/time/DateTimeRange.ts
@@ -252,7 +252,7 @@ export class DateTimeRange
         const rangeBuilder: DateTimeRangePickerBuilder = new DateTimeRangePickerBuilder()
             .setFromLabel(this.labels.from)
             .setToLabel(this.labels.to)
-            .setUseLocalTimezoneIfNotPresent(true);
+            .setUseLocalTimezone(true);
 
         this.setFromTo(rangeBuilder, property);
 
@@ -289,7 +289,7 @@ export class DateTimeRange
                     builder.setEndDate((to as DateTime).toDate());
                 }
                 if (this.useTimezone) {
-                    builder.setTimezone(((from || to) as DateTime).getTimezone());
+                    builder.setUseLocalTimezone(true);
                 }
             }
         }

--- a/src/main/resources/assets/admin/common/js/ui/time/DateTimePicker.ts
+++ b/src/main/resources/assets/admin/common/js/ui/time/DateTimePicker.ts
@@ -1,4 +1,3 @@
-import {Timezone} from '../../util/Timezone';
 import {TextInput} from '../text/TextInput';
 import {KeyHelper} from '../KeyHelper';
 import {StringHelper} from '../../util/StringHelper';
@@ -18,14 +17,11 @@ export class DateTimePickerBuilder
 
     dateTime: Date;
 
-    timezone: Timezone;
-
     startingDayOfWeek: DayOfWeek = DaysOfWeek.MONDAY;
 
     closeOnSelect: boolean = false;
 
-    // use local timezone if timezone value is not initialized
-    useLocalTimezoneIfNotPresent: boolean = false;
+    useLocalTimezone: boolean = false;
 
     inputPlaceholder: string = 'YYYY-MM-DD hh:mm';
 
@@ -62,18 +58,13 @@ export class DateTimePickerBuilder
         return this;
     }
 
-    setTimezone(value: Timezone): DateTimePickerBuilder {
-        this.timezone = value;
-        return this;
-    }
-
     setCloseOnSelect(value: boolean): DateTimePickerBuilder {
         this.closeOnSelect = value;
         return this;
     }
 
-    setUseLocalTimezoneIfNotPresent(value: boolean): DateTimePickerBuilder {
-        this.useLocalTimezoneIfNotPresent = value;
+    setUseLocalTimezone(value: boolean): DateTimePickerBuilder {
+        this.useLocalTimezone = value;
         return this;
     }
 
@@ -139,12 +130,8 @@ export class DateTimePicker
             popupBuilder.setDefaultTime(this.builder.defaultTime);
         }
 
-        if (this.builder.timezone) {
-            popupBuilder.setTimezone(this.builder.timezone);
-        }
-
-        if (this.builder.useLocalTimezoneIfNotPresent) {
-            popupBuilder.setUseLocalTimezoneIfNotPresent(true);
+        if (this.builder.useLocalTimezone) {
+            popupBuilder.setUseLocalTimezone(true);
         }
 
         if (this.builder.defaultValue) {

--- a/src/main/resources/assets/admin/common/js/ui/time/DateTimePickerPopup.ts
+++ b/src/main/resources/assets/admin/common/js/ui/time/DateTimePickerPopup.ts
@@ -19,18 +19,11 @@ export class DateTimePickerPopupBuilder {
 
     defaultValue: Date;
 
-    hours: number;
-
-    minutes: number;
-
     date: Date;
-
-    timezone: Timezone;
 
     defaultTime: TimeHM;
 
-    // use local timezone if timezone value is not initialized
-    useLocalTimezoneIfNotPresent: boolean = false;
+    useLocalTimezone: boolean = false;
 
     setManageDate(value: boolean): DateTimePickerPopupBuilder {
         this.manageDate = value;
@@ -65,13 +58,8 @@ export class DateTimePickerPopupBuilder {
         return this.date?.getMinutes();
     }
 
-    setTimezone(value: Timezone): DateTimePickerPopupBuilder {
-        this.timezone = value;
-        return this;
-    }
-
-    setUseLocalTimezoneIfNotPresent(value: boolean): DateTimePickerPopupBuilder {
-        this.useLocalTimezoneIfNotPresent = value;
+    setUseLocalTimezone(value: boolean): DateTimePickerPopupBuilder {
+        this.useLocalTimezone = value;
         return this;
     }
 
@@ -80,12 +68,8 @@ export class DateTimePickerPopupBuilder {
         return this;
     }
 
-    isUseLocalTimezoneIfNotPresent(): boolean {
-        return this.useLocalTimezoneIfNotPresent;
-    }
-
-    getTimezone(): Timezone {
-        return this.timezone;
+    isUseLocalTimezone(): boolean {
+        return this.useLocalTimezone;
     }
 
     build(): DateTimePickerPopup {
@@ -125,11 +109,18 @@ export class DateTimePickerPopup
             this.timePickerPopup =
                 new TimePickerPopupBuilder()
                     .setHours(builder.getHours())
-                    .setTimezone(builder.timezone)
-                    .setUseLocalTimezoneIfNotPresent(builder.useLocalTimezoneIfNotPresent)
+                    .setUseLocalTimezone(builder.useLocalTimezone)
                     .setMinutes(builder.getMinutes())
                     .setDefaultTime(builder.defaultTime)
                     .build();
+        }
+
+        if (builder.manageDate && builder.manageTime && builder.useLocalTimezone) {
+            this.timePickerPopup.updateLocalTimezoneByDate(this.getSelectedDateTime());
+
+            this.onSelectedDateChanged((event) => {
+                this.timePickerPopup.updateLocalTimezoneByDate(event.getDate());
+            });
         }
     }
 

--- a/src/main/resources/assets/admin/common/js/ui/time/DateTimeRangePicker.ts
+++ b/src/main/resources/assets/admin/common/js/ui/time/DateTimeRangePicker.ts
@@ -3,7 +3,6 @@ import {DivEl} from '../../dom/DivEl';
 import {Element} from '../../dom/Element';
 import {LabelEl} from '../../dom/LabelEl';
 import {TimeHM} from '../../util/TimeHM';
-import {Timezone} from '../../util/Timezone';
 import {DateTimePicker, DateTimePickerBuilder} from './DateTimePicker';
 import {DayOfWeek} from './DayOfWeek';
 import {DaysOfWeek} from './DaysOfWeek';
@@ -31,10 +30,7 @@ export class DateTimeRangePickerBuilder {
 
     closeOnSelect: boolean = false;
 
-    timezone: Timezone;
-
-    // use local timezone if timezone value is not initialized
-    useLocalTimezoneIfNotPresent: boolean = false;
+    useLocalTimezone: boolean = false;
 
     setStartDate(value: Date): DateTimeRangePickerBuilder {
         this.startDate = value;
@@ -61,18 +57,13 @@ export class DateTimeRangePickerBuilder {
         return this;
     }
 
-    setTimezone(value: Timezone): DateTimeRangePickerBuilder {
-        this.timezone = value;
-        return this;
-    }
-
     setCloseOnSelect(value: boolean): DateTimeRangePickerBuilder {
         this.closeOnSelect = value;
         return this;
     }
 
-    setUseLocalTimezoneIfNotPresent(value: boolean): DateTimeRangePickerBuilder {
-        this.useLocalTimezoneIfNotPresent = value;
+    setUseLocalTimezone(value: boolean): DateTimeRangePickerBuilder {
+        this.useLocalTimezone = value;
         return this;
     }
 
@@ -113,9 +104,7 @@ interface DateTimeConfig {
 
     closeOnSelect: boolean;
 
-    timezone: Timezone;
-
-    useLocalTimezoneIfNotPresent: boolean;
+    useLocalTimezone: boolean;
 
 }
 
@@ -136,8 +125,7 @@ export class DateTimeRangePicker
         const basePickerConfig: DateTimeConfig = {
             startingDayOfWeek: builder.startingDayOfWeek,
             closeOnSelect: builder.closeOnSelect,
-            timezone: builder.timezone,
-            useLocalTimezoneIfNotPresent: builder.useLocalTimezoneIfNotPresent
+            useLocalTimezone: builder.useLocalTimezone
         }
 
         const startPickerConfig: DateTimeConfig = {
@@ -224,8 +212,7 @@ export class DateTimeRangePicker
         return new DateTimePickerBuilder()
             .setStartingDayOfWeek(config.startingDayOfWeek)
             .setCloseOnSelect(config.closeOnSelect)
-            .setUseLocalTimezoneIfNotPresent(config.useLocalTimezoneIfNotPresent)
-            .setTimezone(config.timezone);
+            .setUseLocalTimezone(config.useLocalTimezone)
     }
 
     private createPicker(config: DateTimeConfig): DateTimePicker {

--- a/src/main/resources/assets/admin/common/js/ui/time/TimePickerPopup.ts
+++ b/src/main/resources/assets/admin/common/js/ui/time/TimePickerPopup.ts
@@ -14,10 +14,7 @@ export class TimePickerPopupBuilder {
 
     minutes: number;
 
-    timezone: Timezone;
-
-    // use local timezone if timezone value is not initialized
-    useLocalTimezoneIfNotPresent: boolean = false;
+    useLocalTimezone: boolean = false;
 
     defaultTime: TimeHM;
 
@@ -39,22 +36,13 @@ export class TimePickerPopupBuilder {
         return this.minutes;
     }
 
-    setTimezone(value: Timezone): TimePickerPopupBuilder {
-        this.timezone = value;
+    setUseLocalTimezone(value: boolean): TimePickerPopupBuilder {
+        this.useLocalTimezone = value;
         return this;
     }
 
-    getTimezone(): Timezone {
-        return this.timezone;
-    }
-
-    setUseLocalTimezoneIfNotPresent(value: boolean): TimePickerPopupBuilder {
-        this.useLocalTimezoneIfNotPresent = value;
-        return this;
-    }
-
-    isUseLocalTimezoneIfNotPresent(): boolean {
-        return this.useLocalTimezoneIfNotPresent;
+    isUseLocalTimezone(): boolean {
+        return this.useLocalTimezone;
     }
 
     setDefaultTime(value: TimeHM): TimePickerPopupBuilder {
@@ -89,8 +77,7 @@ export class TimePickerPopup
     private selectedMinute: number;
     private interval: number;
 
-    private timezone?: Timezone;
-    private useLocalTimezoneIfNotPresent: boolean = false;
+    private useLocalTimezone: boolean = false;
 
     private timeChangedListeners: ((time: TimeHM) => void)[] = [];
     private builder: TimePickerPopupBuilder;
@@ -111,16 +98,11 @@ export class TimePickerPopup
         this.minute = new SpanEl();
         this.prevMinute = new AEl('prev');
 
-        this.useLocalTimezoneIfNotPresent = this.builder.useLocalTimezoneIfNotPresent;
-        this.timezone = this.builder.timezone;
+        this.useLocalTimezone = this.builder.isUseLocalTimezone();
 
-        if (!this.timezone && this.useLocalTimezoneIfNotPresent) {
-            this.timezone = Timezone.getLocalTimezone();
-        }
-
-        if (this.timezone) {
-            this.timezoneLocation = new SpanEl('timezone-location').setHtml(this.timezone.getLocation());
-            this.timezoneOffset = new SpanEl('timezone-offset').setHtml(this.getUTCString(this.timezone.getOffset()));
+        if (this.useLocalTimezone) {
+            this.timezoneLocation = new SpanEl('timezone-location');
+            this.timezoneOffset = new SpanEl('timezone-offset'); // .setHtml(this.getUTCString(this.timezone.getOffset()))
         }
 
         this.presetTime();
@@ -214,6 +196,13 @@ export class TimePickerPopup
         }
     }
 
+    updateLocalTimezoneByDate(date: Date): void {
+        if (this.useLocalTimezone) {
+            const timezone = Timezone.getDateTimezone(date);
+            this.timezoneOffset.setHtml(this.getUTCString(timezone.getOffset()));
+        }
+    }
+
     private startInterval(fn: (add: number, silent?: boolean) => void, ...args: any[]) {
         let times: number = 0;
         let delay: number = 400;
@@ -304,7 +293,7 @@ export class TimePickerPopup
 
             minuteContainer.appendChildren(this.nextMinute, this.minute, this.prevMinute);
 
-            if (this.timezone) {
+            if (this.useLocalTimezone) {
                 const timezoneContainer: LiEl = new LiEl('timezone');
                 timezoneContainer.appendChild(this.timezoneLocation);
                 timezoneContainer.appendChild(this.timezoneOffset);

--- a/src/main/resources/assets/admin/common/js/util/DateHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/DateHelper.ts
@@ -10,7 +10,11 @@ export class DateHelper {
     }
 
     public static getTZOffset(): number {
-        return new Date().getTimezoneOffset() / -60;
+        return DateHelper.getTZOffsetForDate(new Date());
+    }
+
+    public static getTZOffsetForDate(date: Date): number {
+        return date.getTimezoneOffset() / -60;
     }
 
     // returns true if passed date uses daylight savings time

--- a/src/main/resources/assets/admin/common/js/util/DateTime.ts
+++ b/src/main/resources/assets/admin/common/js/util/DateTime.ts
@@ -15,23 +15,21 @@ export class DateTime
 
     private static FRACTION_SEPARATOR: string = '.';
 
-    private static DEFAULT_TIMEZONE: string = '+00:00';
+    private readonly year: number;
 
-    private year: number;
+    private readonly month: number; // 0-11
 
-    private month: number; // 0-11
+    private readonly day: number;
 
-    private day: number;
+    private readonly hours: number;
 
-    private hours: number;
+    private readonly minutes: number;
 
-    private minutes: number;
+    private readonly seconds: number;
 
-    private seconds: number;
+    private readonly fractions: number;
 
-    private fractions: number;
-
-    private timezone: Timezone;
+    private readonly timezone: Timezone;
 
     constructor(builder: DateTimeBuilder) {
         this.year = builder.year;
@@ -41,7 +39,7 @@ export class DateTime
         this.minutes = builder.minutes;
         this.seconds = builder.seconds;
         this.fractions = builder.fractions;
-        this.timezone = builder.timezone;
+        this.timezone = builder.timezone || Timezone.getZeroOffsetTimezone();
     }
 
     static isValidDateTime(s: string): boolean {
@@ -56,7 +54,7 @@ export class DateTime
         2015-02-29T12:05:59+01:00
         2015-02-29T12:05:59.001+01:00
         */
-         
+
         const regex = /^(\d{2}|\d{4})(?:\-)?([0]{1}\d{1}|[1]{1}[0-2]{1})(?:\-)?([0-2]{1}\d{1}|[3]{1}[0-1]{1})(T)([0-1]{1}\d{1}|[2]{1}[0-3]{1})(?::)?([0-5]{1}\d{1})((:[0-5]{1}\d{1})(\.\d{3})?)?((\+|\-)([0-1]{1}\d{1}|[2]{1}[0-3]{1})(:)([0-5]{1}\d{1})|(z|Z)|$)$/;
         return regex.test(s);
     }
@@ -76,7 +74,7 @@ export class DateTime
 
         if (DateHelper.isUTCdate(s)) {
             date = DateHelper.makeDateFromUTCString(s);
-            timezone = Timezone.getLocalTimezone();
+            timezone = Timezone.getDateTimezone(date);
             if (DateHelper.isDST(date)) { // when converting from UTC date, Date object may have an extra hour added due to DST
                 date.setHours(date.getHours() - 1);
             }
@@ -123,7 +121,7 @@ export class DateTime
             .setMinutes(s.getMinutes())
             .setSeconds(s.getSeconds())
             .setFractions(s.getMilliseconds())
-            .setTimezone(Timezone.getLocalTimezone())// replace with timezone picker value if implemented tz selection
+            .setTimezone(Timezone.getDateTimezone(s))// replace with timezone picker value if implemented tz selection
             .build();
     }
 
@@ -232,8 +230,7 @@ export class DateTime
 
     /** Returns date in ISO format. Month value is incremented because ISO month range is 1-12, whereas JS Date month range is 0-11 */
     toString(): string {
-        return this.dateToString() + DateTime.DATE_TIME_SEPARATOR + this.timeToString() +
-               (this.timezone ? this.timezone.toString() : DateTime.DEFAULT_TIMEZONE);
+        return this.dateToString() + DateTime.DATE_TIME_SEPARATOR + this.timeToString() + this.timezone.toString();
     }
 
     equals(o: Equitable): boolean {

--- a/src/main/resources/assets/admin/common/js/util/Timezone.ts
+++ b/src/main/resources/assets/admin/common/js/util/Timezone.ts
@@ -45,6 +45,10 @@ export class Timezone
         return Timezone.fromOffset(DateHelper.getTZOffset());
     }
 
+    static getDateTimezone(date: Date): Timezone {
+        return Timezone.fromOffset(DateHelper.getTZOffsetForDate(date));
+    }
+
     static getZeroOffsetTimezone(): Timezone {
         return Timezone.create().setOffset(0).build();
     }


### PR DESCRIPTION
- TimePickerPopup now uses selected date's offset (+ 1 for wintertime and +2 for summertime)
- Key change is to stop using today's date timezone offset as default and to use the offset value of the selected date. The issue was that when parsing and initializing saved DateTime value (which is saved in UTC format, '2025-09-15T12:00:00Z' for example) we've been using TODAY's date offset and not the one from the actual value