### PR TITLE
Add CheckboxInput component to form2 #4301

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/CheckboxInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/CheckboxInput.stories.tsx
@@ -1,0 +1,179 @@
+import type {Meta, StoryObj} from '@storybook/preact-vite';
+import {useState} from 'react';
+import type {Value} from '../../../data/Value';
+import {ValueTypes} from '../../../data/ValueTypes';
+import {InputBuilder} from '../../../form/Input';
+import {InputTypeName} from '../../../form/InputTypeName';
+import {OccurrencesBuilder} from '../../../form/Occurrences';
+import type {CheckboxConfig} from '../../descriptor/InputTypeConfig';
+import type {InputTypeComponentProps} from '../../types';
+import {CheckboxInput, type CheckboxInputProps} from './CheckboxInput';
+
+function makeConfig(overrides: Partial<CheckboxConfig> = {}): CheckboxConfig {
+    return {alignment: 'LEFT', ...overrides};
+}
+
+function makeInput(
+    label = 'Accept Terms',
+    minOccurrences = 0,
+): InstanceType<typeof InputBuilder>['build'] extends () => infer R ? R : never {
+    return new InputBuilder()
+        .setName('myCheckbox')
+        .setInputType(new InputTypeName('Checkbox', false))
+        .setLabel(label)
+        .setOccurrences(new OccurrencesBuilder().setMinimum(minOccurrences).setMaximum(1).build())
+        .setHelpText('')
+        .setInputTypeConfig({})
+        .build();
+}
+
+const meta: Meta<InputTypeComponentProps<CheckboxConfig>> = {
+    title: 'InputTypes/CheckboxInput',
+    component: CheckboxInput,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        value: {description: 'Current field value (Value object)'},
+        onChange: {description: 'Callback fired when the value changes'},
+        config: {description: 'Checkbox config: alignment'},
+        input: {description: 'Input descriptor (name, label, occurrences, etc.)'},
+        enabled: {control: 'boolean', description: 'Whether the input is interactive'},
+        index: {description: 'Occurrence index within the form'},
+        errors: {description: 'Array of validation error objects'},
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<InputTypeComponentProps<CheckboxConfig>>;
+
+const defaultArgs: InputTypeComponentProps<CheckboxConfig> = {
+    value: ValueTypes.BOOLEAN.fromJsonValue(false),
+    onChange: v => console.log('onChange', v.getBoolean()),
+    config: makeConfig(),
+    input: makeInput(),
+    enabled: true,
+    index: 0,
+    errors: [],
+};
+
+export const Default: Story = {
+    name: 'Examples / Default',
+    args: {...defaultArgs},
+};
+
+export const Checked: Story = {
+    name: 'Examples / Checked',
+    args: {
+        ...defaultArgs,
+        value: ValueTypes.BOOLEAN.fromJsonValue(true),
+    },
+};
+
+export const AlignRight: Story = {
+    name: 'Examples / Align Right',
+    args: {
+        ...defaultArgs,
+        config: makeConfig({alignment: 'RIGHT'}),
+    },
+};
+
+export const AlignTop: Story = {
+    name: 'Examples / Align Top',
+    args: {
+        ...defaultArgs,
+        config: makeConfig({alignment: 'TOP'}),
+    },
+};
+
+export const AlignBottom: Story = {
+    name: 'Examples / Align Bottom',
+    args: {
+        ...defaultArgs,
+        config: makeConfig({alignment: 'BOTTOM'}),
+    },
+};
+
+export const Disabled: Story = {
+    name: 'States / Disabled',
+    args: {
+        ...defaultArgs,
+        enabled: false,
+    },
+};
+
+export const DisabledChecked: Story = {
+    name: 'States / Disabled Checked',
+    args: {
+        ...defaultArgs,
+        value: ValueTypes.BOOLEAN.fromJsonValue(true),
+        enabled: false,
+    },
+};
+
+export const WithError: Story = {
+    name: 'States / With Error',
+    args: {
+        ...defaultArgs,
+        errors: [{message: 'This field is required'}],
+    },
+};
+
+export const Required: Story = {
+    name: 'States / Required',
+    args: {
+        ...defaultArgs,
+        input: makeInput('I agree to the terms', 1),
+    },
+};
+
+function StatefulCheckbox(props: Omit<CheckboxInputProps, 'onChange'> & {initialValue?: Value}) {
+    const [value, setValue] = useState(props.initialValue ?? props.value);
+    return <CheckboxInput {...props} value={value} onChange={setValue} />;
+}
+
+export const AllStates: Story = {
+    name: 'States / All States',
+    render: () => (
+        <div className='w-80 space-y-6 p-4'>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Unchecked</h3>
+                <StatefulCheckbox {...defaultArgs} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Checked</h3>
+                <StatefulCheckbox {...defaultArgs} initialValue={ValueTypes.BOOLEAN.fromJsonValue(true)} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Align Right</h3>
+                <StatefulCheckbox {...defaultArgs} config={makeConfig({alignment: 'RIGHT'})} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Align Top</h3>
+                <StatefulCheckbox {...defaultArgs} config={makeConfig({alignment: 'TOP'})} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Align Bottom</h3>
+                <StatefulCheckbox {...defaultArgs} config={makeConfig({alignment: 'BOTTOM'})} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Disabled</h3>
+                <StatefulCheckbox {...defaultArgs} enabled={false} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Disabled Checked</h3>
+                <StatefulCheckbox
+                    {...defaultArgs}
+                    initialValue={ValueTypes.BOOLEAN.fromJsonValue(true)}
+                    enabled={false}
+                />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Error</h3>
+                <StatefulCheckbox {...defaultArgs} errors={[{message: 'This field is required'}]} />
+            </div>
+        </div>
+    ),
+};

--- a/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/CheckboxInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/CheckboxInput.test.ts
@@ -1,0 +1,140 @@
+import {describe, expect, it} from 'vitest';
+import type {Value} from '../../../data/Value';
+import {ValueTypes} from '../../../data/ValueTypes';
+import {InputBuilder} from '../../../form/Input';
+import {InputTypeName} from '../../../form/InputTypeName';
+import {OccurrencesBuilder} from '../../../form/Occurrences';
+import type {CheckboxConfig} from '../../descriptor/InputTypeConfig';
+
+//
+// * Helpers
+//
+
+function _makeConfig(overrides: Partial<CheckboxConfig> = {}): CheckboxConfig {
+    return {alignment: 'LEFT', ...overrides};
+}
+
+function makeInput(minOccurrences = 0) {
+    return new InputBuilder()
+        .setName('myCheckbox')
+        .setInputType(new InputTypeName('Checkbox', false))
+        .setLabel('Accept Terms')
+        .setOccurrences(new OccurrencesBuilder().setMinimum(minOccurrences).setMaximum(1).build())
+        .setHelpText('')
+        .setInputTypeConfig({})
+        .build();
+}
+
+/** Simulate handleCheckedChange logic from the component. */
+function simulateCheckedChange(checked: boolean | 'indeterminate', isRequired: boolean): Value {
+    if (checked === true) {
+        return ValueTypes.BOOLEAN.fromJsonValue(true);
+    }
+    return isRequired ? ValueTypes.BOOLEAN.newNullValue() : ValueTypes.BOOLEAN.fromJsonValue(false);
+}
+
+/** Simulate isChecked derivation from the component. */
+function deriveIsChecked(value: Value): boolean {
+    return value.isNull() ? false : (value.getBoolean() ?? false);
+}
+
+describe('CheckboxInput', () => {
+    describe('value transformation', () => {
+        it('should produce false for null value', () => {
+            const value = ValueTypes.BOOLEAN.newNullValue();
+
+            expect(value.isNull()).toBe(true);
+            expect(deriveIsChecked(value)).toBe(false);
+        });
+
+        it('should produce true for boolean true value', () => {
+            const value = ValueTypes.BOOLEAN.fromJsonValue(true);
+
+            expect(value.isNull()).toBe(false);
+            expect(deriveIsChecked(value)).toBe(true);
+        });
+
+        it('should produce false for boolean false value', () => {
+            const value = ValueTypes.BOOLEAN.fromJsonValue(false);
+
+            expect(value.isNull()).toBe(false);
+            expect(deriveIsChecked(value)).toBe(false);
+        });
+    });
+
+    describe('handleCheckedChange logic', () => {
+        it('should create true Value when checked', () => {
+            const result = simulateCheckedChange(true, false);
+
+            expect(result.isNull()).toBe(false);
+            expect(result.getBoolean()).toBe(true);
+            expect(result.getType()).toBe(ValueTypes.BOOLEAN);
+        });
+
+        it('should create false Value when unchecked (optional)', () => {
+            const result = simulateCheckedChange(false, false);
+
+            expect(result.isNull()).toBe(false);
+            expect(result.getBoolean()).toBe(false);
+            expect(result.getType()).toBe(ValueTypes.BOOLEAN);
+        });
+
+        it('should create null Value when unchecked (required)', () => {
+            const result = simulateCheckedChange(false, true);
+
+            expect(result.isNull()).toBe(true);
+            expect(result.getType()).toBe(ValueTypes.BOOLEAN);
+        });
+
+        it('should treat indeterminate as unchecked (optional)', () => {
+            const result = simulateCheckedChange('indeterminate', false);
+
+            expect(result.isNull()).toBe(false);
+            expect(result.getBoolean()).toBe(false);
+        });
+
+        it('should treat indeterminate as unchecked (required)', () => {
+            const result = simulateCheckedChange('indeterminate', true);
+
+            expect(result.isNull()).toBe(true);
+        });
+    });
+
+    describe('isRequired derivation', () => {
+        it('should be required when minimum occurrences > 0', () => {
+            const input = makeInput(1);
+            expect(input.getOccurrences().getMinimum()).toBeGreaterThan(0);
+        });
+
+        it('should not be required when minimum occurrences is 0', () => {
+            const input = makeInput(0);
+            expect(input.getOccurrences().getMinimum()).toBe(0);
+        });
+    });
+
+    describe('round-trip: check → uncheck → check', () => {
+        it('optional checkbox: false → true → false', () => {
+            const v0 = ValueTypes.BOOLEAN.fromJsonValue(false);
+            expect(deriveIsChecked(v0)).toBe(false);
+
+            const v1 = simulateCheckedChange(true, false);
+            expect(deriveIsChecked(v1)).toBe(true);
+
+            const v2 = simulateCheckedChange(false, false);
+            expect(deriveIsChecked(v2)).toBe(false);
+            expect(v2.isNull()).toBe(false);
+        });
+
+        it('required checkbox: null → true → null', () => {
+            const v0 = ValueTypes.BOOLEAN.newNullValue();
+            expect(deriveIsChecked(v0)).toBe(false);
+
+            const v1 = simulateCheckedChange(true, true);
+            expect(deriveIsChecked(v1)).toBe(true);
+
+            const v2 = simulateCheckedChange(false, true);
+            expect(deriveIsChecked(v2)).toBe(false);
+            expect(v2.isNull()).toBe(true);
+        });
+    });
+});

--- a/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/CheckboxInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/CheckboxInput.tsx
@@ -1,0 +1,47 @@
+import {Checkbox} from '@enonic/ui';
+import type {ReactElement} from 'react';
+
+import {ValueTypes} from '../../../data/ValueTypes';
+import type {Alignment, CheckboxConfig} from '../../descriptor/InputTypeConfig';
+import type {InputTypeComponentProps} from '../../types';
+import {getFirstError} from '../../utils';
+
+const CHECKBOX_INPUT_NAME = 'CheckboxInput';
+
+const ALIGNMENT_CLASSES: Record<Alignment, string | undefined> = {
+    LEFT: undefined,
+    RIGHT: 'flex-row-reverse justify-end',
+    TOP: 'flex-col items-start',
+    BOTTOM: 'flex-col-reverse items-start',
+};
+
+export type CheckboxInputProps = InputTypeComponentProps<CheckboxConfig>;
+
+export const CheckboxInput = ({value, onChange, config, input, enabled, errors}: CheckboxInputProps): ReactElement => {
+    const isChecked = value.isNull() ? false : (value.getBoolean() ?? false);
+    const isRequired = input.getOccurrences().getMinimum() > 0;
+
+    const handleCheckedChange = (checked: boolean | 'indeterminate') => {
+        if (checked === true) {
+            onChange(ValueTypes.BOOLEAN.fromJsonValue(true));
+        } else {
+            onChange(isRequired ? ValueTypes.BOOLEAN.newNullValue() : ValueTypes.BOOLEAN.fromJsonValue(false));
+        }
+    };
+
+    return (
+        <div data-component={CHECKBOX_INPUT_NAME}>
+            <Checkbox
+                checked={isChecked}
+                label={input.getLabel()}
+                className={ALIGNMENT_CLASSES[config.alignment]}
+                disabled={!enabled}
+                error={errors.length > 0}
+                errorMessage={getFirstError(errors)}
+                onCheckedChange={handleCheckedChange}
+            />
+        </div>
+    );
+};
+
+CheckboxInput.displayName = CHECKBOX_INPUT_NAME;

--- a/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/checkbox-input/index.ts
@@ -1,0 +1,1 @@
+export * from './CheckboxInput';

--- a/src/main/resources/assets/admin/common/js/form2/components/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/index.ts
@@ -1,3 +1,4 @@
+export * from './checkbox-input';
 export * from './counter-description';
 export * from './long-input';
 export * from './occurrence-list';

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/CheckboxDescriptor.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/CheckboxDescriptor.test.ts
@@ -108,9 +108,9 @@ describe('CheckboxDescriptor', () => {
             expect(CheckboxDescriptor.valueBreaksRequired(value)).toBe(false);
         });
 
-        it('returns false for boolean false', () => {
+        it('returns true for boolean false (unchecked does not satisfy required)', () => {
             const value = ValueTypes.BOOLEAN.fromJsonValue(false);
-            expect(CheckboxDescriptor.valueBreaksRequired(value)).toBe(false);
+            expect(CheckboxDescriptor.valueBreaksRequired(value)).toBe(true);
         });
     });
 });

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/CheckboxDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/CheckboxDescriptor.ts
@@ -2,7 +2,7 @@ import type {Value} from '../../data/Value';
 import type {ValueType} from '../../data/ValueType';
 import {ValueTypes} from '../../data/ValueTypes';
 import type {RawInputConfig} from '../../form/Input';
