### PR TITLE
Plumb reveal highlight through OccurrenceList to inputs #4492

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~1.0.0-beta.3",
+    "@enonic/ui": "~1.0.0-beta.5",
     "@radix-ui/react-slot": "^1.2.0",
     "focus-trap-react": "^11.0.0",
     "lucide-react": ">=0.500.0",
@@ -52,7 +52,7 @@
     "@biomejs/biome": "~2.4.15",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~1.0.0-beta.3",
+    "@enonic/ui": "~1.0.0-beta.5",
     "@rollup/plugin-inject": "^5.0.5",
     "@storybook/addon-docs": "~10.3.6",
     "@storybook/addon-themes": "~10.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@enonic/ui':
-        specifier: ~1.0.0-beta.3
-        version: 1.0.0-beta.3(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.16.0(react@19.2.5))(preact@10.29.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)
+        specifier: ~1.0.0-beta.5
+        version: 1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.16.0(react@19.2.5))(preact@10.29.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5
@@ -253,8 +253,8 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@enonic/ui@1.0.0-beta.3':
-    resolution: {integrity: sha512-obhpBDrE6JSbhyBIZaNnYS/4/iygVXoKsD4y973/mugCAasd2gaB5flZLoIVa3dGy6WtnJvMGoselsvc/fy6AQ==}
+  '@enonic/ui@1.0.0-beta.5':
+    resolution: {integrity: sha512-1CBPbC8vERGWZaeovqf57W5MgEbL9/MI3cEp6nFagzK85ekbtm2gqlai9wxwIcEfPONYOQMrIbQMumNaTSXj5A==}
     engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -1989,7 +1989,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@enonic/ui@1.0.0-beta.3(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.16.0(react@19.2.5))(preact@10.29.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)':
+  '@enonic/ui@1.0.0-beta.5(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.16.0(react@19.2.5))(preact@10.29.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       class-variance-authority: 0.7.1

--- a/src/main/resources/assets/admin/common/js/form2/FieldRegistry.ts
+++ b/src/main/resources/assets/admin/common/js/form2/FieldRegistry.ts
@@ -22,7 +22,7 @@ export type FieldRegistration = {
     notifyActivePath: (path: string | undefined) => void;
 };
 
-export type RevealOptions = {focus?: boolean};
+export type RevealOptions = {focus?: boolean; scroll?: boolean};
 
 /**
  * Routes external messages (e.g. translation failures) to specific input fields by path.

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
@@ -229,6 +229,9 @@ export const InputFieldResolved = ({
     const activeNotifierRef = useRef<((path: string | undefined) => void) | null>(null);
     const [, setTick] = useState(0);
     const forceRender = useCallback((): void => setTick(tick => tick + 1), []);
+    const [highlightTrigger, setHighlightTrigger] = useState<{occurrenceId: string; count: number} | undefined>(
+        undefined,
+    );
 
     // Prune processing tokens and cached ref callbacks for occurrences that no
     // longer exist. Runs every render; the Maps are small (one entry per
@@ -432,7 +435,13 @@ export const InputFieldResolved = ({
                     if (el.readOnly) return false;
                 }
             }
-            el.scrollIntoView({block: 'center', behavior: 'smooth'});
+            if (options?.scroll !== false) {
+                el.scrollIntoView({block: 'center', behavior: 'smooth'});
+            }
+            setHighlightTrigger(prev => ({
+                occurrenceId: targetId,
+                count: (prev?.occurrenceId === targetId ? prev.count : 0) + 1,
+            }));
             if (options?.focus === true) {
                 el.focus({preventScroll: true});
             }
@@ -515,6 +524,11 @@ export const InputFieldResolved = ({
                         readOnly={!enabled || processing}
                         processing={processing}
                         inputRef={occId != null ? getInputRefCallback(occId) : undefined}
+                        highlight={
+                            occId != null && highlightTrigger?.occurrenceId === occId
+                                ? highlightTrigger.count
+                                : undefined
+                        }
                     />
                 </div>
             );
@@ -561,11 +575,14 @@ export const InputFieldResolved = ({
                         onRemove={handleRemove}
                         onMove={handleMove}
                         onChange={handleChange}
-                        onBlur={handleBlur}
+                        onBlur={handleOccurrenceBlur}
+                        onFocus={handleOccurrenceFocus}
                         config={config}
                         input={input}
                         enabled={enabled}
                         processingOccurrenceIds={processingOccurrenceIds}
+                        getInputRef={getInputRefCallback}
+                        highlight={highlightTrigger}
                     />
                 </div>
             );

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -23,6 +23,7 @@ export type OccurrenceListRootProps<C extends InputTypeConfig = InputTypeConfig>
     onMove: (fromIndex: number, toIndex: number) => void;
     onChange: (index: number, value: Value, rawValue?: string) => void;
     onBlur?: (index: number) => void;
+    onFocus?: () => void;
     config: C;
     input: Input;
     enabled: boolean;
@@ -33,6 +34,17 @@ export type OccurrenceListRootProps<C extends InputTypeConfig = InputTypeConfig>
      * affordance through TextLine/TextArea inputs.
      */
     processingOccurrenceIds?: ReadonlySet<string>;
+    /**
+     * Resolves the `inputRef` callback for an occurrence ID. InputField supplies this so
+     * each rendered occurrence reports its focusable DOM element back into the field's
+     * ref map — backing reveal/focus/blur-on-acquire for list-mode input types.
+     */
+    getInputRef?: (occurrenceId: string) => (el: HTMLElement | null) => void;
+    /**
+     * Attention-blink trigger for a single occurrence. The matching occurrence receives
+     * `count` as its `highlight` prop; every other occurrence receives `undefined`.
+     */
+    highlight?: {occurrenceId: string; count: number};
 };
 
 type OccurrenceListItemContentProps<C extends InputTypeConfig = InputTypeConfig> = {
@@ -45,8 +57,11 @@ type OccurrenceListItemContentProps<C extends InputTypeConfig = InputTypeConfig>
     errors: OccurrenceManagerState['occurrenceValidation'][number];
     showRemove: boolean;
     processing: boolean;
+    inputRef?: (el: HTMLElement | null) => void;
+    highlight?: number;
     onChange: (index: number, value: Value, rawValue?: string) => void;
     onBlur?: (index: number) => void;
+    onFocus?: () => void;
     onRemove: (index: number) => void;
 };
 
