### PR TITLE
Add RadioButtonInput component to form2 #4303

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/index.ts
@@ -1,6 +1,7 @@
 export * from './counter-description';
 export * from './long-input';
 export * from './occurrence-list';
+export * from './radio-button-input';
 export * from './text-area-input';
 export * from './text-line-input';
 export * from './unsupported-input';

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.stories.tsx
@@ -1,0 +1,167 @@
+import type {Meta, StoryObj} from '@storybook/preact-vite';
+import {useState} from 'react';
+import type {Value} from '../../../data/Value';
+import {ValueTypes} from '../../../data/ValueTypes';
+import {InputBuilder} from '../../../form/Input';
+import {InputTypeName} from '../../../form/InputTypeName';
+import {OccurrencesBuilder} from '../../../form/Occurrences';
+import type {RadioButtonConfig} from '../../descriptor/InputTypeConfig';
+import type {InputTypeComponentProps} from '../../types';
+import {RadioButtonInput} from './RadioButtonInput';
+
+function makeConfig(overrides: Partial<RadioButtonConfig> = {}): RadioButtonConfig {
+    return {
+        options: [
+            {label: 'Option A', value: 'a'},
+            {label: 'Option B', value: 'b'},
+            {label: 'Option C', value: 'c'},
+        ],
+        ...overrides,
+    };
+}
+
+function makeInput(): InstanceType<typeof InputBuilder>['build'] extends () => infer R ? R : never {
+    return new InputBuilder()
+        .setName('myRadioButton')
+        .setInputType(new InputTypeName('RadioButton', false))
+        .setLabel('Radio Button')
+        .setOccurrences(new OccurrencesBuilder().setMinimum(0).setMaximum(1).build())
+        .setHelpText('')
+        .setInputTypeConfig({})
+        .build();
+}
+
+const meta: Meta<InputTypeComponentProps<RadioButtonConfig>> = {
+    title: 'InputTypes/RadioButtonInput',
+    component: RadioButtonInput,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        value: {description: 'Current field value (Value object)'},
+        onChange: {description: 'Callback fired when the value changes'},
+        config: {description: 'RadioButton config: options with label and value'},
+        input: {description: 'Input descriptor (name, label, occurrences, etc.)'},
+        enabled: {control: 'boolean', description: 'Whether the input is interactive'},
+        index: {description: 'Occurrence index within the form'},
+        errors: {description: 'Array of validation error objects'},
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<InputTypeComponentProps<RadioButtonConfig>>;
+
+const defaultArgs: InputTypeComponentProps<RadioButtonConfig> = {
+    value: ValueTypes.STRING.newNullValue(),
+    onChange: v => console.log('onChange', v.getString()),
+    onBlur: () => console.log('onBlur'),
+    config: makeConfig(),
+    input: makeInput(),
+    enabled: true,
+    index: 0,
+    errors: [],
+};
+
+export const Default: Story = {
+    name: 'Examples / Default',
+    args: {...defaultArgs},
+};
+
+export const WithValue: Story = {
+    name: 'Examples / With Value',
+    args: {
+        ...defaultArgs,
+        value: ValueTypes.STRING.newValue('b'),
+    },
+};
+
+export const TwoOptions: Story = {
+    name: 'Examples / Two Options',
+    args: {
+        ...defaultArgs,
+        config: makeConfig({
+            options: [
+                {label: 'Yes', value: 'yes'},
+                {label: 'No', value: 'no'},
+            ],
+        }),
+    },
+};
+
+export const ManyOptions: Story = {
+    name: 'Examples / Many Options',
+    args: {
+        ...defaultArgs,
+        config: makeConfig({
+            options: [
+                {label: 'Red', value: 'red'},
+                {label: 'Orange', value: 'orange'},
+                {label: 'Yellow', value: 'yellow'},
+                {label: 'Green', value: 'green'},
+                {label: 'Blue', value: 'blue'},
+                {label: 'Purple', value: 'purple'},
+            ],
+        }),
+    },
+};
+
+export const Disabled: Story = {
+    name: 'States / Disabled',
+    args: {
+        ...defaultArgs,
+        value: ValueTypes.STRING.newValue('a'),
+        enabled: false,
+    },
+};
+
+export const WithError: Story = {
+    name: 'States / With Error',
+    args: {
+        ...defaultArgs,
+        errors: [{message: 'This field is required'}],
+    },
+};
+
+function StatefulRadio(props: Omit<InputTypeComponentProps<RadioButtonConfig>, 'onChange'> & {initialValue?: Value}) {
+    const [value, setValue] = useState(props.initialValue ?? props.value);
+    return <RadioButtonInput {...props} value={value} onChange={setValue} />;
+}
+
+export const AllStates: Story = {
+    name: 'States / All States',
+    render: () => (
+        <div className='w-80 space-y-6 p-4'>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Empty</h3>
+                <StatefulRadio {...defaultArgs} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>With Value</h3>
+                <StatefulRadio {...defaultArgs} initialValue={ValueTypes.STRING.newValue('b')} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Disabled</h3>
+                <StatefulRadio {...defaultArgs} initialValue={ValueTypes.STRING.newValue('a')} enabled={false} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Error</h3>
+                <StatefulRadio {...defaultArgs} errors={[{message: 'This field is required'}]} />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Two Options</h3>
+                <StatefulRadio
+                    {...defaultArgs}
+                    initialValue={ValueTypes.STRING.newValue('yes')}
+                    config={makeConfig({
+                        options: [
+                            {label: 'Yes', value: 'yes'},
+                            {label: 'No', value: 'no'},
+                        ],
+                    })}
+                />
+            </div>
+        </div>
+    ),
+};

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from 'vitest';
+import {Value} from '../../../data/Value';
+import {ValueTypes} from '../../../data/ValueTypes';
+
+describe('RadioButtonInput', () => {
+    describe('value transformation', () => {
+        it('should produce empty string for null value', () => {
+            const value = ValueTypes.STRING.newNullValue();
+            const stringValue = value.isNull() ? '' : (value.getString() ?? '');
+            expect(value.isNull()).toBe(true);
+            expect(stringValue).toBe('');
+        });
+
+        it('should produce string for valid value', () => {
+            const value = ValueTypes.STRING.newValue('option1');
+            const stringValue = value.isNull() ? '' : (value.getString() ?? '');
+            expect(value.isNull()).toBe(false);
+            expect(stringValue).toBe('option1');
+        });
+
+        it('should produce correct Value on onChange', () => {
+            const newValue = ValueTypes.STRING.newValue('yes');
+            expect(newValue).toBeInstanceOf(Value);
+            expect(newValue.getString()).toBe('yes');
+            expect(newValue.getType()).toBe(ValueTypes.STRING);
+        });
+
+        it('should handle value not matching any option', () => {
+            const value = ValueTypes.STRING.newValue('nonexistent');
+            const stringValue = value.isNull() ? '' : (value.getString() ?? '');
+            expect(stringValue).toBe('nonexistent');
+        });
+    });
+});

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.tsx
@@ -1,0 +1,48 @@
+import {RadioGroup} from '@enonic/ui';
+import type {ReactElement} from 'react';
+
+import {ValueTypes} from '../../../data/ValueTypes';
+import type {RadioButtonConfig} from '../../descriptor/InputTypeConfig';
+import type {InputTypeComponentProps} from '../../types';
+import {getFirstError} from '../../utils';
+
+const RADIO_BUTTON_INPUT_NAME = 'RadioButtonInput';
+
+export const RadioButtonInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: InputTypeComponentProps<RadioButtonConfig>): ReactElement => {
+    const stringValue = value.isNull() ? '' : (value.getString() ?? '');
+    const hasErrors = errors.length > 0;
+
+    const handleValueChange = (newValue: string): void => {
+        onChange(ValueTypes.STRING.newValue(newValue));
+    };
+
+    return (
+        <RadioGroup
+            data-component={RADIO_BUTTON_INPUT_NAME}
+            name={`${input.getName()}-${index}`}
+            value={stringValue}
+            onValueChange={handleValueChange}
+            onBlur={onBlur}
+            error={hasErrors}
+            errorMessage={getFirstError(errors)}
+        >
+            {config.options.map(option => (
+                <RadioGroup.Item key={option.value} value={option.value} disabled={!enabled}>
+                    <RadioGroup.Indicator />
+                    {option.label}
+                </RadioGroup.Item>
+            ))}
+        </RadioGroup>
+    );
+};
+
+RadioButtonInput.displayName = RADIO_BUTTON_INPUT_NAME;

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/index.ts
@@ -1,0 +1,1 @@
+export * from './RadioButtonInput';

