### PR TITLE
Impossible to type into input with regular expression #4411

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
@@ -5,6 +5,7 @@ import {ValueTypes} from '../../../data/ValueTypes';
 import {InputBuilder} from '../../../form/Input';
 import {InputTypeName} from '../../../form/InputTypeName';
 import {Occurrences} from '../../../form/Occurrences';
+import type {InputTypeConfig, InputTypeDescriptor} from '../../descriptor';
 import type {InputTypeComponent, SelfManagedInputTypeComponent} from '../../types';
 import {InputField, InputFieldResolved} from './InputField';
 
@@ -91,13 +92,13 @@ function makeInput(typeName: string, max = 1) {
         .build();
 }
 
-function makeDescriptor() {
+function makeDescriptor(): InputTypeDescriptor<InputTypeConfig> {
     return {
         name: 'TestType',
         getValueType: () => ValueTypes.STRING,
         readConfig: vi.fn(() => ({})),
         createDefaultValue: () => ValueTypes.STRING.newNullValue(),
-        validate: () => [],
+        validate: (_value: Value, _config: InputTypeConfig, _rawValue?: string) => [],
         valueBreaksRequired: (value: Value) => value.isNull(),
     };
 }
@@ -189,6 +190,49 @@ describe('InputField', () => {
 
         expect(child.type).toBe(mocks.occurrenceListRoot);
         expect(child.props.Component).toBe(component);
+    });
+
+    it('stores null plus rawValue for invalid TextLine edits', () => {
+        const component: InputTypeComponent = () => null;
+        const descriptor = makeDescriptor();
+        const definition = {mode: 'list' as const, descriptor, component};
+        const input = makeInput('TextLine', 2);
+        const propertySet = new PropertyTree().getRoot();
+        const set = vi.fn();
+        const rawValueMap = new Map<string, (string | undefined)[]>();
+
+        descriptor.validate = vi.fn((value: Value, _config: unknown, rawValue?: string) => {
+            const text = value.isNull() ? rawValue : value.getString();
+            return text === 'abc' ? [{message: 'field.value.invalid'}] : [];
+        });
+
+        mocks.useRawValueMap.mockReturnValue(rawValueMap);
+        mocks.usePropertyArray.mockReturnValue({values: [ValueTypes.STRING.newNullValue()], size: 1});
+        mocks.useOccurrenceManager.mockReturnValue({
+            state: {
+                ...makeManagerState(ValueTypes.STRING.newNullValue()),
+                values: [ValueTypes.STRING.newNullValue()],
+                occurrenceValidation: [{index: 0, breaksRequired: false, validationResults: []}],
+                totalValid: 0,
+            },
+            add: vi.fn(() => true),
+            remove: vi.fn(() => true),
+            move: vi.fn(() => true),
+            set,
+            sync: vi.fn(),
+        });
+
+        const element = InputFieldResolved({input, propertySet, enabled: true, definition});
+        const child = getOnlyChild(element);
+
+        child.props.onChange(0, ValueTypes.STRING.newValue('abc'), 'abc');
+
+        expect(set).toHaveBeenCalledOnce();
+        expect(set.mock.calls[0][0]).toBe(0);
+        expect((set.mock.calls[0][1] as Value).isNull()).toBe(true);
+        expect(set.mock.calls[0][2]).toBe('abc');
+        expect(rawValueMap.get('testField')).toEqual(['abc']);
+        expect(propertySet.getPropertyArray('testField')?.getValue(0)?.isNull()).toBe(true);
     });
 
     it('renders internal components with onMove and disables auto-seeding', () => {

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.test.ts
@@ -1,8 +1,51 @@
-import {describe, expect, it} from 'vitest';
+import type {JSX} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {Value} from '../../../data/Value';
 import {ValueTypes} from '../../../data/ValueTypes';
-import type {ValidationResult} from '../../descriptor/ValidationResult';
+import type {ValidationResult} from '../../descriptor';
 import {getFirstError} from '../../utils';
+import {TextLineInput, type TextLineInputProps} from './TextLineInput';
+
+const mocks = vi.hoisted(() => ({
+    useState: vi.fn((initial: unknown) => [
+        typeof initial === 'function' ? (initial as () => unknown)() : initial,
+        vi.fn(),
+    ]),
+    useEffect: vi.fn(),
+    useRef: vi.fn((initial: unknown) => ({current: initial})),
+    input: vi.fn(() => null),
+}));
+
+vi.mock('react', async importOriginal => {
+    const actual = await importOriginal<typeof import('react')>();
+
+    return {
+        ...actual,
+        useState: mocks.useState,
+        useEffect: mocks.useEffect,
+        useRef: mocks.useRef,
+    };
+});
+
+vi.mock('@enonic/ui', () => ({
+    Input: mocks.input,
+}));
+
+function makeProps(overrides: Partial<TextLineInputProps> = {}): TextLineInputProps {
+    return {
+        value: ValueTypes.STRING.newNullValue(),
+        onChange: vi.fn(),
+        onBlur: vi.fn(),
+        config: {regexp: undefined, maxLength: -1, showCounter: false},
+        input: {} as TextLineInputProps['input'],
+        enabled: true,
+        index: 0,
+        errors: [],
+        ...overrides,
+    };
+}
+
+type VNode = {type: unknown; props: Record<string, any>};
 
 describe('getFirstError', () => {
     it('should return undefined for empty array', () => {
@@ -30,6 +73,16 @@ describe('getFirstError', () => {
 });
 
 describe('TextLineInput', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.useState.mockImplementation((initial: unknown) => [
+            typeof initial === 'function' ? (initial as () => unknown)() : initial,
+            vi.fn(),
+        ]);
+        mocks.useEffect.mockImplementation(() => undefined);
+        mocks.useRef.mockImplementation((initial: unknown) => ({current: initial}));
+    });
+
     describe('value transformation', () => {
         it('should produce empty string for null value', () => {
             const value = ValueTypes.STRING.newNullValue();
@@ -56,6 +109,25 @@ describe('TextLineInput', () => {
             expect(newValue).toBeInstanceOf(Value);
             expect(newValue.getString()).toBe('test input');
             expect(newValue.getType()).toBe(ValueTypes.STRING);
+        });
+
+        it('forwards raw input value through onChange', () => {
+            const onChange = vi.fn();
+            const setRawInput = vi.fn();
+
+            mocks.useState.mockImplementationOnce((initial: unknown) => [
+                typeof initial === 'function' ? (initial as () => unknown)() : initial,
+                setRawInput,
+            ]);
+
+            const element = TextLineInput(makeProps({onChange})) as VNode;
+
+            element.props.onChange({currentTarget: {value: 'abc'}} as JSX.TargetedEvent<HTMLInputElement>);
+
+            expect(setRawInput).toHaveBeenCalledWith('abc');
+            expect(onChange).toHaveBeenCalledOnce();
+            expect((onChange.mock.calls[0][0] as Value).getString()).toBe('abc');
+            expect(onChange.mock.calls[0][1]).toBe('abc');
         });
     });
 });

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
@@ -1,5 +1,6 @@
 import {Input} from '@enonic/ui';
 import type {JSX} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {ValueTypes} from '../../../data/ValueTypes';
 import type {TextLineConfig} from '../../descriptor';
@@ -7,34 +8,47 @@ import type {InputTypeComponentProps} from '../../types';
 import {getFirstError} from '../../utils';
 import {Counter} from '../counter';
 
+export type TextLineInputProps = InputTypeComponentProps<TextLineConfig>;
+
+function valueToString(value: TextLineInputProps['value']): string {
+    return value.isNull() ? '' : (value.getString() ?? '');
+}
+
 const TEXT_LINE_INPUT_NAME = 'TextLineInput';
 
-export const TextLineInput = ({
-    value,
-    onChange,
-    onBlur,
-    config,
-    enabled,
-    errors,
-}: InputTypeComponentProps<TextLineConfig>): JSX.Element => {
-    const stringValue = value.isNull() ? '' : (value.getString() ?? '');
+export const TextLineInput = ({value, onChange, onBlur, config, enabled, errors}: TextLineInputProps): JSX.Element => {
+    const [rawInput, setRawInput] = useState(() => valueToString(value));
+    const isLocalChange = useRef(false);
     const hasMaxLength = config.maxLength > 0;
     const maxLength = hasMaxLength ? config.maxLength : undefined;
     const hasBoth = hasMaxLength && config.showCounter;
 
+    useEffect(() => {
+        if (isLocalChange.current) {
+            isLocalChange.current = false;
+            return;
+        }
+
+        setRawInput(valueToString(value));
+    }, [value]);
+
     const counterAddon = config.showCounter ? (
         <div className='mr-3 self-center'>
-            <Counter length={stringValue.length} maxLength={maxLength} />
+            <Counter length={rawInput.length} maxLength={maxLength} />
         </div>
     ) : undefined;
 
     const handleChange = (e: JSX.TargetedEvent<HTMLInputElement>) => {
-        onChange(ValueTypes.STRING.newValue(e.currentTarget.value));
+        const inputValue = e.currentTarget.value;
+
+        isLocalChange.current = true;
+        setRawInput(inputValue);
+        onChange(ValueTypes.STRING.newValue(inputValue), inputValue);
     };
 
     return (
         <Input
-            value={stringValue}
+            value={rawInput}
             onChange={handleChange}
             onBlur={onBlur}
             disabled={!enabled}

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/TextLineDescriptor.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/TextLineDescriptor.test.ts
@@ -103,6 +103,28 @@ describe('TextLineDescriptor', () => {
             return {regexp: undefined, maxLength: -1, showCounter: false, ...overrides};
         }
 
+        it('validates rawValue when stored value is null and regexp is broken', () => {
+            const config = makeConfig({regexp: /^[A-Z]+$/});
+            const results = TextLineDescriptor.validate(ValueTypes.STRING.newNullValue(), config, 'abc');
+
+            expect(results).toHaveLength(1);
+            expect(results[0].message).toContain('field.value.invalid');
+        });
+
+        it('validates rawValue when stored value is null and maxLength is exceeded', () => {
+            const config = makeConfig({maxLength: 3});
+            const results = TextLineDescriptor.validate(ValueTypes.STRING.newNullValue(), config, 'abcd');
+
+            expect(results).toHaveLength(1);
+            expect(results[0].message).toContain('field.value.breaks.maxlength');
+        });
+
+        it('does not report an error for empty rawValue when stored value is null', () => {
+            const config = makeConfig({regexp: /^[A-Z]+$/});
+
+            expect(TextLineDescriptor.validate(ValueTypes.STRING.newNullValue(), config, '')).toEqual([]);
+        });
+
         it('returns empty array for valid input', () => {
             const config = makeConfig();
             const value = ValueTypes.STRING.newValue('hello');

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/TextLineDescriptor.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/TextLineDescriptor.ts
@@ -43,13 +43,13 @@ export const TextLineDescriptor: InputTypeDescriptor<TextLineConfig> = {
         return ValueTypes.STRING.newValue(raw);
     },
 
-    validate(value: Value, config: TextLineConfig): ValidationResult[] {
+    validate(value: Value, config: TextLineConfig, rawValue?: string): ValidationResult[] {
         const results: ValidationResult[] = [];
-        if (value.isNull()) {
+        const str = value.isNull() ? rawValue : (value.getString() ?? '');
+
+        if (str == null) {
             return results;
         }
-
-        const str = value.getString();
 
         if (config.maxLength > 0 && str.length > config.maxLength) {
             results.push({message: i18n('field.value.breaks.maxlength', config.maxLength)});


### PR DESCRIPTION
Fixed form2 TextLine regex handling so users can keep typing invalid intermediate values instead of the field clearing on each keystroke. The input now keeps local raw text, forwards that raw value upstream, and TextLineDescriptor validates rawValue when the stored value is null.

Added regression tests for all three layers: TextLineInput, InputField, and TextLineDescriptor.