@@ -68,8 +83,11 @@ const OccurrenceListItemContent = <C extends InputTypeConfig = InputTypeConfig>(
     errors,
     showRemove,
     processing,
+    inputRef,
+    highlight,
     onChange,
     onBlur,
+    onFocus,
     onRemove,
 }: OccurrenceListItemContentProps<C>): ReactNode => {
     const t = useI18n();
@@ -81,12 +99,15 @@ const OccurrenceListItemContent = <C extends InputTypeConfig = InputTypeConfig>(
                     value={value}
                     onChange={(v: Value, raw?: string) => onChange(index, v, raw)}
                     onBlur={onBlur ? () => onBlur(index) : undefined}
+                    onFocus={onFocus}
                     config={config}
                     input={input}
                     enabled={enabled}
                     index={index}
                     errors={errors.validationResults}
                     processing={processing}
+                    inputRef={inputRef}
+                    highlight={highlight}
                 />
             </div>
             {showRemove && (
@@ -131,12 +152,23 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
     onMove,
     onChange,
     onBlur,
+    onFocus,
     config,
     input,
     enabled,
     processingOccurrenceIds,
+    getInputRef,
+    highlight,
 }: OccurrenceListRootProps<C>): ReactElement => {
     const isProcessing = (index: number): boolean => processingOccurrenceIds?.has(state.ids[index]) ?? false;
+    const occurrenceInputRef = (index: number): ((el: HTMLElement | null) => void) | undefined => {
+        const occurrenceId = state.ids[index];
+        return occurrenceId != null ? getInputRef?.(occurrenceId) : undefined;
+    };
+    const occurrenceHighlight = (index: number): number | undefined => {
+        const occurrenceId = state.ids[index];
+        return highlight != null && highlight.occurrenceId === occurrenceId ? highlight.count : undefined;
+    };
     const t = useI18n();
     const occurrences = input.getOccurrences();
     const min = occurrences.getMinimum();
@@ -172,12 +204,15 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
                     value={value}
                     onChange={(v: Value, raw?: string) => onChange(0, v, raw)}
                     onBlur={onBlur ? () => onBlur(0) : undefined}
+                    onFocus={onFocus}
                     config={config}
                     input={input}
                     enabled={enabled}
                     index={0}
                     errors={allErrors}
                     processing={isProcessing(0)}
+                    inputRef={occurrenceInputRef(0)}
+                    highlight={occurrenceHighlight(0)}
                 />
             </div>
         );
@@ -195,8 +230,11 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
         // matching legacy isRemoveButtonRequiredStrict() — never remove the last visible input.
         showRemove: state.canRemove && state.values.length > 1 && !isFixed,
         processing: isProcessing(index),
+        inputRef: occurrenceInputRef(index),
+        highlight: occurrenceHighlight(index),
         onChange,
         onBlur,
+        onFocus,
         onRemove,
     });
 

