### PR TITLE
Fix timezone handling in DateTime, Timezone and DateHelper #4368

### DIFF
--- a/src/main/resources/assets/admin/common/js/util/DateHelper.ts
+++ b/src/main/resources/assets/admin/common/js/util/DateHelper.ts
@@ -17,11 +17,6 @@ export class DateHelper {
         return date.getTimezoneOffset() / -60;
     }
 
-    // returns true if passed date uses daylight savings time
-    public static isDST(date: Date): boolean {
-        return Math.abs(date.getTimezoneOffset() / 60) > DateHelper.getTZOffset();
-    }
-
     /**
      * Parses passed UTC string into Date object.
      * @param value

--- a/src/main/resources/assets/admin/common/js/util/DateTime.ts
+++ b/src/main/resources/assets/admin/common/js/util/DateTime.ts
@@ -75,9 +75,6 @@ export class DateTime
         if (DateHelper.isUTCdate(s)) {
             date = DateHelper.makeDateFromUTCString(s);
             timezone = Timezone.getDateTimezone(date);
-            if (DateHelper.isDST(date)) { // when converting from UTC date, Date object may have an extra hour added due to DST
-                date.setHours(date.getHours() - 1);
-            }
         } else {
             date = DateHelper.parseLongDateTime(
                 DateTime.trimTZ(s),
@@ -132,53 +129,73 @@ export class DateTime
     private static parseOffset(value: string): number {
         if (DateHelper.isUTCdate(value)) {
             return 0;
-        } else {
-            const dateStr = (value || '').trim();
-
-            if (dateStr.indexOf('+') > 0) { // case with positive offset
-                const parts = dateStr.split('+');
-                if (parts.length === 2) {
-                    const offsetPart = parts[1];
-
-                    const offset = parseFloat(offsetPart);
-                    if (isNaN(offset)) {
-                        return 0;
-                    }
-
-                    return offset;
-                } else {
-                    return 0;
-                }
-            } else if (dateStr.split('-').length === 4) { // case with negative offset ('2015-02-29T12:05:59-01:00')
-                const parts = dateStr.split('-');
-                const offsetPart = parts[3];
-
-                const offset = parseFloat(offsetPart);
-                if (isNaN(offset)) {
-                    return 0;
-                }
-
-                return -offset;
-            } else {
-                return 0;
-            }
         }
+
+        const tIndex = (value || '').indexOf('T');
+        if (tIndex < 0) {
+            return null;
+        }
+
+        const timePart = value.substring(tIndex);
+
+        // Check for positive offset (e.g. +05:30)
+        const plusIndex = timePart.indexOf('+');
+        if (plusIndex > 0) {
+            return DateTime.parseOffsetValue(timePart.substring(plusIndex + 1), false);
+        }
+
+        // Check for negative offset (e.g. -05:00) — search for '-' in the time part
+        const minusIndex = timePart.lastIndexOf('-');
+        if (minusIndex > 0) {
+            return DateTime.parseOffsetValue(timePart.substring(minusIndex + 1), true);
+        }
+
+        return null;
+    }
+
+    private static parseOffsetValue(offsetStr: string, negative: boolean): number {
+        const parts = offsetStr.split(':');
+        if (parts.length !== 2) {
+            return null;
+        }
+
+        const hours = parseInt(parts[0], 10);
+        const minutes = parseInt(parts[1], 10);
+
+        if (isNaN(hours) || isNaN(minutes)) {
+            return null;
+        }
+
+        const offset = hours + minutes / 60;
+        return negative ? -offset : offset;
     }
 
     private static trimTZ(dateString: string): string {
-        let tzStartIndex = dateString.indexOf('+');
-        if (tzStartIndex > 0) {
-            return dateString.substr(0, tzStartIndex);
-        } else if (dateString.split('-').length === 4) {
-            // case when there is a negative tz (2015-02-29T12:05:59.001-01:00)
-            tzStartIndex = dateString.lastIndexOf('-');
-            return dateString.substr(0, tzStartIndex);
-        } else {
-            tzStartIndex = dateString.toLowerCase().indexOf('z');
-            if (tzStartIndex > 0) {
-                return dateString.substr(0, tzStartIndex);
-            }
+        const tIndex = dateString.indexOf('T');
+        if (tIndex < 0) {
+            return dateString;
         }
+
+        const timePart = dateString.substring(tIndex);
+
+        // Check for 'Z' / 'z'
+        const zIndex = timePart.toLowerCase().indexOf('z');
+        if (zIndex > 0) {
+            return dateString.substring(0, tIndex + zIndex);
+        }
+
+        // Check for '+' offset in time part
+        const plusIndex = timePart.indexOf('+');
+        if (plusIndex > 0) {
+            return dateString.substring(0, tIndex + plusIndex);
+        }
+
+        // Check for '-' offset in time part (negative timezone)
+        const minusIndex = timePart.lastIndexOf('-');
+        if (minusIndex > 0) {
+            return dateString.substring(0, tIndex + minusIndex);
+        }
+
         return dateString;
     }
 

--- a/src/main/resources/assets/admin/common/js/util/Timezone.ts
+++ b/src/main/resources/assets/admin/common/js/util/Timezone.ts
@@ -24,11 +24,7 @@ export class Timezone
     }
 
     static isValidOffset(s: number): boolean {
-        if (s > -13 && s < 13) {
-            return true;
-        }
-
-        return false;
+        return s >= -12 && s <= 14;
     }
 
     static fromOffset(s: number): Timezone {
@@ -90,14 +86,14 @@ export class Timezone
         return true;
     }
 
-    private padOffset(num: number, length: number = 2): string {
-        let numAsString = String(num);
+    private padOffset(num: number): string {
+        const hours = Math.floor(num);
+        const minutes = Math.round((num - hours) * 60);
 
-        while (numAsString.length < length) {
-            numAsString = '0' + numAsString;
-        }
+        const hoursStr = hours < 10 ? '0' + hours : String(hours);
+        const minutesStr = minutes < 10 ? '0' + minutes : String(minutes);
 
-        return numAsString + ':00';
+        return hoursStr + ':' + minutesStr;
     }
 }
 

--- a/src/main/resources/assets/spec/common/util/DateTime.spec.ts
+++ b/src/main/resources/assets/spec/common/util/DateTime.spec.ts
@@ -277,4 +277,149 @@ describe('DateTime', () => {
             expect(originalDate.equals(parsedDate)).toBeTruthy();
         });
     });
+
+    describe('half-hour timezone offsets', () => {
+
+        it('should parse +05:30 offset correctly', () => {
+            dateTime = DateTime.fromString('2015-04-25T12:05:00+05:30');
+            expect(dateTime.getTimezone().getOffset()).toEqual(5.5);
+            expect(dateTime.toString()).toEqual('2015-04-25T12:05:00+05:30');
+        });
+
+        it('should parse +05:45 offset correctly', () => {
+            dateTime = DateTime.fromString('2015-04-25T12:05:00+05:45');
+            expect(dateTime.getTimezone().getOffset()).toEqual(5.75);
+            expect(dateTime.toString()).toEqual('2015-04-25T12:05:00+05:45');
+        });
+
+        it('should parse -09:30 offset correctly', () => {
+            dateTime = DateTime.fromString('2015-04-25T12:05:00-09:30');
+            expect(dateTime.getTimezone().getOffset()).toEqual(-9.5);
+            expect(dateTime.toString()).toEqual('2015-04-25T12:05:00-09:30');
+        });
+
+        it('should render half-hour offset from builder correctly', () => {
+            timeZone = Timezone.create().setOffset(5.5).build();
+            expect(timeZone.toString()).toEqual('+05:30');
+        });
+
+        it('should render negative half-hour offset from builder correctly', () => {
+            timeZone = Timezone.create().setOffset(-9.5).build();
+            expect(timeZone.toString()).toEqual('-09:30');
+        });
+    });
+
+    describe('UTC date parsing', () => {
+
+        it('should convert UTC date to local time', () => {
+            dateTime = DateTime.fromString('2015-01-01T12:00:00Z');
+            let expectedDate = new Date(Date.UTC(2015, 0, 1, 12, 0, 0));
+            expect(dateTime.getHours()).toEqual(expectedDate.getHours());
+            expect(dateTime.getMinutes()).toEqual(expectedDate.getMinutes());
+        });
+
+        it('should set local timezone for UTC date', () => {
+            dateTime = DateTime.fromString('2015-04-25T12:05:00Z');
+            let expectedDate = new Date(Date.UTC(2015, 3, 25, 12, 5, 0));
+            let expectedOffset = expectedDate.getTimezoneOffset() / -60;
+            expect(dateTime.getTimezone().getOffset()).toEqual(expectedOffset);
+        });
+    });
+
+    describe('DST transitions', () => {
+
+        // These tests verify correct UTC-to-local conversion regardless of
+        // whether the test machine is currently in winter or summer time.
+        // Each test compares against a reference Date(Date.UTC(...)) which
+        // JS converts to local time correctly, proving no double-correction.
+
+        it('should correctly convert winter UTC date to local time', () => {
+            // Deep winter — standard time in most timezones
+            dateTime = DateTime.fromString('2015-01-15T14:30:00Z');
+            let expected = new Date(Date.UTC(2015, 0, 15, 14, 30, 0));
+            expect(dateTime.getYear()).toEqual(expected.getFullYear());
+            expect(dateTime.getMonth()).toEqual(expected.getMonth());
+            expect(dateTime.getDay()).toEqual(expected.getDate());
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+            expect(dateTime.getTimezone().getOffset()).toEqual(expected.getTimezoneOffset() / -60);
+        });
+
+        it('should correctly convert summer UTC date to local time', () => {
+            // Deep summer — DST active in most timezones that observe it
+            dateTime = DateTime.fromString('2015-07-15T14:30:00Z');
+            let expected = new Date(Date.UTC(2015, 6, 15, 14, 30, 0));
+            expect(dateTime.getYear()).toEqual(expected.getFullYear());
+            expect(dateTime.getMonth()).toEqual(expected.getMonth());
+            expect(dateTime.getDay()).toEqual(expected.getDate());
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+            expect(dateTime.getTimezone().getOffset()).toEqual(expected.getTimezoneOffset() / -60);
+        });
+
+        it('should correctly convert date just after spring-forward (EU)', () => {
+            // 2015-03-29 01:00 UTC = moment CET springs forward to CEST
+            dateTime = DateTime.fromString('2015-03-29T02:30:00Z');
+            let expected = new Date(Date.UTC(2015, 2, 29, 2, 30, 0));
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+            expect(dateTime.getTimezone().getOffset()).toEqual(expected.getTimezoneOffset() / -60);
+        });
+
+        it('should correctly convert date just after fall-back (EU)', () => {
+            // 2015-10-25 01:00 UTC = moment CEST falls back to CET
+            dateTime = DateTime.fromString('2015-10-25T02:30:00Z');
+            let expected = new Date(Date.UTC(2015, 9, 25, 2, 30, 0));
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+            expect(dateTime.getTimezone().getOffset()).toEqual(expected.getTimezoneOffset() / -60);
+        });
+
+        it('should correctly convert date just after spring-forward (US)', () => {
+            // 2015-03-08 07:00 UTC = moment US/Eastern springs forward
+            dateTime = DateTime.fromString('2015-03-08T08:30:00Z');
+            let expected = new Date(Date.UTC(2015, 2, 8, 8, 30, 0));
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+            expect(dateTime.getTimezone().getOffset()).toEqual(expected.getTimezoneOffset() / -60);
+        });
+
+        it('should correctly convert date just after fall-back (US)', () => {
+            // 2015-11-01 06:00 UTC = moment US/Eastern falls back
+            dateTime = DateTime.fromString('2015-11-01T06:30:00Z');
+            let expected = new Date(Date.UTC(2015, 10, 1, 6, 30, 0));
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+            expect(dateTime.getTimezone().getOffset()).toEqual(expected.getTimezoneOffset() / -60);
+        });
+
+        it('should use correct timezone offset for winter vs summer dates', () => {
+            let winterDt = DateTime.fromString('2015-01-15T12:00:00Z');
+            let summerDt = DateTime.fromString('2015-07-15T12:00:00Z');
+            let winterRef = new Date(Date.UTC(2015, 0, 15, 12, 0, 0));
+            let summerRef = new Date(Date.UTC(2015, 6, 15, 12, 0, 0));
+
+            // Timezone offsets should match JS Date behavior for each season
+            expect(winterDt.getTimezone().getOffset()).toEqual(winterRef.getTimezoneOffset() / -60);
+            expect(summerDt.getTimezone().getOffset()).toEqual(summerRef.getTimezoneOffset() / -60);
+
+            // If the local timezone observes DST, offsets will differ between winter and summer
+            let winterOffset = winterRef.getTimezoneOffset();
+            let summerOffset = summerRef.getTimezoneOffset();
+            if (winterOffset !== summerOffset) {
+                expect(winterDt.getTimezone().getOffset()).not.toEqual(summerDt.getTimezone().getOffset());
+            }
+        });
+
+        it('should handle midnight UTC crossing date boundary', () => {
+            // 2015-07-15T23:30:00Z — in positive-offset timezones this crosses to the next day
+            dateTime = DateTime.fromString('2015-07-15T23:30:00Z');
+            let expected = new Date(Date.UTC(2015, 6, 15, 23, 30, 0));
+            expect(dateTime.getYear()).toEqual(expected.getFullYear());
+            expect(dateTime.getMonth()).toEqual(expected.getMonth());
+            expect(dateTime.getDay()).toEqual(expected.getDate());
+            expect(dateTime.getHours()).toEqual(expected.getHours());
+            expect(dateTime.getMinutes()).toEqual(expected.getMinutes());
+        });
+    });
 });


### PR DESCRIPTION
  - Support half-hour timezone offsets (e.g. +05:30, +05:45) by parsing HH:MM format in parseOffset and rendering fractional hours in padOffset
  - Remove broken DST double-correction in UTC date parsing; JS Date          already converts UTC to local time correctly
  - Return null instead of 0 from parseOffset on failure so malformed
    offsets are not silently treated as UTC
  - Replace fragile split-count heuristic in trimTZ with T-index-relative
    search for timezone markers
  - Extend valid offset range to [-12, +14] to cover all real timezones
  - Add tests for half-hour offsets, DST transitions and UTC conversion