### PR TITLE
Bump @enonic/ui from 0.49.0 to 0.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~0.49.0",
+    "@enonic/ui": "~0.50.0",
     "@radix-ui/react-slot": "^1.2.0",
     "focus-trap-react": "^11.0.0",
     "lucide-react": ">=0.500.0",
@@ -52,7 +52,7 @@
     "@biomejs/biome": "~2.4.14",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~0.49.0",
+    "@enonic/ui": "~0.50.0",
     "@rollup/plugin-inject": "^5.0.5",
     "@storybook/addon-docs": "~10.3.6",
     "@storybook/addon-themes": "~10.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@enonic/ui':
-        specifier: ~0.49.0
-        version: 0.49.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(preact@10.29.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)
+        specifier: ~0.50.0
+        version: 0.50.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(preact@10.29.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5(rollup@4.60.1)
@@ -253,8 +253,8 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@enonic/ui@0.49.0':
-    resolution: {integrity: sha512-htA0dEX4L+xuWo+hj5olNyX315DsyiuAKVHLch4ukCrBiroEzJ+IwSlF776vtYROcStyXZAzl8rAUVP3vEEkoQ==}
+  '@enonic/ui@0.50.0':
+    resolution: {integrity: sha512-VTZFAvVAX5tET3PK0br6LuKFNUEgxVQxljcBN+WL5BoPMm32vhwXNboXHME2iQzwqaV4aDwfnlJjP/RAOsLVwA==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -2131,7 +2131,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@enonic/ui@0.49.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(preact@10.29.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)':
+  '@enonic/ui@0.50.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(preact@10.29.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       class-variance-authority: 0.7.1


### PR DESCRIPTION
Updates `@enonic/ui` from `~0.49.0` to `~0.50.0` in both `peerDependencies` and `devDependencies`, and refreshes `pnpm-lock.yaml`.

Verified with `pnpm check` (types, lint, 941 tests passing).

<sub>*Drafted with AI assistance*</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9KHwCG3VkaSQUwcMXc5E5)_