### PR TITLE
Show occurrence validation errors in form inputs #4373

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
@@ -31,6 +31,10 @@ vi.mock('react', () => ({
     useState: mocks.useState,
 }));
 
+vi.mock('../../I18nContext', () => ({
+    useI18n: vi.fn(() => (key: string) => key),
+}));
+
 vi.mock('../../ValidationContext', () => ({
     useValidationVisibility: mocks.useValidationVisibility,
 }));
@@ -55,6 +59,14 @@ vi.mock('../../hooks/usePropertyArray', () => ({
 
 vi.mock('../../hooks/useOccurrenceManager', () => ({
     useOccurrenceManager: mocks.useOccurrenceManager,
+}));
+
+vi.mock('../../utils/validation', () => ({
+    getOccurrenceErrorMessage: vi.fn(() => undefined),
+}));
+
+vi.mock('../field-error', () => ({
+    FieldError: () => null,
 }));
 
 vi.mock('../occurrence-list', () => ({

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
@@ -8,10 +8,13 @@ import {getEffectiveOccurrences} from '../../descriptor/getEffectiveOccurrences'
 import type {OccurrenceValidationState} from '../../descriptor/OccurrenceManager';
 import {useOccurrenceManager} from '../../hooks/useOccurrenceManager';
 import {usePropertyArray} from '../../hooks/usePropertyArray';
+import {useI18n} from '../../I18nContext';
 import {useRawValueMap} from '../../RawValueContext';
 import {InputTypeRegistry} from '../../registry/InputTypeRegistry';
 import type {InputTypeComponent, InputTypeDefinition, SelfManagedInputTypeComponent} from '../../types';
+import {getOccurrenceErrorMessage} from '../../utils/validation';
 import {useValidationVisibility} from '../../ValidationContext';
+import {FieldError} from '../field-error';
 import {InputLabel} from '../input-label';
 import {OccurrenceList} from '../occurrence-list';
 import {UnsupportedInput} from '../unsupported-input';
@@ -80,6 +83,7 @@ export const InputFieldResolved = ({
         () => getEffectiveOccurrences(definition.mode, input.getOccurrences()),
         [definition.mode, input],
     );
+    const t = useI18n();
     const visibility = useValidationVisibility();
     const rawValueMap = useRawValueMap();
     const [touched, setTouched] = useState<Set<number>>(() => new Set());
@@ -201,6 +205,7 @@ export const InputFieldResolved = ({
 
         case 'internal': {
             const Component = definition.component;
+            const occurrenceError = getOccurrenceErrorMessage(occurrences, filteredValidation, t);
             // TODO: [#4328] Clamp oversupplied initial values for internal mode to legacy max behavior.
             return (
                 <div data-component={INPUT_FIELD_NAME} className='flex flex-col'>
@@ -217,6 +222,7 @@ export const InputFieldResolved = ({
                         enabled={enabled}
                         errors={filteredValidation}
                     />
+                    {occurrenceError != null && <FieldError className='mt-2' message={occurrenceError} />}
                 </div>
             );
         }

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -145,6 +145,15 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
         const errors = state.occurrenceValidation[0];
         if (value == null || errors == null) return <div data-component={OCCURRENCE_LIST_NAME} />;
 
+        const occurrenceError = getOccurrenceErrorMessage(occurrences, state.occurrenceValidation, t);
+        // Occurrence error is mutually exclusive with field errors (getOccurrenceErrorMessage
+        // returns undefined when field errors exist), so it's safe to merge into the same array.
+        // This lets components render it via their built-in error display (e.g. Input.error).
+        const allErrors =
+            occurrenceError != null
+                ? [...errors.validationResults, {message: occurrenceError}]
+                : errors.validationResults;
+
         return (
             <div data-component={OCCURRENCE_LIST_NAME} className='grid gap-y-2'>
                 <InputLabel input={input} />
@@ -156,7 +165,7 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
                     input={input}
                     enabled={enabled}
                     index={0}
-                    errors={errors.validationResults}
+                    errors={allErrors}
                 />
             </div>
         );


### PR DESCRIPTION
Added occurrence validation error display to `InputField` (internal mode) and `OccurrenceList` (single mode). Internal-mode inputs render a standalone `FieldError` below the component; single-mode inputs merge the occurrence error into `validationResults` so it surfaces through the component's built-in error UI.

Closes #4373

<sub>*Drafted with AI assistance*</sub>
