### PR TITLE
Fix inputTypeConfig type — introduce RawInputConfig and handle undefined #4289

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormContext.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormContext.ts
@@ -1,6 +1,6 @@
 import {PropertyPath} from '../data/PropertyPath';
 import {InputTypeViewContext} from './inputtype/InputTypeViewContext';
-import {Input} from './Input';
+import {Input, type RawInputConfig} from './Input';
 import {FormState} from '../app/wizard/WizardPanel';
 import {ValidationError} from '../ValidationError';
 import {AiToolType} from '../ai/tool/AiToolType';
@@ -40,7 +40,7 @@ export class FormContext {
         this.showEmptyFormItemSetOccurrences = value;
     }
 
-    createInputTypeViewContext(inputTypeConfig: any, parentPropertyPath: PropertyPath,
+    createInputTypeViewContext(inputTypeConfig: RawInputConfig, parentPropertyPath: PropertyPath,
                                input: Input): InputTypeViewContext {
 
         return {

--- a/src/main/resources/assets/admin/common/js/form/Input.ts
+++ b/src/main/resources/assets/admin/common/js/form/Input.ts
@@ -6,6 +6,8 @@ import {InputTypeName} from './InputTypeName';
 import {Occurrences} from './Occurrences';
 import {FormItem} from './FormItem';
 
+export type RawInputConfig = Record<string, Record<string, unknown>[]>;
+
 export class InputBuilder {
 
     name: string;
@@ -18,7 +20,7 @@ export class InputBuilder {
 
     helpText: string;
 
-    inputTypeConfig: object;
+    inputTypeConfig: RawInputConfig | undefined;
 
     setName(value: string): InputBuilder {
         this.name = value;
@@ -45,7 +47,7 @@ export class InputBuilder {
         return this;
     }
 
-    setInputTypeConfig(value: object): InputBuilder {
+    setInputTypeConfig(value: RawInputConfig | undefined): InputBuilder {
         this.inputTypeConfig = value;
         return this;
     }
@@ -85,7 +87,7 @@ export class Input
 
     private helpText: string;
 
-    private inputTypeConfig: object;
+    private inputTypeConfig: RawInputConfig | undefined;
 
     constructor(builder: InputBuilder) {
         super(builder.name);
@@ -118,7 +120,7 @@ export class Input
         return this.helpText;
     }
 
-    getInputTypeConfig(): object {
+    getInputTypeConfig(): RawInputConfig | undefined {
         return this.inputTypeConfig;
     }
 

--- a/src/main/resources/assets/admin/common/js/form/InputView.ts
+++ b/src/main/resources/assets/admin/common/js/form/InputView.ts
@@ -316,7 +316,7 @@ export class InputView
     protected createInputTypeView(): InputTypeView {
         let inputType: InputTypeName = this.input.getInputType();
         let inputTypeViewContext = this.getContext().createInputTypeViewContext(
-            this.input.getInputTypeConfig() || {},
+            this.input.getInputTypeConfig() ?? {},
             this.parentPropertySet.getPropertyPath(),
             this.input
         );

--- a/src/main/resources/assets/admin/common/js/form/inputtype/InputTypeViewContext.ts
+++ b/src/main/resources/assets/admin/common/js/form/inputtype/InputTypeViewContext.ts
@@ -1,5 +1,5 @@
 import {FormContext} from '../FormContext';
-import {Input} from '../Input';
+import {Input, type RawInputConfig} from '../Input';
 import {PropertyPath} from '../../data/PropertyPath';
 
 export interface InputTypeViewContext {
@@ -8,7 +8,7 @@ export interface InputTypeViewContext {
 
     input: Input;
 
-    inputConfig: Record<string, Record<string, unknown>[]>;
+    inputConfig: RawInputConfig;
 
     parentDataPath: PropertyPath;
 }

--- a/src/main/resources/assets/admin/common/js/form/json/InputJson.ts
+++ b/src/main/resources/assets/admin/common/js/form/json/InputJson.ts
@@ -12,5 +12,5 @@ export interface InputJson
 
     inputType: string;
 
-    config?: any;
+    config?: Record<string, Record<string, unknown>[]>;
 }

--- a/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
+++ b/src/main/resources/assets/admin/common/js/form/set/FormSetOccurrenceView.ts
@@ -546,7 +546,7 @@ export abstract class FormSetOccurrenceView
     }
 
     private getRadioButtonTextByValue(radioGroup: Input, selectedValue: string): string {
-        const radioButtons: object[] = radioGroup.getInputTypeConfig()['option'];
+        const radioButtons: object[] | undefined = radioGroup.getInputTypeConfig()?.['option'];
         if (!radioButtons) {
             return '';
         }

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/CheckboxDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/CheckboxDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import type {CheckboxConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
 import type {ValidationResult} from './ValidationResult';
@@ -12,7 +13,7 @@ export const CheckboxDescriptor: InputTypeDescriptor<CheckboxConfig> = {
         return ValueTypes.BOOLEAN;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): CheckboxConfig {
+    readConfig(raw: RawInputConfig): CheckboxConfig {
         const alignmentEntry = raw.alignment?.[0];
         return {
             alignment: alignmentEntry ? (alignmentEntry.value as string) || 'LEFT' : 'LEFT',

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/ComboBoxDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/ComboBoxDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import type {ComboBoxConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
 import type {ValidationResult} from './ValidationResult';
@@ -12,7 +13,7 @@ export const ComboBoxDescriptor: InputTypeDescriptor<ComboBoxConfig> = {
         return ValueTypes.STRING;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): ComboBoxConfig {
+    readConfig(raw: RawInputConfig): ComboBoxConfig {
         const optionValues = raw.options || [];
 
         return {

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/DateDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/DateDescriptor.ts
@@ -1,6 +1,7 @@
 import {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {RelativeTimeParser} from '../../form/inputtype/time/RelativeTimeParser';
 import {LocalDate} from '../../util/LocalDate';
 import type {DateConfig} from './InputTypeConfig';
@@ -16,7 +17,7 @@ export const DateDescriptor: InputTypeDescriptor<DateConfig> = {
         return ValueTypes.LOCAL_DATE;
     },
 
-    readConfig(_raw: Record<string, Record<string, unknown>[]>): DateConfig {
+    readConfig(_raw: RawInputConfig): DateConfig {
         return {};
     },
 

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/DateTimeDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/DateTimeDescriptor.ts
@@ -1,6 +1,7 @@
 import {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {RelativeTimeParser} from '../../form/inputtype/time/RelativeTimeParser';
 import {LocalDateTime} from '../../util/LocalDateTime';
 import type {DateTimeConfig} from './InputTypeConfig';
@@ -16,7 +17,7 @@ export const DateTimeDescriptor: InputTypeDescriptor<DateTimeConfig> = {
         return ValueTypes.LOCAL_DATE_TIME;
     },
 
-    readConfig(_raw: Record<string, Record<string, unknown>[]>): DateTimeConfig {
+    readConfig(_raw: RawInputConfig): DateTimeConfig {
         return {
             useTimezone: false,
         };

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/DateTimeRangeDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/DateTimeRangeDescriptor.ts
@@ -2,6 +2,7 @@ import type {PropertySet} from '../../data/PropertySet';
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {LocalDateTime} from '../../util/LocalDateTime';
 import type {DateTimeRangeConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
@@ -14,7 +15,7 @@ export const DateTimeRangeDescriptor: InputTypeDescriptor<DateTimeRangeConfig> =
         return ValueTypes.DATA;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): DateTimeRangeConfig {
+    readConfig(raw: RawInputConfig): DateTimeRangeConfig {
         const readVal = (name: string): string => {
             return (raw[name]?.[0]?.value as string) ?? '';
         };

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/DoubleDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/DoubleDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {NumberHelper} from '../../util/NumberHelper';
 import type {NumberConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
@@ -13,7 +14,7 @@ export const DoubleDescriptor: InputTypeDescriptor<NumberConfig> = {
         return ValueTypes.DOUBLE;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): NumberConfig {
+    readConfig(raw: RawInputConfig): NumberConfig {
         return {
             min: (raw.min?.[0]?.value as number) ?? undefined,
             max: (raw.max?.[0]?.value as number) ?? undefined,

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/GeoPointDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/GeoPointDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import type {GeoPointConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
 import type {ValidationResult} from './ValidationResult';
@@ -12,7 +13,7 @@ export const GeoPointDescriptor: InputTypeDescriptor<GeoPointConfig> = {
         return ValueTypes.GEO_POINT;
     },
 
-    readConfig(_raw: Record<string, Record<string, unknown>[]>): GeoPointConfig {
+    readConfig(_raw: RawInputConfig): GeoPointConfig {
         return {};
     },
 

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/InputTypeDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/InputTypeDescriptor.ts
@@ -1,5 +1,6 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
+import type {RawInputConfig} from '../../form/Input';
 import type {InputTypeConfig} from './InputTypeConfig';
 import type {ValidationResult} from './ValidationResult';
 
@@ -19,7 +20,7 @@ export type InputTypeDescriptor<C extends InputTypeConfig = InputTypeConfig> = {
     getValueType(): ValueType;
 
     /** Parse raw inputConfig into a typed config object. */
-    readConfig(raw: Record<string, Record<string, unknown>[]>): C;
+    readConfig(raw: RawInputConfig): C;
 
     /** Create a typed default Value from the raw default config value. */
     createDefaultValue(raw: unknown): Value;

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/LongDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/LongDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {NumberHelper} from '../../util/NumberHelper';
 import type {NumberConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
@@ -13,7 +14,7 @@ export const LongDescriptor: InputTypeDescriptor<NumberConfig> = {
         return ValueTypes.LONG;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): NumberConfig {
+    readConfig(raw: RawInputConfig): NumberConfig {
         return {
             min: (raw.min?.[0]?.value as number) ?? undefined,
             max: (raw.max?.[0]?.value as number) ?? undefined,

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/PrincipalSelectorDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/PrincipalSelectorDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {PrincipalKey} from '../../security/PrincipalKey';
 import {PrincipalType} from '../../security/PrincipalType';
 import type {PrincipalSelectorConfig} from './InputTypeConfig';
@@ -14,7 +15,7 @@ export const PrincipalSelectorDescriptor: InputTypeDescriptor<PrincipalSelectorC
         return ValueTypes.REFERENCE;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): PrincipalSelectorConfig {
+    readConfig(raw: RawInputConfig): PrincipalSelectorConfig {
         const principalTypeEntries = raw.principalType || [];
         const skipPrincipalsEntries = raw.skipPrincipals || [];
 

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/RadioButtonDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/RadioButtonDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import type {RadioButtonConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
 import type {ValidationResult} from './ValidationResult';
@@ -12,7 +13,7 @@ export const RadioButtonDescriptor: InputTypeDescriptor<RadioButtonConfig> = {
         return ValueTypes.STRING;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): RadioButtonConfig {
+    readConfig(raw: RawInputConfig): RadioButtonConfig {
         const optionValues = raw.options || [];
 
         return {

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/TextAreaDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/TextAreaDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {StringHelper} from '../../util/StringHelper';
 import type {TextAreaConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
@@ -13,7 +14,7 @@ export const TextAreaDescriptor: InputTypeDescriptor<TextAreaConfig> = {
         return ValueTypes.STRING;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): TextAreaConfig {
+    readConfig(raw: RawInputConfig): TextAreaConfig {
         const maxLengthVal = Number(raw.maxLength?.[0]?.value);
         const showCounter = (raw.showCounter?.[0]?.value as boolean) || false;
 

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/TextLineDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/TextLineDescriptor.ts
@@ -1,6 +1,7 @@
 import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {i18n} from '../../util/Messages';
 import {StringHelper} from '../../util/StringHelper';
 import type {TextLineConfig} from './InputTypeConfig';
@@ -14,7 +15,7 @@ export const TextLineDescriptor: InputTypeDescriptor<TextLineConfig> = {
         return ValueTypes.STRING;
     },
 
-    readConfig(raw: Record<string, Record<string, unknown>[]>): TextLineConfig {
+    readConfig(raw: RawInputConfig): TextLineConfig {
         const maxLengthVal = Number(raw.maxLength?.[0]?.value);
         const showCounter = (raw.showCounter?.[0]?.value as boolean) || false;
 

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/TimeDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/TimeDescriptor.ts
@@ -1,6 +1,7 @@
 import {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
+import type {RawInputConfig} from '../../form/Input';
 import {RelativeTimeParser} from '../../form/inputtype/time/RelativeTimeParser';
 import {LocalTime} from '../../util/LocalTime';
 import type {TimeConfig} from './InputTypeConfig';
@@ -16,7 +17,7 @@ export const TimeDescriptor: InputTypeDescriptor<TimeConfig> = {
         return ValueTypes.LOCAL_TIME;
     },
 
-    readConfig(_raw: Record<string, Record<string, unknown>[]>): TimeConfig {
+    readConfig(_raw: RawInputConfig): TimeConfig {
         return {};
     },
 

--- a/src/main/resources/assets/admin/common/js/form2/hooks/useInputTypeDescriptor.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/hooks/useInputTypeDescriptor.test.ts
@@ -21,14 +21,14 @@ vi.mock('../../store/Store', () => {
 });
 
 import {ValueTypes} from '../../data/ValueTypes';
-import {type Input, InputBuilder} from '../../form/Input';
+import {type Input, InputBuilder, type RawInputConfig} from '../../form/Input';
 import {InputTypeName} from '../../form/InputTypeName';
 import {Occurrences} from '../../form/Occurrences';
 import {DescriptorRegistry} from '../descriptor/DescriptorRegistry';
 import type {TextLineConfig} from '../descriptor/InputTypeConfig';
 import {initBuiltInDescriptors} from '../descriptor/initBuiltInDescriptors';
 
-function makeInput(typeName: string, config: object = {}): Input {
+function makeInput(typeName: string, config: RawInputConfig | undefined = {}): Input {
     return new InputBuilder()
         .setName('testField')
         .setInputType(new InputTypeName(typeName, false))
@@ -58,9 +58,7 @@ describe('useInputTypeDescriptor — logic', () => {
             expect(descriptor?.name).toBe('TextLine');
             expect(descriptor?.getValueType()).toBe(ValueTypes.STRING);
 
-            const config = descriptor?.readConfig(
-                input.getInputTypeConfig() as Record<string, Record<string, unknown>[]>,
-            );
+            const config = descriptor?.readConfig(input.getInputTypeConfig() ?? {});
             expect(config?.maxLength).toBe(100);
         });
 
@@ -68,9 +66,7 @@ describe('useInputTypeDescriptor — logic', () => {
             const input = makeInput('TextLine', {regexp: [{value: '^[A-Z]+$'}]});
             const descriptor = DescriptorRegistry.get<TextLineConfig>(input.getInputType().getName());
 
-            const config = descriptor?.readConfig(
-                input.getInputTypeConfig() as Record<string, Record<string, unknown>[]>,
-            );
+            const config = descriptor?.readConfig(input.getInputTypeConfig() ?? {});
             expect(config?.regexp).toBeInstanceOf(RegExp);
             expect(config?.regexp?.source).toBe('^[A-Z]+$');
         });
@@ -105,9 +101,17 @@ describe('useInputTypeDescriptor — logic', () => {
             const input = makeInput('TextLine', {});
             const descriptor = DescriptorRegistry.get<TextLineConfig>(input.getInputType().getName());
 
-            const config = descriptor?.readConfig(
-                input.getInputTypeConfig() as Record<string, Record<string, unknown>[]>,
-            );
+            const config = descriptor?.readConfig(input.getInputTypeConfig() ?? {});
+            expect(config?.regexp).toBeUndefined();
+            expect(config?.maxLength).toBe(-1);
+            expect(config?.showCounter).toBe(false);
+        });
+
+        it('handles undefined config gracefully', () => {
+            const input = makeInput('TextLine', undefined);
+            const descriptor = DescriptorRegistry.get<TextLineConfig>(input.getInputType().getName());
+
+            const config = descriptor?.readConfig(input.getInputTypeConfig() ?? {});
             expect(config?.regexp).toBeUndefined();
             expect(config?.maxLength).toBe(-1);
             expect(config?.showCounter).toBe(false);

--- a/src/main/resources/assets/admin/common/js/form2/hooks/useInputTypeDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/hooks/useInputTypeDescriptor.ts
@@ -17,7 +17,7 @@ export function useInputTypeDescriptor<C extends InputTypeConfig = InputTypeConf
         const descriptor = DescriptorRegistry.get<C>(input.getInputType().getName());
         if (descriptor == null) return undefined;
 
-        const config = descriptor.readConfig(input.getInputTypeConfig() as Record<string, Record<string, unknown>[]>);
+        const config = descriptor.readConfig(input.getInputTypeConfig() ?? {});
 
         return {descriptor, config};
     }, [input]);


### PR DESCRIPTION
Introduced `RawInputConfig` type alias (`Record<string, Record<string, unknown>[]>`) in `Input.ts` to name XP's wire format for input config properties. Updated `Input.inputTypeConfig` and `InputBuilder` to `RawInputConfig | undefined` — `undefined` is the correct runtime state when the server sends no `config` key. Replaced the unsafe `as` cast in `useInputTypeDescriptor` with `?? {}`, added optional chaining in `FormSetOccurrenceView`, and updated `FormContext.createInputTypeViewContext` parameter from `any` to `RawInputConfig`. Propagated the alias across `InputTypeDescriptor`, `InputTypeViewContext`, and all 13 descriptor implementations. Added a test for undefined config and cleaned up `as` casts from existing test assertions.

Closes #4289

<sub>*Drafted with AI assistance*</sub>