### PR TITLE
Add hasOccurrenceError helper to form2 validation utils #4434

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/index.ts
@@ -46,7 +46,13 @@ export type {
     SelfManagedComponentProps,
     SelfManagedInputTypeComponent,
 } from './types';
-export {findByPath, getFirstError, getOccurrenceErrorMessage, type TranslateFn} from './utils/validation';
+export {
+    findByPath,
+    getFirstError,
+    getOccurrenceErrorMessage,
+    hasOccurrenceError,
+    type TranslateFn,
+} from './utils/validation';
 // Validation
 export {
     useValidationVisibility,

--- a/src/main/resources/assets/admin/common/js/form2/utils/validation.ts
+++ b/src/main/resources/assets/admin/common/js/form2/utils/validation.ts
@@ -11,6 +11,19 @@ export function getFirstError(errors: ValidationResult[]): string | undefined {
     return errors.at(0)?.message ?? undefined;
 }
 
+type OccurrenceBreach = 'none' | 'min' | 'max';
+
+function getOccurrenceBreach(occurrences: Occurrences, validation: OccurrenceValidationState[]): OccurrenceBreach {
+    const hasFieldErrors = validation.some(entry => entry.validationResults.length > 0);
+    if (hasFieldErrors) return 'none';
+
+    const totalValid = validation.filter(entry => !entry.breaksRequired && entry.validationResults.length === 0).length;
+
+    if (occurrences.minimumBreached(totalValid)) return 'min';
+    if (occurrences.maximumBreached(totalValid)) return 'max';
+    return 'none';
+}
+
 /**
  * Derive an occurrence-level error message from validation state.
  *
@@ -22,22 +35,27 @@ export function getOccurrenceErrorMessage(
     validation: OccurrenceValidationState[],
     t: TranslateFn,
 ): string | undefined {
-    const hasFieldErrors = validation.some(entry => entry.validationResults.length > 0);
-    if (hasFieldErrors) return undefined;
+    const breach = getOccurrenceBreach(occurrences, validation);
+    if (breach === 'none') return undefined;
 
-    const totalValid = validation.filter(entry => !entry.breaksRequired && entry.validationResults.length === 0).length;
     const min = occurrences.getMinimum();
     const max = occurrences.getMaximum();
 
-    if (occurrences.minimumBreached(totalValid)) {
+    if (breach === 'min') {
         return min >= 1 && max !== 1 ? t('field.occurrence.breaks.min', min) : t('field.value.required');
     }
 
-    if (occurrences.maximumBreached(totalValid)) {
-        return max > 1 ? t('field.occurrence.breaks.max.many', max) : t('field.occurrence.breaks.max.one');
-    }
+    return max > 1 ? t('field.occurrence.breaks.max.many', max) : t('field.occurrence.breaks.max.one');
+}
 
-    return undefined;
+/**
+ * Check whether occurrence counts breach min/max bounds.
+ *
+ * Boolean counterpart to {@link getOccurrenceErrorMessage} — use when
+ * only the presence of an occurrence error matters and no message is needed.
+ */
+export function hasOccurrenceError(occurrences: Occurrences, validation: OccurrenceValidationState[]): boolean {
+    return getOccurrenceBreach(occurrences, validation) !== 'none';
 }
 
 function search(nodes: FormValidationNode[], path: string): FormValidationNode | undefined {


### PR DESCRIPTION
Added `hasOccurrenceError` as a boolean counterpart to `getOccurrenceErrorMessage` so callers that only need a flag (e.g. `useSelectorInputHasError`) can skip the `useI18n()` dependency. Extracted a shared private `getOccurrenceBreach` helper so both functions single-source the min/max check. Exported the new function from the `form2` barrel.

Closes #4434

<sub>*Drafted with AI assistance*</sub>
