### PR TITLE
ComboBoxInput: fix multi-select checkbox rendering and interaction #4378

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~0.47.2",
+    "@enonic/ui": "~0.47.5",
     "@radix-ui/react-slot": "^1.2.0",
     "focus-trap-react": "^11.0.0",
     "lucide-react": ">=0.500.0",
@@ -52,7 +52,7 @@
     "@biomejs/biome": "~2.3.8",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~0.47.2",
+    "@enonic/ui": "~0.47.5",
     "@rollup/plugin-inject": "^5.0.5",
     "@storybook/addon-docs": "~10.2.19",
     "@storybook/addon-themes": "~10.2.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/ui':
-        specifier: ~0.47.2
-        version: 0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+        specifier: ~0.47.5
+        version: 0.47.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.59.0)
@@ -241,8 +241,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@enonic/ui@0.47.2':
-    resolution: {integrity: sha512-O5OJDnF0Z89Cc8D4u71s9MGmoBgV6zquCOKeh2PrTJR4QxYzrVytkBo3GP6wOYy3ZfJo/wZYFjSCP/+MIM6+pw==}
+  '@enonic/ui@0.47.5':
+    resolution: {integrity: sha512-rTl2RPg+l6IFk4v8ueEcYxr6JmGLmWBXt9FwL/gEaY+KcYqTXVyQyCHU8LMuasLCb56WDPv+8lvcxziQEX97PA==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -1973,7 +1973,7 @@ snapshots:
       react: 19.2.4
       tslib: 2.8.1
 
-  '@enonic/ui@0.47.2(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.47.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       class-variance-authority: 0.7.1

--- a/src/main/resources/assets/admin/common/js/form2/components/combo-box-input/ComboBoxInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/combo-box-input/ComboBoxInput.tsx
@@ -1,5 +1,5 @@
-import {Combobox, cn, IconButton, Listbox} from '@enonic/ui';
-import {X} from 'lucide-react';
+import {Combobox, cn, FilledSquareCheck, IconButton, Listbox} from '@enonic/ui';
+import {Square, X} from 'lucide-react';
 import type {ReactElement} from 'react';
 import {useCallback, useMemo, useState} from 'react';
 
@@ -103,8 +103,17 @@ export const ComboBoxInput = ({
                         <Combobox.Popup>
                             <Listbox.Content className='rounded-sm'>
                                 {filteredOptions.map(option => (
-                                    <Listbox.Item key={option.value} value={option.value}>
-                                        {option.label}
+                                    <Listbox.Item key={option.value} value={option.value} className='min-h-5.5'>
+                                        <span className='flex-1'>{option.label}</span>
+                                        {isMultiSelect && (
+                                            <span
+                                                className='pointer-events-none inline-flex shrink-0'
+                                                aria-hidden='true'
+                                            >
+                                                <Square className='size-4 text-main group-aria-selected:hidden group-data-[tone=inverse]:text-alt' />
+                                                <FilledSquareCheck className='hidden size-4 text-main group-aria-selected:block group-data-[tone=inverse]:text-alt' />
+                                            </span>
+                                        )}
                                     </Listbox.Item>
                                 ))}
                             </Listbox.Content>


### PR DESCRIPTION
Replaced `Checkbox` component with CSS-driven icon swap (`Square`/`FilledSquareCheck`) in ComboBoxInput multi-select dropdown. The `Checkbox` label intercepted clicks preventing `Listbox.Item` from toggling selection, and its `checked` prop read committed values instead of the Combobox's internal staged selection. Added `min-h-5.5` for consistent row height. Bumped `@enonic/ui` to 0.47.5.

Closes #4378

<sub>*Drafted with AI assistance*</sub>
