### PR TITLE
Add InputLabel component to form2 #4339

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@biomejs/biome": "~2.3.8",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~0.47.0",
+    "@enonic/ui": "~0.47.1",
     "@rollup/plugin-inject": "^5.0.5",
     "@storybook/addon-docs": "~10.1.6",
     "@storybook/addon-themes": "~10.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@enonic/ui':
-        specifier: ~0.47.0
-        version: 0.47.0(@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0))(focus-trap-react@11.0.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(lucide-react@0.540.0(react@19.2.0))(preact@10.27.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tw-animate-css@1.4.0)
+        specifier: ~0.47.1
+        version: 0.47.1(@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0))(focus-trap-react@11.0.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(lucide-react@0.540.0(react@19.2.0))(preact@10.27.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.55.1)
@@ -238,8 +238,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@enonic/ui@0.47.0':
-    resolution: {integrity: sha512-h9LF23Fkyb2ZHAFCFXgDMPVwztFL5732bwfI4qcWJJ4MLwHv8rK9WxxL9zlNPBLWSuevUmFi/l8DB88l9rRjSQ==}
+  '@enonic/ui@0.47.1':
+    resolution: {integrity: sha512-Jh9gH30WvLsSoJJd6G5L55t8o5ygxFOOKMUnG/iuGXqPO5Dhyap07CPz3xHaiRxKkiv5ylfnsePf0/Wop2gEmQ==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -2105,7 +2105,7 @@ snapshots:
       react: 19.2.0
       tslib: 2.8.1
 
-  '@enonic/ui@0.47.0(@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0))(focus-trap-react@11.0.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(lucide-react@0.540.0(react@19.2.0))(preact@10.27.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.47.1(@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0))(focus-trap-react@11.0.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(lucide-react@0.540.0(react@19.2.0))(preact@10.27.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
       class-variance-authority: 0.7.1

--- a/src/main/resources/assets/admin/common/js/form2/components/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/index.ts
@@ -4,6 +4,7 @@ export * from './date-input';
 export * from './date-time-input';
 export * from './double-input';
 export * from './geo-point-input';
+export * from './input-label';
 export * from './instant-input';
 export * from './long-input';
 export * from './occurrence-list';

--- a/src/main/resources/assets/admin/common/js/form2/components/input-label/InputLabel.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-label/InputLabel.stories.tsx
@@ -1,0 +1,125 @@
+import type {Meta, StoryObj} from '@storybook/preact-vite';
+import {InputBuilder} from '../../../form/Input';
+import {InputTypeName} from '../../../form/InputTypeName';
+import {OccurrencesBuilder} from '../../../form/Occurrences';
+import type {InputLabelRootProps} from './InputLabel';
+import {InputLabel} from './InputLabel';
+
+function makeInput(overrides: {label?: string; helpText?: string} = {}) {
+    return new InputBuilder()
+        .setName('myInput')
+        .setInputType(new InputTypeName('TextLine', false))
+        .setLabel(overrides.label ?? '')
+        .setOccurrences(new OccurrencesBuilder().setMinimum(0).setMaximum(1).build())
+        .setHelpText(overrides.helpText ?? '')
+        .setInputTypeConfig({})
+        .build();
+}
+
+const meta: Meta<InputLabelRootProps> = {
+    title: 'Components/InputLabel',
+    component: InputLabel,
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<InputLabelRootProps>;
+
+export const LabelOnly: Story = {
+    name: 'Examples / Label Only',
+    render: () => <InputLabel input={makeInput({label: 'Full Name'})} />,
+};
+
+export const DescriptionOnly: Story = {
+    name: 'Examples / Description Only',
+    render: () => <InputLabel input={makeInput({helpText: 'Enter your full legal name as it appears on your ID.'})} />,
+};
+
+export const LabelAndDescription: Story = {
+    name: 'Examples / Label and Description',
+    render: () => (
+        <InputLabel
+            input={makeInput({label: 'Full Name', helpText: 'Enter your full legal name as it appears on your ID.'})}
+        />
+    ),
+};
+
+export const WithActionLabelAndDescription: Story = {
+    name: 'Examples / With Action (Label + Description)',
+    render: () => (
+        <InputLabel
+            input={makeInput({label: 'Full Name', helpText: 'Enter your full legal name as it appears on your ID.'})}
+        >
+            <InputLabel.Action variant='solid'>Expand All</InputLabel.Action>
+        </InputLabel>
+    ),
+};
+
+export const WithActionLabelOnly: Story = {
+    name: 'Examples / With Action (Label Only)',
+    render: () => (
+        <InputLabel input={makeInput({label: 'Full Name'})}>
+            <InputLabel.Action variant='solid'>Expand All</InputLabel.Action>
+        </InputLabel>
+    ),
+};
+
+export const AllVariants: Story = {
+    name: 'States / All Variants',
+    render: () => (
+        <div className='w-80 space-y-6 p-4'>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Label Only</h3>
+                <InputLabel
+                    input={makeInput({label: 'Full Name'})}
+                    className='rounded border border-bdr-subtle border-dashed p-2'
+                />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Description Only</h3>
+                <InputLabel
+                    input={makeInput({helpText: 'Enter your full legal name.'})}
+                    className='rounded border border-bdr-subtle border-dashed p-2'
+                />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Label + Description</h3>
+                <InputLabel
+                    input={makeInput({label: 'Full Name', helpText: 'Enter your full legal name.'})}
+                    className='rounded border border-bdr-subtle border-dashed p-2'
+                />
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Label + Description + Action</h3>
+                <InputLabel
+                    input={makeInput({label: 'Full Name', helpText: 'Enter your full legal name.'})}
+                    className='rounded border border-bdr-subtle border-dashed p-2'
+                >
+                    <InputLabel.Action variant='solid'>Expand All</InputLabel.Action>
+                </InputLabel>
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Label + Action (no description)</h3>
+                <InputLabel
+                    input={makeInput({label: 'Full Name'})}
+                    className='rounded border border-bdr-subtle border-dashed p-2'
+                >
+                    <InputLabel.Action variant='solid'>Expand All</InputLabel.Action>
+                </InputLabel>
+            </div>
+            <div>
+                <h3 className='mb-3 font-medium text-sm'>Description + Action (no label)</h3>
+                <InputLabel
+                    input={makeInput({helpText: 'Enter your full legal name.'})}
+                    className='rounded border border-bdr-subtle border-dashed p-2'
+                >
+                    <InputLabel.Action variant='solid'>Expand All</InputLabel.Action>
+                </InputLabel>
+            </div>
+        </div>
+    ),
+};

--- a/src/main/resources/assets/admin/common/js/form2/components/input-label/InputLabel.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-label/InputLabel.tsx
@@ -1,0 +1,69 @@
+import {Button, type ButtonProps, cn} from '@enonic/ui';
+import type {ComponentPropsWithoutRef, ReactElement, ReactNode} from 'react';
+
+import type {Input} from '../../../form/Input';
+
+//
+// * InputLabelAction
+//
+
+const INPUT_LABEL_ACTION_NAME = 'InputLabelAction';
+
+export type InputLabelActionProps = Omit<ButtonProps, 'size'>;
+
+const InputLabelAction = ({className, ...props}: InputLabelActionProps): ReactElement => {
+    return (
+        <Button
+            data-component={INPUT_LABEL_ACTION_NAME}
+            {...props}
+            variant='text'
+            size='sm'
+            className={cn('-my-0.75 h-6 px-1.5 focus-visible:ring-offset-0', className)}
+        />
+    );
+};
+
+InputLabelAction.displayName = INPUT_LABEL_ACTION_NAME;
+
+//
+// * InputLabelRoot
+//
+
+const INPUT_LABEL_NAME = 'InputLabel';
+
+export type InputLabelRootProps = {
+    input: Input;
+    children?: ReactNode;
+} & ComponentPropsWithoutRef<'div'>;
+
+const InputLabelRoot = ({input, children, className, ...props}: InputLabelRootProps): ReactElement | null => {
+    const label = input.getLabel();
+    const description = input.getHelpText();
+
+    if (!label && !description) return null;
+
+    const hasChildren = children != null;
+
+    return (
+        <div
+            data-component={INPUT_LABEL_NAME}
+            className={cn(hasChildren && 'grid grid-cols-[1fr_auto] items-baseline gap-x-2', className)}
+            {...props}
+        >
+            {label && (
+                <div className={cn('font-semibold text-base text-main', hasChildren && description && 'col-span-full')}>
+                    {label}
+                </div>
+            )}
+            {description && <div className='text-sm text-subtle'>{description}</div>}
+            {children}
+        </div>
+    );
+};
+
+InputLabelRoot.displayName = INPUT_LABEL_NAME;
+
+export const InputLabel = Object.assign(InputLabelRoot, {
+    Root: InputLabelRoot,
+    Action: InputLabelAction,
+});

--- a/src/main/resources/assets/admin/common/js/form2/components/input-label/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-label/index.ts
@@ -1,0 +1,1 @@
+export {InputLabel, type InputLabelActionProps, type InputLabelRootProps} from './InputLabel';

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.stories.tsx
@@ -24,13 +24,13 @@ function makeConfig(): TextLineConfig {
     return {regexp: undefined, maxLength: -1, showCounter: false};
 }
 
-function makeInput(min: number, max: number) {
+function makeInput(min: number, max: number, label = 'Text Line', helpText = '') {
     return new InputBuilder()
         .setName('myTextLine')
         .setInputType(new InputTypeName('TextLine', false))
-        .setLabel('Text Line')
+        .setLabel(label)
         .setOccurrences(new OccurrencesBuilder().setMinimum(min).setMaximum(max).build())
-        .setHelpText('')
+        .setHelpText(helpText)
         .setInputTypeConfig({})
         .build();
 }
@@ -69,82 +69,68 @@ export default {
 export const Single: Story = {
     name: 'Examples / Single',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>Single (1:1)</h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState(['Hello'], 1, 1)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(1, 1)}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState(['Hello'], 1, 1)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(1, 1, 'Single (1:1)')}
+            enabled={true}
+        />
     ),
 };
 
 export const Optional: Story = {
     name: 'Examples / Optional',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>Optional (0:1)</h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState(['Hello'], 0, 1)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(0, 1)}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState(['Hello'], 0, 1)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(0, 1, 'Optional (0:1)')}
+            enabled={true}
+        />
     ),
 };
 
 export const OptionalEmpty: Story = {
     name: 'Examples / Optional Empty',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>Optional Empty (0:1) — renders bare input with null value</h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState([''], 0, 1)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(0, 1)}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState([''], 0, 1)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(0, 1, 'Optional Empty (0:1)', 'Renders bare input with null value')}