--- a/src/main/resources/assets/admin/common/js/form2/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/index.ts
@@ -3,6 +3,7 @@ export {BaseInputType} from './BaseInputType';
 export {CounterDescription} from './components/counter-description';
 export {LongInput, type LongInputProps} from './components/long-input';
 export {OccurrenceList, type OccurrenceListRootProps} from './components/occurrence-list';
+export {RadioButtonInput} from './components/radio-button-input';
 export {TextAreaInput} from './components/text-area-input';
 export {TextLineInput} from './components/text-line-input';
 export {UnsupportedInput} from './components/unsupported-input';

--- a/src/main/resources/assets/admin/common/js/form2/initBuiltInComponents.ts
+++ b/src/main/resources/assets/admin/common/js/form2/initBuiltInComponents.ts
@@ -1,4 +1,5 @@
 import {LongInput} from './components/long-input';
+import {RadioButtonInput} from './components/radio-button-input';
 import {TextAreaInput} from './components/text-area-input';
 import {TextLineInput} from './components/text-line-input';
 import {ComponentRegistry} from './registry/ComponentRegistry';
@@ -10,4 +11,5 @@ export function initBuiltInComponents(): void {
     ComponentRegistry.register('TextLine', TextLineInput as InputTypeComponent, true);
     ComponentRegistry.register('TextArea', TextAreaInput as InputTypeComponent, true);
     ComponentRegistry.register('Long', LongInput as InputTypeComponent, true);
+    ComponentRegistry.register('RadioButton', RadioButtonInput as InputTypeComponent, true);
 }


### PR DESCRIPTION
## Changes

- Added `RadioButtonInput` component using `RadioGroup` compound component from `@enonic/ui`
- Registered `RadioButton` in `ComponentRegistry` via `initBuiltInComponents`
- Exported `RadioButtonInput` from `form2/index.ts` and `components/index.ts`
- Used `${input.getName()}-${index}` as unique `name` prop to prevent cross-field radio group collision
- Added `data-component` attribute for test/debug parity with other form2 components
- Added unit tests for value transformation logic
- Added Storybook stories with `StatefulRadio` wrapper for interactive All States demo

Closes #4303

<sub>*Drafted with AI assistance*</sub>