### PR TITLE
SortableList: disable pointer events on row content during drag #4432

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-grid-list/SortableGridList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-grid-list/SortableGridList.tsx
@@ -2,6 +2,7 @@ import {
     closestCenter,
     DndContext,
     type DragEndEvent,
+    type DragStartEvent,
     KeyboardSensor,
     PointerSensor,
     useSensor,
@@ -30,6 +31,8 @@ export type SortableGridListItemContext<T> = {
     index: number;
     /** `true` while this item is actively being dragged. */
     isDragging: boolean;
+    /** `true` while any item in the list is being dragged. */
+    isDragActive: boolean;
     /** `true` when the row or any of its children has DOM focus. */
     isFocused: boolean;
     /** `true` when this row can be reordered. */
@@ -301,6 +304,7 @@ type SortableGridListItemInternalProps<T> = {
     index: number;
     isMovable: boolean;
     isNavigable: boolean;
+    isDragActive: boolean;
     enabled: boolean;
     fullRowDraggable: boolean;
     isTabStop: boolean;
@@ -319,6 +323,7 @@ const SortableGridListItem = <T,>({
     index,
     isMovable,
     isNavigable,
+    isDragActive,
     enabled,
     fullRowDraggable,
     isTabStop,
@@ -432,6 +437,7 @@ const SortableGridListItem = <T,>({
         item,
         index,
         isDragging,
+        isDragActive,
         isFocused,
         isMovable,
     };
@@ -518,6 +524,7 @@ export const SortableGridList = <T,>({
     const [focusedIndex, setFocusedIndex] = useState(0);
     const [focusedTargetIndex, setFocusedTargetIndex] = useState(0);
     const [focusedItemId, setFocusedItemId] = useState<string | null>(null);
+    const [isDragActive, setIsDragActive] = useState(false);
     const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
     const hasFocusWithinRef = useRef(false);
     const pendingBlurClearVersionRef = useRef(0);
@@ -711,8 +718,14 @@ export const SortableGridList = <T,>({
         }
     }, [focusRowByIndex, focusedIndex, focusedItemId, focusedTargetIndex, ids, items.length]);
 
+    const handleDragStart = useCallback((_event: DragStartEvent) => {
+        setIsDragActive(true);
+    }, []);
+
     const handleDragEnd = useCallback(
         (event: DragEndEvent) => {
+            setIsDragActive(false);
+
             const {active, over} = event;
             if (over == null || active.id === over.id) return;
 
@@ -736,13 +749,25 @@ export const SortableGridList = <T,>({
         [focusRowByIndex, focusedIndex, focusedItemId, focusedTargetIndex, ids, onMove],
     );
 
+    const handleDragCancel = useCallback(() => {
+        setIsDragActive(false);
+    }, []);
+
     return (
-        <div data-component={dataComponent} className={className} onFocus={handleListFocus} onBlur={handleListBlur}>
+        <div
+            data-component={dataComponent}
+            data-drag-active={isDragActive || undefined}
+            className={cn(isDragActive && '[&_*]:pointer-events-none', className)}
+            onFocus={handleListFocus}
+            onBlur={handleListBlur}
+        >
             <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
                 modifiers={[restrictToVerticalAxis]}
+                onDragStart={handleDragStart}
                 onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
             >
                 <SortableContext items={ids} strategy={verticalListSortingStrategy}>
                     {items.map((item, i) => (
@@ -753,6 +778,7 @@ export const SortableGridList = <T,>({
                             index={i}
                             isMovable={getIsItemMovable(item, i)}
                             isNavigable={isNavigable}
+                            isDragActive={isDragActive}
                             enabled={enabled}
                             fullRowDraggable={fullRowDraggable}
                             isTabStop={focusedIndex === i}

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.tsx
@@ -32,6 +32,8 @@ export type SortableListItemContext<T> = {
     index: number;
     /** `true` while this item is actively being dragged. */
     isDragging: boolean;
+    /** `true` while any item in the list is being dragged. */
+    isDragActive: boolean;
     /** `true` when the row or any of its children has DOM focus. */
     isFocused: boolean;
     /** `true` when the list has 2+ items (drag handles visible). */
@@ -98,6 +100,7 @@ type SortableListItemInternalProps<T> = {
     item: T;
     index: number;
     isMovable: boolean;
+    isDragActive: boolean;
     enabled: boolean;
     controlGrip: boolean;
     fullRowDraggable: boolean;
@@ -114,6 +117,7 @@ const SortableListItem = <T,>({
     item,
     index,
     isMovable,
+    isDragActive,
     enabled,
     controlGrip,
     fullRowDraggable,
@@ -159,6 +163,7 @@ const SortableListItem = <T,>({
         item,
         index,
         isDragging,
+        isDragActive,
         isFocused,
         isMovable,
     };
@@ -242,6 +247,7 @@ export const SortableList = <T,>({
     const ids = useMemo(() => items.map((item, i) => keyExtractor(item, i)), [items, keyExtractor]);
     const isMovable = items.length >= 2;
     const [dropAllowed, setDropAllowed] = useState(true);
+    const [isDragActive, setIsDragActive] = useState(false);
 
     const sensors = useSensors(
         useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
@@ -253,6 +259,7 @@ export const SortableList = <T,>({
     const handleDragStart = useCallback(
         (event: DragStartEvent) => {
             setDropAllowed(true);
+            setIsDragActive(true);
             if (onDragStartProp != null) {
                 const index = ids.indexOf(String(event.active.id));
                 if (index !== -1) {
@@ -283,6 +290,7 @@ export const SortableList = <T,>({
     const handleDragEnd = useCallback(
         (event: DragEndEvent) => {
             setDropAllowed(true);
+            setIsDragActive(false);
 
             const {active, over} = event;
             if (over == null || active.id === over.id) return;
@@ -296,8 +304,17 @@ export const SortableList = <T,>({
         [ids, onMove],
     );
 
+    const handleDragCancel = useCallback(() => {
+        setDropAllowed(true);
+        setIsDragActive(false);
+    }, []);
+
     return (
-        <div data-component={dataComponent} className={className}>
+        <div
+            data-component={dataComponent}
+            data-drag-active={isDragActive || undefined}
+            className={cn(isDragActive && '[&_*]:pointer-events-none', className)}
+        >
             <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
@@ -305,6 +322,7 @@ export const SortableList = <T,>({
                 onDragStart={handleDragStart}
                 onDragOver={handleDragOver}
                 onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
             >
                 <SortableContext items={ids} strategy={verticalListSortingStrategy}>
                     {items.map((item, i) => (
@@ -314,6 +332,7 @@ export const SortableList = <T,>({
                             item={item}
                             index={i}
                             isMovable={isItemMovable?.(item, i) ?? isMovable}
+                            isDragActive={isDragActive}
                             controlGrip={controlGrip}
                             enabled={enabled}
                             fullRowDraggable={fullRowDraggable}


### PR DESCRIPTION
Disabled pointer events on descendants of `SortableList` and `SortableGridList` rows while a drag is active, and exposed `isDragActive` on the item render context.

- Track `isDragActive` at the list root via `onDragStart` / `onDragEnd` / `onDragCancel`
- Apply `[&_*]:pointer-events-none` to all descendants during drag; root keeps its own events
- Add `data-drag-active` on the list root for external styling
- Extend `SortableListItemContext` and `SortableGridListItemContext` with `isDragActive`

Closes #4432

<sub>*Drafted with AI assistance*</sub>
