### PR TITLE
Accessibility patch #4479

### DIFF
--- a/src/main/resources/assets/admin/common/js/dom/WindowDOM.ts
+++ b/src/main/resources/assets/admin/common/js/dom/WindowDOM.ts
@@ -22,11 +22,7 @@ export class WindowDOM {
         this.el.onbeforeunload = (event) => {
             handle(event, this.onBeforeUnloadListeners);
         };
-        // Avoid the unload event: it can be disabled by Permissions-Policy and
-        // logs a browser violation when registered. pagehide still covers page
-        // exit cleanup, including bfcache navigations. Listeners intentionally
-        // run for persisted pages too, matching the old "leaving the page"
-        // semantics.
+
         this.el.addEventListener('pagehide', (event: PageTransitionEvent) => {
             handle(event, this.onUnloadListeners);
         }, {capture: true});

--- a/src/main/resources/assets/admin/common/js/dom/WindowDOM.ts
+++ b/src/main/resources/assets/admin/common/js/dom/WindowDOM.ts
@@ -10,21 +10,26 @@ export class WindowDOM {
 
     private onBeforeUnloadListeners: ((event: UIEvent) => void)[] = [];
 
-    private onUnloadListeners: ((event: UIEvent) => void)[] = [];
+    private onUnloadListeners: ((event: PageTransitionEvent) => void)[] = [];
 
     constructor(element: Window = window) {
         this.el = element;
 
-        const handle = function (event: UIEvent, listeners: ((event: UIEvent) => void)[]) {
+        const handle = function <TEvent extends Event>(event: TEvent, listeners: ((event: TEvent) => void)[]) {
             listeners.forEach(l => l(event));
         };
 
         this.el.onbeforeunload = (event) => {
             handle(event, this.onBeforeUnloadListeners);
         };
-        this.el.onunload = (event) => {
+        // Avoid the unload event: it can be disabled by Permissions-Policy and
+        // logs a browser violation when registered. pagehide still covers page
+        // exit cleanup, including bfcache navigations. Listeners intentionally
+        // run for persisted pages too, matching the old "leaving the page"
+        // semantics.
+        this.el.addEventListener('pagehide', (event: PageTransitionEvent) => {
             handle(event, this.onUnloadListeners);
-        };
+        }, {capture: true});
 
         Store.instance().set(WINDOW_KEY, this);
     }
@@ -133,11 +138,11 @@ export class WindowDOM {
         return this;
     }
 
-    onUnload(listener: (event: UIEvent) => void) {
+    onUnload(listener: (event: PageTransitionEvent) => void) {
         this.onUnloadListeners.push(listener);
     }
 
-    unUnload(listener: (event: UIEvent) => void) {
+    unUnload(listener: (event: PageTransitionEvent) => void) {
         this.onUnloadListeners = this.onUnloadListeners.filter(curr => curr !== listener);
         return this;
     }

--- a/src/main/resources/assets/admin/common/js/form2/components/date-input/DateInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/date-input/DateInput.tsx
@@ -3,11 +3,11 @@ import {type JSX, type ReactElement, useEffect, useRef, useState} from 'react';
 
 import {ValueTypes} from '../../../data/ValueTypes';
 import {DateHelper} from '../../../util/DateHelper';
+import type {DateConfig} from '../../descriptor';
 import {DATE_PATTERN} from '../../descriptor/DateDescriptor';
-import type {DateConfig} from '../../descriptor/InputTypeConfig';
 import {useI18n} from '../../I18nContext';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils/validation';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 
 const DATE_INPUT_NAME = 'DateInput';
 
@@ -17,7 +17,16 @@ function valueToString(value: DateInputProps['value']): string {
     return value.isNull() ? '' : (value.getString() ?? '');
 }
 
-export const DateInput = ({value, onChange, onBlur, config, enabled, errors}: DateInputProps): ReactElement => {
+export const DateInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: DateInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const [open, setOpen] = useState(false);
     // ? DatePicker API uses null for "no selection" — applies to draftDate, selectedDate, calendarValue
@@ -88,6 +97,7 @@ export const DateInput = ({value, onChange, onBlur, config, enabled, errors}: Da
             <div ref={inputWrapperRef}>
                 <Input
                     ref={inputRef}
+                    aria-label={getInputAccessibleName(input, index)}
                     type='text'
                     placeholder={t('field.date.placeholder')}
                     value={rawInput}

--- a/src/main/resources/assets/admin/common/js/form2/components/date-time-input/DateTimeInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/date-time-input/DateTimeInput.tsx
@@ -3,10 +3,10 @@ import {type JSX, type ReactElement, useEffect, useRef, useState} from 'react';
 
 import {ValueTypes} from '../../../data/ValueTypes';
 import {DateHelper} from '../../../util/DateHelper';
-import type {DateTimeConfig} from '../../descriptor/InputTypeConfig';
+import type {DateTimeConfig} from '../../descriptor';
 import {useI18n} from '../../I18nContext';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils/validation';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 
 const DATE_TIME_INPUT_NAME = 'DateTimeInput';
 
@@ -55,7 +55,16 @@ function parseTimeFromDisplay(raw: string): string | null {
     return `${DateHelper.padNumber(hour)}:${DateHelper.padNumber(minute)}`;
 }
 
-export const DateTimeInput = ({value, onChange, onBlur, config, enabled, errors}: DateTimeInputProps): ReactElement => {
+export const DateTimeInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: DateTimeInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToDisplay(value));
     const [open, setOpen] = useState(false);
     // ? DatePicker/TimePicker API uses null for "no selection"
@@ -143,6 +152,7 @@ export const DateTimeInput = ({value, onChange, onBlur, config, enabled, errors}
             <div ref={inputWrapperRef}>
                 <Input
                     ref={inputRef}
+                    aria-label={getInputAccessibleName(input, index)}
                     type='text'
                     placeholder={t('field.dateTime.placeholder')}
                     value={rawInput}

--- a/src/main/resources/assets/admin/common/js/form2/components/double-input/DoubleInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/double-input/DoubleInput.tsx
@@ -3,7 +3,7 @@ import {type JSX, type ReactElement, useEffect, useRef, useState} from 'react';
 import {ValueTypes} from '../../../data/ValueTypes';
 import type {NumberConfig} from '../../descriptor';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 import {getStep} from './utils';
 
 const DOUBLE_INPUT_NAME = 'DoubleInput';
@@ -14,7 +14,16 @@ function valueToString(value: DoubleInputProps['value']): string {
     return value.isNull() ? '' : String(value.getDouble() ?? '');
 }
 
-export const DoubleInput = ({value, onChange, onBlur, config, enabled, errors}: DoubleInputProps): ReactElement => {
+export const DoubleInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: DoubleInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const minStep = useRef(getStep(rawInput));
     const prevRawInput = useRef(rawInput);
@@ -66,6 +75,7 @@ export const DoubleInput = ({value, onChange, onBlur, config, enabled, errors}: 
     return (
         <Input
             data-component={DOUBLE_INPUT_NAME}
+            aria-label={getInputAccessibleName(input, index)}
             type='number'
             step={step}
             value={rawInput}

--- a/src/main/resources/assets/admin/common/js/form2/components/geo-point-input/GeoPointInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/geo-point-input/GeoPointInput.tsx
@@ -4,7 +4,7 @@ import {ValueTypes} from '../../../data/ValueTypes';
 import {GeoPoint} from '../../../util/GeoPoint';
 import type {GeoPointConfig} from '../../descriptor';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 
 const GEO_POINT_INPUT_NAME = 'GeoPointInput';
 
@@ -14,7 +14,15 @@ function valueToString(value: GeoPointInputProps['value']): string {
     return value.isNull() ? '' : (value.getGeoPoint().toString() ?? '');
 }
 
-export const GeoPointInput = ({value, onChange, onBlur, enabled, errors}: GeoPointInputProps): ReactElement => {
+export const GeoPointInput = ({
+    value,
+    onChange,
+    onBlur,
+    input,
+    enabled,
+    index,
+    errors,
+}: GeoPointInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const lastEmitted = useRef<string | undefined>(undefined);
 
@@ -50,6 +58,7 @@ export const GeoPointInput = ({value, onChange, onBlur, enabled, errors}: GeoPoi
     return (
         <Input
             data-component={GEO_POINT_INPUT_NAME}
+            aria-label={getInputAccessibleName(input, index)}
             type='text'
             value={rawInput}
             onChange={handleChange}

--- a/src/main/resources/assets/admin/common/js/form2/components/instant-input/InstantInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/instant-input/InstantInput.tsx
@@ -3,10 +3,10 @@ import {type JSX, type ReactElement, useEffect, useMemo, useRef, useState} from 
 
 import {ValueTypes} from '../../../data/ValueTypes';
 import {DateHelper} from '../../../util/DateHelper';
-import type {InstantConfig} from '../../descriptor/InputTypeConfig';
+import type {InstantConfig} from '../../descriptor';
 import {useI18n} from '../../I18nContext';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils/validation';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 
 const INSTANT_INPUT_NAME = 'InstantInput';
 
@@ -90,7 +90,16 @@ function formatTimezoneLabel(date: Date | null, time: string | null): string {
     return `UTC${sign}${DateHelper.padNumber(hours)}:${DateHelper.padNumber(minutes)}`;
 }
 
-export const InstantInput = ({value, onChange, onBlur, config, enabled, errors}: InstantInputProps): ReactElement => {
+export const InstantInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: InstantInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToDisplay(value));
     const [open, setOpen] = useState(false);
     // ? DatePicker/TimePicker API uses null for "no selection"
@@ -180,6 +189,7 @@ export const InstantInput = ({value, onChange, onBlur, config, enabled, errors}:
             <div ref={inputWrapperRef}>
                 <Input
                     ref={inputRef}
+                    aria-label={getInputAccessibleName(input, index)}
                     type='text'
                     placeholder={t('field.dateTime.placeholder')}
                     value={rawInput}

--- a/src/main/resources/assets/admin/common/js/form2/components/long-input/LongInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/long-input/LongInput.tsx
@@ -3,9 +3,9 @@ import type {JSX, ReactElement} from 'react';
 import {useEffect, useRef, useState} from 'react';
 
 import {ValueTypes} from '../../../data/ValueTypes';
-import type {NumberConfig} from '../../descriptor/InputTypeConfig';
+import type {NumberConfig} from '../../descriptor';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 
 const LONG_INPUT_NAME = 'LongInput';
 
@@ -15,7 +15,16 @@ function valueToString(value: LongInputProps['value']): string {
     return value.isNull() ? '' : String(value.getLong() ?? '');
 }
 
-export const LongInput = ({value, onChange, onBlur, config, enabled, errors}: LongInputProps): ReactElement => {
+export const LongInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: LongInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const isLocalChange = useRef(false);
 
@@ -43,6 +52,7 @@ export const LongInput = ({value, onChange, onBlur, config, enabled, errors}: Lo
     return (
         <Input
             data-component={LONG_INPUT_NAME}
+            aria-label={getInputAccessibleName(input, index)}
             type='number'
             step={1}
             value={rawInput}

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
@@ -19,7 +19,7 @@ import {ValueTypes} from '../../../data/ValueTypes';
 import type {Occurrences} from '../../../form/Occurrences';
 import {useI18n} from '../../I18nContext';
 import type {SelfManagedComponentProps} from '../../types';
-import {getFirstError, getOccurrenceErrorMessage} from '../../utils';
+import {getFirstError, getInputAccessibleName, getOccurrenceErrorMessage} from '../../utils';
 import {FieldError} from '../field-error';
 import {
     getPastedTagLabels,
@@ -79,6 +79,7 @@ type TagViewState = {
 
 type TagDraftInputProps = {
     draft: string;
+    accessibleName: string;
     enabled: boolean;
     invalid: boolean;
     visible: boolean;
@@ -323,6 +324,7 @@ function getCompactedTagIndex(values: Value[], index: number): number {
 
 function renderTagDraftInput({
     draft,
+    accessibleName,
     enabled,
     invalid,
     visible,
@@ -344,6 +346,7 @@ function renderTagDraftInput({
         >
             <Input
                 ref={inputRef}
+                aria-label={accessibleName}
                 className={cn(
                     '[&_input]:px-2.5 [&_input]:text-sm',
                     '[&>div[data-state]]:h-7 [&>div[data-state]]:border-transparent! [&>div[data-state]]::text-sm',
@@ -612,6 +615,7 @@ export const TagInput = ({
     onRemove,
     onMove,
     occurrences,
+    input,
     enabled,
     errors,
 }: TagInputProps): ReactElement => {
@@ -1072,6 +1076,7 @@ export const TagInput = ({
                             {showInlineInput &&
                                 renderTagDraftInput({
                                     draft,
+                                    accessibleName: getInputAccessibleName(input),
                                     enabled,
                                     invalid: isDraftDuplicate,
                                     visible: isDraftInputVisible,

--- a/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.tsx
@@ -4,7 +4,7 @@ import type {JSX} from 'react';
 import {ValueTypes} from '../../../data/ValueTypes';
 import type {TextAreaConfig} from '../../descriptor';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 import {Counter} from '../counter';
 
 const TEXT_AREA_INPUT_NAME = 'TextAreaInput';
@@ -14,7 +14,9 @@ export const TextAreaInput = ({
     onChange,
     onBlur,
     config,
+    input,
     enabled,
+    index,
     errors,
 }: InputTypeComponentProps<TextAreaConfig>): JSX.Element => {
     const stringValue = value.isNull() ? '' : (value.getString() ?? '');
@@ -40,6 +42,7 @@ export const TextAreaInput = ({
 
     return (
         <TextArea
+            aria-label={getInputAccessibleName(input, index)}
             autoSize
             value={stringValue}
             onChange={handleChange}

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.test.ts
@@ -2,6 +2,9 @@ import type {JSX} from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {Value} from '../../../data/Value';
 import {ValueTypes} from '../../../data/ValueTypes';
+import {InputBuilder} from '../../../form/Input';
+import {InputTypeName} from '../../../form/InputTypeName';
+import {Occurrences} from '../../../form/Occurrences';
 import type {ValidationResult} from '../../descriptor';
 import {getFirstError} from '../../utils';
 import {TextLineInput, type TextLineInputProps} from './TextLineInput';
@@ -31,13 +34,24 @@ vi.mock('@enonic/ui', () => ({
     Input: mocks.input,
 }));
 
+function makeInput() {
+    return new InputBuilder()
+        .setName('textLine')
+        .setInputType(new InputTypeName('TextLine', false))
+        .setLabel('Text line')
+        .setOccurrences(Occurrences.max(1))
+        .setHelpText('')
+        .setInputTypeConfig({})
+        .build();
+}
+
 function makeProps(overrides: Partial<TextLineInputProps> = {}): TextLineInputProps {
     return {
         value: ValueTypes.STRING.newNullValue(),
         onChange: vi.fn(),
         onBlur: vi.fn(),
         config: {regexp: undefined, maxLength: -1, showCounter: false},
-        input: {} as TextLineInputProps['input'],
+        input: makeInput(),
         enabled: true,
         index: 0,
         errors: [],

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
@@ -5,7 +5,7 @@ import {useEffect, useRef, useState} from 'react';
 import {ValueTypes} from '../../../data/ValueTypes';
 import type {TextLineConfig} from '../../descriptor';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 import {Counter} from '../counter';
 
 export type TextLineInputProps = InputTypeComponentProps<TextLineConfig>;
@@ -16,7 +16,16 @@ function valueToString(value: TextLineInputProps['value']): string {
 
 const TEXT_LINE_INPUT_NAME = 'TextLineInput';
 
-export const TextLineInput = ({value, onChange, onBlur, config, enabled, errors}: TextLineInputProps): JSX.Element => {
+export const TextLineInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: TextLineInputProps): JSX.Element => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const isLocalChange = useRef(false);
     const hasMaxLength = config.maxLength > 0;
@@ -48,6 +57,7 @@ export const TextLineInput = ({value, onChange, onBlur, config, enabled, errors}
 
     return (
         <Input
+            aria-label={getInputAccessibleName(input, index)}
             value={rawInput}
             onChange={handleChange}
             onBlur={onBlur}

--- a/src/main/resources/assets/admin/common/js/form2/components/time-input/TimeInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/time-input/TimeInput.tsx
@@ -3,11 +3,11 @@ import {type JSX, type ReactElement, useEffect, useRef, useState} from 'react';
 
 import {ValueTypes} from '../../../data/ValueTypes';
 import {DateHelper} from '../../../util/DateHelper';
-import type {TimeConfig} from '../../descriptor/InputTypeConfig';
+import type {TimeConfig} from '../../descriptor';
 import {TIME_PATTERN} from '../../descriptor/TimeDescriptor';
 import {useI18n} from '../../I18nContext';
 import type {InputTypeComponentProps} from '../../types';
-import {getFirstError} from '../../utils/validation';
+import {getFirstError, getInputAccessibleName} from '../../utils';
 
 const TIME_INPUT_NAME = 'TimeInput';
 
@@ -32,7 +32,16 @@ function parseTimeToPickerValue(raw: string): string | null {
     return `${DateHelper.padNumber(hour)}:${DateHelper.padNumber(minute)}`;
 }
 
-export const TimeInput = ({value, onChange, onBlur, config, enabled, errors}: TimeInputProps): ReactElement => {
+export const TimeInput = ({
+    value,
+    onChange,
+    onBlur,
+    config,
+    input,
+    enabled,
+    index,
+    errors,
+}: TimeInputProps): ReactElement => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const [open, setOpen] = useState(false);
     // ? Uses `null` instead of `undefined` because TimePicker API uses `null` for empty value
@@ -96,6 +105,7 @@ export const TimeInput = ({value, onChange, onBlur, config, enabled, errors}: Ti
             <div data-component={TIME_INPUT_NAME} ref={inputWrapperRef}>
                 <Input
                     ref={inputRef}
+                    aria-label={getInputAccessibleName(input, index)}
                     type='text'
                     placeholder={t('field.time.placeholder')}
                     value={rawInput}

--- a/src/main/resources/assets/admin/common/js/form2/utils/accessibility.ts
+++ b/src/main/resources/assets/admin/common/js/form2/utils/accessibility.ts
@@ -1,0 +1,11 @@
+import type {Input} from '../../form/Input';
+
+export function getInputAccessibleName(input: Input, index?: number): string {
+    const label = input.getLabel() || input.getName().toString();
+
+    if (index == null || !input.getOccurrences().multiple()) {
+        return label;
+    }
+
+    return `${label} ${index + 1}`;
+}

--- a/src/main/resources/assets/admin/common/js/form2/utils/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './accessibility';
 export * from './validation';


### PR DESCRIPTION
Fix WindowDOM.onLoad
* Replace the deprecated unload handler with pagehide.
Add aria-label for inputs.