--- a/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.stories.tsx
@@ -171,12 +171,9 @@ export const WithMaxLengthAndCounter: Story = {
 };
 
 function HighlightDemo() {
-    const [highlight, setHighlight] = useState(false);
+    const [highlight, setHighlight] = useState(0);
 
-    const handleClick = () => {
-        setHighlight(false);
-        window.setTimeout(() => setHighlight(true), 0);
-    };
+    const handleClick = () => setHighlight(count => count + 1);
 
     return (
         <div className='flex flex-col gap-y-3 p-4'>

--- a/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.tsx
@@ -8,9 +8,7 @@ import type {InputTypeComponentProps} from '../../types';
 import {getFirstError, getInputAccessibleName} from '../../utils';
 import {Counter} from '../counter';
 
-export type TextAreaInputProps = InputTypeComponentProps<TextAreaConfig> & {
-    highlight?: boolean;
-};
+export type TextAreaInputProps = InputTypeComponentProps<TextAreaConfig>;
 
 const TEXT_AREA_INPUT_NAME = 'TextAreaInput';
 
@@ -26,7 +24,7 @@ export const TextAreaInput = ({
     errors,
     readOnly = false,
     processing = false,
-    highlight = false,
+    highlight,
     inputRef: externalInputRef,
 }: TextAreaInputProps): JSX.Element => {
     const textAreaRef = useRef<HTMLTextAreaElement | null>(null);

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.stories.tsx
@@ -164,12 +164,9 @@ export const WithMaxLengthAndCounter: Story = {
 };
 
 function HighlightDemo() {
-    const [highlight, setHighlight] = useState(false);
+    const [highlight, setHighlight] = useState(0);
 
-    const handleClick = () => {
-        setHighlight(false);
-        window.setTimeout(() => setHighlight(true), 0);
-    };
+    const handleClick = () => setHighlight(count => count + 1);
 
     return (
         <div className='flex flex-col gap-y-3 p-4'>

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
@@ -8,9 +8,7 @@ import type {InputTypeComponentProps} from '../../types';
 import {getFirstError, getInputAccessibleName} from '../../utils';
 import {Counter} from '../counter';
 
-export type TextLineInputProps = InputTypeComponentProps<TextLineConfig> & {
-    highlight?: boolean;
-};
+export type TextLineInputProps = InputTypeComponentProps<TextLineConfig>;
 
 function valueToString(value: TextLineInputProps['value']): string {
     return value.isNull() ? '' : (value.getString() ?? '');
@@ -30,7 +28,7 @@ export const TextLineInput = ({
     errors,
     readOnly = false,
     processing = false,
-    highlight = false,
+    highlight,
     inputRef: externalInputRef,
 }: TextLineInputProps): JSX.Element => {
     const [rawInput, setRawInput] = useState(() => valueToString(value));

--- a/src/main/resources/assets/admin/common/js/form2/types.ts
+++ b/src/main/resources/assets/admin/common/js/form2/types.ts
@@ -30,6 +30,12 @@ export type InputTypeComponentProps<C extends InputTypeConfig = InputTypeConfig>
      * value of their internal ref and call with `null` on unmount.
      */
     inputRef?: (el: HTMLElement | null) => void;
+    /**
+     * Edge-trigger counter for the attention blink. Each increment restarts the one-shot
+     * ring pulse — InputField bumps it on `reveal`. Input types that support the affordance
+     * forward the value straight to `useBlinkAttention`; others ignore it.
+     */
+    highlight?: number;
 };
 
 /** The shape stored in ComponentRegistry: a Preact functional or class component. */


### PR DESCRIPTION
Wires the attention-blink highlight through the form2 reveal flow so calling `reveal()` on a registered field briefly pulses the targeted input.

- `RevealOptions` gains `scroll?: boolean` — callers can blink without scrolling
- `InputTypeComponentProps.highlight` is now an edge-triggered `number` counter; `TextLineInput`/`TextAreaInput` drop their local `highlight?: boolean` prop
- `InputField` tracks a `{occurrenceId, count}` trigger and bumps it on each `reveal`
- `OccurrenceList` accepts `getInputRef` and `highlight` props, routing them to the matching occurrence
- TextLine/TextArea Highlight stories switched from a `setTimeout`-toggled boolean to a counter

Closes #4492

<sub>*Drafted with AI assistance*</sub>