+            enabled={true}
+        />
     ),
 };
 
 export const OptionalMultipleEmpty: Story = {
     name: 'Examples / Optional Multiple Empty',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>
-                Optional Multiple Empty (0:3) — 1 auto-filled null, no remove button
-            </h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState([''], 0, 3)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(0, 3)}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState([''], 0, 3)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(0, 3, 'Optional Multiple Empty (0:3)', '1 auto-filled null, no remove button')}
+            enabled={true}
+        />
     ),
 };
 
@@ -177,46 +163,34 @@ export const RequiredMultiple: Story = {
 export const Unlimited: Story = {
     name: 'Examples / Unlimited',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>Unlimited (0:0) with 3 values</h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState(['Alpha', 'Beta', 'Gamma'], 0, 0)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(0, 0)}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState(['Alpha', 'Beta', 'Gamma'], 0, 0)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(0, 0, 'Unlimited (0:0)', 'With 3 values')}
+            enabled={true}
+        />
     ),
 };
 
 export const FixedCount: Story = {
     name: 'Examples / Fixed Count',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <div className='w-96 rounded-sm bg-surface-primary p-3 text-sm'>
-                <p className='mb-2 font-medium'>Fixed Count (3:3):</p>
-                <ul className='space-y-1 text-xs'>
-                    <li>No add or remove buttons</li>
-                    <li>No drag handles</li>
-                </ul>
-            </div>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState(['Alpha', 'Beta', 'Gamma'], 3, 3)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(3, 3)}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState(['Alpha', 'Beta', 'Gamma'], 3, 3)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(3, 3, 'Fixed Count (3:3)', 'No add or remove buttons, no drag handles')}
+            enabled={true}
+        />
     ),
 };
 