-import type {CheckboxConfig} from './InputTypeConfig';
+import type {Alignment, CheckboxConfig} from './InputTypeConfig';
 import type {InputTypeDescriptor} from './InputTypeDescriptor';
 import type {ValidationResult} from './ValidationResult';
 
@@ -14,10 +14,11 @@ export const CheckboxDescriptor: InputTypeDescriptor<CheckboxConfig> = {
     },
 
     readConfig(raw: RawInputConfig): CheckboxConfig {
-        const alignmentEntry = raw.alignment?.[0];
-        return {
-            alignment: alignmentEntry ? (alignmentEntry.value as string) || 'LEFT' : 'LEFT',
-        };
+        const rawValue = raw.alignment?.[0]?.value;
+        const normalized = typeof rawValue === 'string' ? rawValue.toUpperCase() : '';
+        const VALID: Alignment[] = ['LEFT', 'RIGHT', 'TOP', 'BOTTOM'];
+        const alignment = VALID.includes(normalized as Alignment) ? (normalized as Alignment) : 'LEFT';
+        return {alignment};
     },
 
     createDefaultValue(raw: unknown): Value {
@@ -29,6 +30,6 @@ export const CheckboxDescriptor: InputTypeDescriptor<CheckboxConfig> = {
     },
 
     valueBreaksRequired(value: Value): boolean {
-        return value.isNull() || !value.getType().equals(ValueTypes.BOOLEAN);
+        return value.isNull() || !value.getType().equals(ValueTypes.BOOLEAN) || value.getBoolean() !== true;
     },
 };

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/InputTypeConfig.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/InputTypeConfig.ts
@@ -17,8 +17,10 @@ export type NumberConfig = {
     max: number | undefined;
 };
 
