### PR TITLE
Fix occurrence rendering for optional inputs with no data #4293

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.stories.tsx
@@ -123,6 +123,28 @@ export const OptionalEmpty: Story = {
     ),
 };
 
+export const OptionalMultipleEmpty: Story = {
+    name: 'Examples / Optional Multiple Empty',
+    render: () => (
+        <div className='flex flex-col gap-y-4 p-4'>
+            <h3 className='mb-0 font-medium text-sm'>
+                Optional Multiple Empty (0:3) — 1 auto-filled null, no remove button
+            </h3>
+            <OccurrenceList
+                Component={TextLineInput}
+                state={makeState([''], 0, 3)}
+                onAdd={noop}
+                onRemove={noop}
+                onMove={noop}
+                onChange={noop}
+                config={makeConfig()}
+                input={makeInput(0, 3)}
+                enabled={true}
+            />
+        </div>
+    ),
+};
+
 export const RequiredMultiple: Story = {
     name: 'Examples / Required Multiple',
     render: () => (

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -274,7 +274,9 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
         input,
         enabled,
         errors: state.occurrenceValidation[index],
-        showRemove: state.canRemove && !isFixed,
+        // canRemove reflects the schema minimum; the count > 1 guard is a UX policy
+        // matching legacy isRemoveButtonRequiredStrict() — never remove the last visible input.
+        showRemove: state.canRemove && state.values.length > 1 && !isFixed,
         onChange,
         onBlur,
         onRemove,

--- a/src/main/resources/assets/admin/common/js/form2/hooks/useOccurrenceManager.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/hooks/useOccurrenceManager.test.ts
@@ -30,7 +30,7 @@ function createManager(opts: {min?: number; max?: number; values?: string[]} = {
 
 /** Mirrors the minFill computation from useOccurrenceManager. */
 function computeMinFill(occurrences: Occurrences): number {
-    return occurrences.multiple() ? occurrences.getMinimum() : Math.max(occurrences.getMinimum(), 1);
+    return Math.max(occurrences.getMinimum(), 1);
 }
 
 /** Mirrors the guarded fill loop from useOccurrenceManager. */
@@ -62,8 +62,8 @@ describe('useOccurrenceManager — logic', () => {
             expect(computeMinFill(Occurrences.minmax(3, 0))).toBe(3);
         });
 
-        it('returns 0 for unlimited with no minimum', () => {
-            expect(computeMinFill(Occurrences.minmax(0, 0))).toBe(0);
+        it('returns 1 for unlimited with no minimum', () => {
+            expect(computeMinFill(Occurrences.minmax(0, 0))).toBe(1);
         });
 
         it('returns 1 for single required (1:1)', () => {
@@ -95,10 +95,11 @@ describe('useOccurrenceManager — logic', () => {
             expect(manager.getCount()).toBe(2);
         });
 
-        it('does not fill 0:0 (unlimited optional)', () => {
+        it('fills 0:0 (unlimited optional) to 1 null value', () => {
             const {manager, occurrences} = createManager({min: 0, max: 0});
             fillTo(manager, computeMinFill(occurrences));
-            expect(manager.getCount()).toBe(0);
+            expect(manager.getCount()).toBe(1);
+            expect(manager.getValues()[0].isNull()).toBe(true);
         });
 
         it('does not overfill when initial values already meet minimum', () => {
@@ -145,12 +146,13 @@ describe('useOccurrenceManager — logic', () => {
             expect(manager.getCount()).toBe(2);
         });
 
-        it('does not re-fill 0:0 after sync([])', () => {
+        it('re-fills to 1 after sync([]) on a 0:0 field', () => {
             const {manager, occurrences} = createManager({min: 0, max: 0, values: ['a']});
             const minFill = computeMinFill(occurrences);
 
             syncAndFill(manager, [], minFill);
-            expect(manager.getCount()).toBe(0);
+            expect(manager.getCount()).toBe(1);
+            expect(manager.getValues()[0].isNull()).toBe(true);
         });
 
         it('preserves values when sync provides enough', () => {

--- a/src/main/resources/assets/admin/common/js/form2/hooks/useOccurrenceManager.ts
+++ b/src/main/resources/assets/admin/common/js/form2/hooks/useOccurrenceManager.ts
@@ -29,12 +29,9 @@ export function useOccurrenceManager<C extends InputTypeConfig = InputTypeConfig
     config,
     initialValues,
 }: UseOccurrenceManagerParams<C>): UseOccurrenceManagerResult {
-    // Minimum fill target: for non-multiple inputs (max=1), always at least 1 so the bare input
-    // renders immediately — matching legacy behavior where single-optional fields show one input.
-    const minFill = useMemo(
-        () => (occurrences.multiple() ? occurrences.getMinimum() : Math.max(occurrences.getMinimum(), 1)),
-        [occurrences],
-    );
+    // Always show at least 1 input — matches legacy showEmptyFormItemOccurrences() which is
+    // unconditionally true for all Inputs regardless of the occurrence config.
+    const minFill = useMemo(() => Math.max(occurrences.getMinimum(), 1), [occurrences]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: initialValues consumed only on construction
     const manager = useMemo(() => {


### PR DESCRIPTION
Fixed `minFill` in `useOccurrenceManager` to always fill to at least 1 regardless of occurrence config, matching legacy `showEmptyFormItemOccurrences()` which unconditionally created one empty occurrence for all Inputs.

Added `values.length > 1` guard on the remove button in `OccurrenceList`, keeping `canRemove()` as a pure schema-minimum check while applying the "never remove last input" UX policy in the view layer — matching legacy `isRemoveButtonRequiredStrict()`.

Updated tests and added a Storybook story for the `0:3` optional multiple case.

Closes #4293

<sub>*Drafted with AI assistance*</sub>