@@ -234,20 +208,17 @@ export const WithErrors: Story = {
         const state = manager.validate();
 
         return (
-            <div className='flex flex-col gap-y-4 p-4'>
-                <h3 className='mb-0 font-medium text-sm'>Second value fails regexp validation</h3>
-                <OccurrenceList
-                    Component={TextLineInput}
-                    state={state}
-                    onAdd={noop}
-                    onRemove={noop}
-                    onMove={noop}
-                    onChange={noop}
-                    config={config}
-                    input={makeInput(1, 3)}
-                    enabled={true}
-                />
-            </div>
+            <OccurrenceList
+                Component={TextLineInput}
+                state={state}
+                onAdd={noop}
+                onRemove={noop}
+                onMove={noop}
+                onChange={noop}
+                config={config}
+                input={makeInput(1, 3, 'With Errors (1:3)', 'Second value fails regexp validation')}
+                enabled={true}
+            />
         );
     },
 };
@@ -255,20 +226,17 @@ export const WithErrors: Story = {
 export const Disabled: Story = {
     name: 'States / Disabled',
     render: () => (
-        <div className='flex flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>Disabled (1:3)</h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={makeState(['Alpha', 'Beta'], 1, 3)}
-                onAdd={noop}
-                onRemove={noop}
-                onMove={noop}
-                onChange={noop}
-                config={makeConfig()}
-                input={makeInput(1, 3)}
-                enabled={false}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={makeState(['Alpha', 'Beta'], 1, 3)}
+            onAdd={noop}
+            onRemove={noop}
+            onMove={noop}
+            onChange={noop}
+            config={makeConfig()}
+            input={makeInput(1, 3, 'Disabled (1:3)')}
+            enabled={false}
+        />
     ),
 };
 
@@ -405,7 +373,7 @@ export const SingleStrategy: Story = {
 const InteractiveUnlimitedDemo = (): ReactElement => {
     const occurrences = useMemo(() => new OccurrencesBuilder().setMinimum(1).setMaximum(0).build(), []);
     const config = useMemo(() => makeConfig(), []);
-    const input = useMemo(() => makeInput(1, 0), []);
+    const input = useMemo(() => makeInput(1, 0, 'Unlimited (1:0)', 'At least one value required'), []);
     const initialValues = useMemo(() => [ValueTypes.STRING.newValue('Required field')], []);
 
     const {state, add, remove, move, set} = useOccurrenceManager({
@@ -416,20 +384,17 @@ const InteractiveUnlimitedDemo = (): ReactElement => {
     });
 
     return (
-        <div className='flex w-100 flex-col gap-y-4 p-4'>
-            <h3 className='mb-0 font-medium text-sm'>Unlimited (1:0), at least one value required</h3>
-            <OccurrenceList
-                Component={TextLineInput}
-                state={state}
-                onAdd={add}
-                onRemove={remove}
-                onMove={move}
-                onChange={set}
-                config={config}
-                input={input}
-                enabled={true}
-            />
-        </div>
+        <OccurrenceList
+            Component={TextLineInput}
+            state={state}
+            onAdd={add}
+            onRemove={remove}
+            onMove={move}
+            onChange={set}
+            config={config}
+            input={input}
+            enabled={true}
+        />
     );
 };
 

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -23,6 +23,7 @@ import type {InputTypeConfig} from '../../descriptor/InputTypeConfig';
 import type {OccurrenceManagerState} from '../../descriptor/OccurrenceManager';
 import {useI18n} from '../../I18nContext';
 import type {InputTypeComponent} from '../../types';
+import {InputLabel} from '../input-label';
 
 //
 // * Types
@@ -224,7 +225,6 @@ const OccurrenceListItem = <C extends InputTypeConfig = InputTypeConfig>({
 //
 
 const OCCURRENCE_LIST_NAME = 'OccurrenceList';
-const OCCURRENCE_LIST_ROOT_NAME = 'OccurrenceList.Root';
 
 const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
     Component,
@@ -263,7 +263,8 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
         if (value == null || errors == null) return <div data-component={OCCURRENCE_LIST_NAME} />;
 
         return (
-            <div data-component={OCCURRENCE_LIST_NAME}>
+            <div data-component={OCCURRENCE_LIST_NAME} className='flex flex-col gap-y-5'>
+                <InputLabel input={input} />
                 <Component
                     value={value}
                     onChange={(v: Value, raw?: string) => onChange(0, v, raw)}
@@ -321,6 +322,7 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
     if (isDraggable) {
         return (
             <div data-component={OCCURRENCE_LIST_NAME} className='flex flex-col gap-y-5'>
+                <InputLabel input={input} />
                 <div className='flex flex-col gap-y-2.5'>
                     <DndContext
                         sensors={sensors}
@@ -347,6 +349,7 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
 
     return (
         <div data-component={OCCURRENCE_LIST_NAME} className='flex flex-col gap-y-5'>
+            <InputLabel input={input} />
             <div className='flex flex-col gap-y-2.5'>
                 {state.values.map((_, i) => (
                     <OccurrenceListItem key={state.ids[i]} {...contentProps(i)} />
@@ -357,7 +360,7 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
     );
 };
 
-OccurrenceListRoot.displayName = OCCURRENCE_LIST_ROOT_NAME;
+OccurrenceListRoot.displayName = OCCURRENCE_LIST_NAME;
 
 export const OccurrenceList = Object.assign(OccurrenceListRoot, {
     Root: OccurrenceListRoot,

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.stories.tsx
@@ -20,16 +20,31 @@ function makeConfig(overrides: Partial<RadioButtonConfig> = {}): RadioButtonConf
     };
 }
 
-function makeInput(): InstanceType<typeof InputBuilder>['build'] extends () => infer R ? R : never {
+function makeInput(
+    label = 'Radio Button',
+): InstanceType<typeof InputBuilder>['build'] extends () => infer R ? R : never {
     return new InputBuilder()
         .setName('myRadioButton')
         .setInputType(new InputTypeName('RadioButton', false))
-        .setLabel('Radio Button')
+        .setLabel(label)
         .setOccurrences(new OccurrencesBuilder().setMinimum(0).setMaximum(1).build())
         .setHelpText('')
         .setInputTypeConfig({})
         .build();
 }
+
+const makeDefaultArgs = (label = 'Radio Button'): InputTypeComponentProps<RadioButtonConfig> => {
+    return {
+        value: ValueTypes.STRING.newNullValue(),
+        onChange: v => console.log('onChange', v.getString()),
+        onBlur: () => console.log('onBlur'),
+        config: makeConfig(),
+        input: makeInput(label),
+        enabled: true,
+        index: 0,
+        errors: [],
+    };
+};
 
 const meta: Meta<InputTypeComponentProps<RadioButtonConfig>> = {
     title: 'InputTypes/RadioButtonInput',
@@ -53,16 +68,7 @@ export default meta;
 
 type Story = StoryObj<InputTypeComponentProps<RadioButtonConfig>>;
 
-const defaultArgs: InputTypeComponentProps<RadioButtonConfig> = {
-    value: ValueTypes.STRING.newNullValue(),
-    onChange: v => console.log('onChange', v.getString()),
-    onBlur: () => console.log('onBlur'),
-    config: makeConfig(),
-    input: makeInput(),
-    enabled: true,
-    index: 0,
-    errors: [],
-};
+const defaultArgs: InputTypeComponentProps<RadioButtonConfig> = makeDefaultArgs();
 
 function StatefulRadio(props: Omit<InputTypeComponentProps<RadioButtonConfig>, 'onChange'> & {initialValue?: Value}) {
     const [value, setValue] = useState(props.initialValue ?? props.value);
@@ -123,39 +129,30 @@ export const WithError: Story = {
     render: () => <StatefulRadio {...defaultArgs} errors={[{message: 'This field is required'}]} />,
 };
 
+const emptyArgs = makeDefaultArgs('Empty');
+const withValueArgs = makeDefaultArgs('With Value');
+const disabledArgs = makeDefaultArgs('Disabled');
+const errorArgs = makeDefaultArgs('Error');
+const twoOptionsArgs = makeDefaultArgs('Two Options');
+
 export const AllStates: Story = {
     name: 'States / All States',
     render: () => (
         <div className='w-80 space-y-6 p-4'>
-            <div>
-                <h3 className='mb-3 font-medium text-sm'>Empty</h3>
-                <StatefulRadio {...defaultArgs} />
-            </div>
-            <div>
-                <h3 className='mb-3 font-medium text-sm'>With Value</h3>
-                <StatefulRadio {...defaultArgs} initialValue={ValueTypes.STRING.newValue('b')} />
-            </div>
-            <div>
-                <h3 className='mb-3 font-medium text-sm'>Disabled</h3>
-                <StatefulRadio {...defaultArgs} initialValue={ValueTypes.STRING.newValue('a')} enabled={false} />
-            </div>
-            <div>
-                <h3 className='mb-3 font-medium text-sm'>Error</h3>
-                <StatefulRadio {...defaultArgs} errors={[{message: 'This field is required'}]} />
-            </div>
-            <div>
-                <h3 className='mb-3 font-medium text-sm'>Two Options</h3>
-                <StatefulRadio
-                    {...defaultArgs}
-                    initialValue={ValueTypes.STRING.newValue('yes')}
-                    config={makeConfig({
-                        options: [
-                            {label: 'Yes', value: 'yes'},
-                            {label: 'No', value: 'no'},
-                        ],
-                    })}
-                />
-            </div>
+            <StatefulRadio {...emptyArgs} />
+            <StatefulRadio {...withValueArgs} initialValue={ValueTypes.STRING.newValue('b')} />
+            <StatefulRadio {...disabledArgs} initialValue={ValueTypes.STRING.newValue('a')} enabled={false} />
+            <StatefulRadio {...errorArgs} errors={[{message: 'This field is required'}]} />
+            <StatefulRadio
+                {...twoOptionsArgs}
+                initialValue={ValueTypes.STRING.newValue('yes')}
+                config={makeConfig({
+                    options: [
+                        {label: 'Yes', value: 'yes'},
+                        {label: 'No', value: 'no'},
+                    ],
+                })}
+            />
         </div>
     ),
 };

--- a/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/radio-button-input/RadioButtonInput.tsx
@@ -5,6 +5,7 @@ import {ValueTypes} from '../../../data/ValueTypes';
 import type {RadioButtonConfig} from '../../descriptor/InputTypeConfig';
 import type {InputTypeComponentProps} from '../../types';
 import {getFirstError} from '../../utils';
+import {InputLabel} from '../input-label';
 
 const RADIO_BUTTON_INPUT_NAME = 'RadioButtonInput';
 
@@ -26,22 +27,24 @@ export const RadioButtonInput = ({
     };
 
     return (
-        <RadioGroup
-            data-component={RADIO_BUTTON_INPUT_NAME}
-            name={`${input.getName()}-${index}`}
-            value={stringValue}
-            onValueChange={handleValueChange}
-            onBlur={onBlur}
-            error={hasErrors}
-            errorMessage={getFirstError(errors)}
-        >
-            {config.options.map(option => (
-                <RadioGroup.Item key={option.value} value={option.value} disabled={!enabled}>
-                    <RadioGroup.Indicator />
-                    {option.label}
-                </RadioGroup.Item>
-            ))}
-        </RadioGroup>
+        <div data-component={RADIO_BUTTON_INPUT_NAME}>
+            <InputLabel input={input} />
+            <RadioGroup
+                name={`${input.getName()}-${index}`}
+                value={stringValue}
+                onValueChange={handleValueChange}
+                onBlur={onBlur}
+                error={hasErrors}
+                errorMessage={getFirstError(errors)}
+            >
+                {config.options.map(option => (
+                    <RadioGroup.Item key={option.value} value={option.value} disabled={!enabled}>
+                        <RadioGroup.Indicator />
+                        {option.label}
+                    </RadioGroup.Item>
+                ))}
+            </RadioGroup>
+        </div>
     );
 };
 


### PR DESCRIPTION
Added `InputLabel` component to form2 with label, description, and composable `InputLabel.Action` subcomponent as a pre-styled inline button slot.
Integrated `InputLabel` into `OccurrenceList` and `RadioButtonInput` to replace inline label rendering.
Added Storybook stories covering label-only, description-only, combined, and all action-button variants.
Bumped `@enonic/ui` to `~0.47.1`.

Closes #4339

<sub>*Drafted with AI assistance*</sub>