+export type Alignment = 'LEFT' | 'RIGHT' | 'TOP' | 'BOTTOM';
+
 export type CheckboxConfig = {
-    alignment: string;
+    alignment: Alignment;
 };
 
 export type ComboBoxOptionConfig = {

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/OccurrenceManager.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/OccurrenceManager.test.ts
@@ -287,10 +287,10 @@ describe('OccurrenceManager', () => {
             expect(state.occurrenceValidation.every(ov => ov.validationResults.length === 0)).toBe(true);
         });
 
-        it('counts valid boolean occurrences', () => {
+        it('counts valid boolean occurrences (only true satisfies required)', () => {
             const mgr = createCheckboxManager({min: 1, values: [true, false]});
             const state = mgr.validate();
-            expect(state.totalValid).toBe(2);
+            expect(state.totalValid).toBe(1);
             expect(state.isMinimumBreached).toBe(false);
         });
 

--- a/src/main/resources/assets/admin/common/js/form2/initBuiltInComponents.ts
+++ b/src/main/resources/assets/admin/common/js/form2/initBuiltInComponents.ts
@@ -1,3 +1,4 @@
+import {CheckboxInput} from './components/checkbox-input';
 import {LongInput} from './components/long-input';
 import {TextAreaInput} from './components/text-area-input';
 import {TextLineInput} from './components/text-line-input';
@@ -7,6 +8,7 @@ import type {InputTypeComponent} from './types';
 export function initBuiltInComponents(): void {
     // Type assertion needed: concrete components use narrower InputTypeComponentProps<XConfig>,
     // but the registry stores the generic InputTypeComponent. Props contract is tested separately.
+    ComponentRegistry.register('Checkbox', CheckboxInput as InputTypeComponent, true);
     ComponentRegistry.register('TextLine', TextLineInput as InputTypeComponent, true);
     ComponentRegistry.register('TextArea', TextAreaInput as InputTypeComponent, true);
     ComponentRegistry.register('Long', LongInput as InputTypeComponent, true);


### PR DESCRIPTION
Added `CheckboxInput` Preact component for the form2 system, replacing the legacy DOM-based checkbox implementation.

- Added `Alignment` strict type union (`LEFT | RIGHT | TOP | BOTTOM`) to `CheckboxConfig`
- Updated `CheckboxDescriptor.readConfig` to normalize and validate incoming alignment values
- Created `CheckboxInput` component using `@enonic/ui` `Checkbox` with alignment via className overrides
- Fixed `valueBreaksRequired` to treat `false` as invalid for required checkboxes — only `true` satisfies the constraint
- Registered as `Checkbox` in `initBuiltInComponents`
- Added tests covering `handleCheckedChange` logic, indeterminate handling, and round-trip cycles
- Added Storybook stories for all alignment variants and states

Closes #4301

<sub>*Drafted with AI assistance*</sub>