### PR TITLE
OccurrenceList: add keyboard sorting support #4318

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,14 @@ Unless asked for specific format by the user, use the default one:
 
 ### Commits
 
-- **With issue**: `<Issue Title> #<number>` — e.g. `Add MyComponent to browse view #12`
+- **With issue**: use `<Issue Title> #<number>` — e.g. issue `Do fix` #10 becomes `Do fix #10`
 - **Without issue**: capitalized plain-English description — e.g. `Add local Git worktrees ignore`, `Fix build`
 - **Body** (optional): past tense, one line per change, 2–6 lines, backticks for code refs
 
 ### Pull Requests
 
-- **Title**: `<Issue Title> #<number>` — matches the commit title
+- **Title**: use the exact same pattern as the commit title when linked to an issue (`<Issue Title> #<number>`)
+- **Commit/PR title pair example**: issue `Do fix` #10 → commit `Do fix #10`, PR `Do fix #10`
 - **Body**: concisely explain what and why, skip trivial details. No emojis. Separate all sections with one blank line.
   ```
   <summary of changes>

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -1,5 +1,18 @@
-import {closestCenter, DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors} from '@dnd-kit/core';
-import {SortableContext, useSortable, verticalListSortingStrategy} from '@dnd-kit/sortable';
+import {
+    closestCenter,
+    DndContext,
+    type DragEndEvent,
+    KeyboardSensor,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import {Button, cn, IconButton} from '@enonic/ui';
 import {GripVertical, Plus, X} from 'lucide-react';
 import type {ReactElement, ReactNode} from 'react';
@@ -133,8 +146,9 @@ const OccurrenceListSortableItem = <C extends InputTypeConfig = InputTypeConfig>
     ...contentProps
 }: OccurrenceListSortableItemProps<C>): ReactElement => {
     const t = useI18n();
-    const {attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging} = useSortable({
+    const {attributes, listeners, setNodeRef, transform, transition, isDragging} = useSortable({
         id,
+        disabled: !showDrag,
     });
 
     const style = {
@@ -147,8 +161,9 @@ const OccurrenceListSortableItem = <C extends InputTypeConfig = InputTypeConfig>
     return (
         <div
             ref={setNodeRef}
+            onKeyDown={listeners?.onKeyDown as preact.JSX.KeyboardEventHandler<HTMLDivElement>}
             role={attributes.role as preact.JSX.AriaRole}
-            tabIndex={attributes.tabIndex}
+            tabIndex={showDrag ? attributes.tabIndex : undefined}
             aria-disabled={attributes['aria-disabled']}
             aria-pressed={attributes['aria-pressed']}
             aria-roledescription={attributes['aria-roledescription']}
@@ -166,7 +181,6 @@ const OccurrenceListSortableItem = <C extends InputTypeConfig = InputTypeConfig>
         >
             {showDrag && (
                 <button
-                    ref={setActivatorNodeRef}
                     type='button'
                     className={cn(
                         'flex shrink-0 cursor-grab items-center text-subtle',
@@ -231,7 +245,10 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
     const isDraggable = occurrences.multiple() && !isFixed;
     const showDrag = isDraggable && state.values.length >= 2;
 
-    const sensors = useSensors(useSensor(PointerSensor, {activationConstraint: {distance: 5}}));
+    const sensors = useSensors(
+        useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
+        useSensor(KeyboardSensor, {coordinateGetter: sortableKeyboardCoordinates}),
+    );
 
     // Single mode: render component bare
     // ? Minimum occurrences are eagerly populated in useOccurrenceManager, so values[0] is always present

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.stories.tsx
@@ -64,70 +64,64 @@ const defaultArgs: InputTypeComponentProps<RadioButtonConfig> = {
     errors: [],
 };
 
-export const Default: Story = {
-    name: 'Examples / Default',
-    args: {...defaultArgs},
-};
-
-export const WithValue: Story = {
-    name: 'Examples / With Value',
-    args: {
-        ...defaultArgs,
-        value: ValueTypes.STRING.newValue('b'),
-    },
-};
-
-export const TwoOptions: Story = {
-    name: 'Examples / Two Options',
-    args: {
-        ...defaultArgs,
-        config: makeConfig({
-            options: [
-                {label: 'Yes', value: 'yes'},
-                {label: 'No', value: 'no'},
-            ],
-        }),
-    },
-};
-
-export const ManyOptions: Story = {
-    name: 'Examples / Many Options',
-    args: {
-        ...defaultArgs,
-        config: makeConfig({
-            options: [
-                {label: 'Red', value: 'red'},
-                {label: 'Orange', value: 'orange'},
-                {label: 'Yellow', value: 'yellow'},
-                {label: 'Green', value: 'green'},
-                {label: 'Blue', value: 'blue'},
-                {label: 'Purple', value: 'purple'},
-            ],
-        }),
-    },
-};
-
-export const Disabled: Story = {
-    name: 'States / Disabled',
-    args: {
-        ...defaultArgs,
-        value: ValueTypes.STRING.newValue('a'),
-        enabled: false,
-    },
-};
-
-export const WithError: Story = {
-    name: 'States / With Error',
-    args: {
-        ...defaultArgs,
-        errors: [{message: 'This field is required'}],
-    },
-};
-
 function StatefulRadio(props: Omit<InputTypeComponentProps<RadioButtonConfig>, 'onChange'> & {initialValue?: Value}) {
     const [value, setValue] = useState(props.initialValue ?? props.value);
     return <RadioButtonInput {...props} value={value} onChange={setValue} />;
 }
+
+export const Default: Story = {
+    name: 'Examples / Default',
+    render: () => <StatefulRadio {...defaultArgs} />,
+};
+
+export const WithValue: Story = {
+    name: 'Examples / With Value',
+    render: () => <StatefulRadio {...defaultArgs} initialValue={ValueTypes.STRING.newValue('b')} />,
+};
+
+export const TwoOptions: Story = {
+    name: 'Examples / Two Options',
+    render: () => (
+        <StatefulRadio
+            {...defaultArgs}
+            config={makeConfig({
+                options: [
+                    {label: 'Yes', value: 'yes'},
+                    {label: 'No', value: 'no'},
+                ],
+            })}
+        />
+    ),
+};
+
+export const ManyOptions: Story = {
+    name: 'Examples / Many Options',
+    render: () => (
+        <StatefulRadio
+            {...defaultArgs}
+            config={makeConfig({
+                options: [
+                    {label: 'Red', value: 'red'},
+                    {label: 'Orange', value: 'orange'},
+                    {label: 'Yellow', value: 'yellow'},
+                    {label: 'Green', value: 'green'},
+                    {label: 'Blue', value: 'blue'},
+                    {label: 'Purple', value: 'purple'},
+                ],
+            })}
+        />
+    ),
+};
+
+export const Disabled: Story = {
+    name: 'States / Disabled',
+    render: () => <StatefulRadio {...defaultArgs} initialValue={ValueTypes.STRING.newValue('a')} enabled={false} />,
+};
+
+export const WithError: Story = {
+    name: 'States / With Error',
+    render: () => <StatefulRadio {...defaultArgs} errors={[{message: 'This field is required'}]} />,
+};
 
 export const AllStates: Story = {
     name: 'States / All States',


### PR DESCRIPTION
Added KeyboardSensor to OccurrenceList so sortable items can be reordered via Tab + Space + Arrow keys. Fixed dnd-kit's activatorNode mismatch by routing onKeyDown to the sortable item div and dropping setActivatorNodeRef. Disabled sorting and tabIndex when only one occurrence is present. Also refactored RadioButtonInput stories to use stateful render functions.

Closes #4318

<sub>*Drafted with AI assistance*</sub>