### PR TITLE
TextLineInput and TextAreaInput scroll twice on reveal highlight #4494

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-area-input/TextAreaInput.tsx
@@ -28,7 +28,9 @@ export const TextAreaInput = ({
     inputRef: externalInputRef,
 }: TextAreaInputProps): JSX.Element => {
     const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
-    const isBlinking = useBlinkAttention(textAreaRef, highlight);
+    // ? Scroll is owned by the parent InputField (gated on RevealOptions.scroll);
+    // the inner blink should highlight only, never scroll again.
+    const isBlinking = useBlinkAttention(textAreaRef, highlight, {scrollIntoView: false});
 
     useEffect(() => {
         if (externalInputRef == null) return undefined;

--- a/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/text-line-input/TextLineInput.tsx
@@ -34,7 +34,9 @@ export const TextLineInput = ({
     const [rawInput, setRawInput] = useState(() => valueToString(value));
     const isLocalChange = useRef(false);
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const isBlinking = useBlinkAttention(inputRef, highlight);
+    // ? Scroll is owned by the parent InputField (gated on RevealOptions.scroll);
+    // the inner blink should highlight only, never scroll again.
+    const isBlinking = useBlinkAttention(inputRef, highlight, {scrollIntoView: false});
     const hasMaxLength = config.maxLength > 0;
     const maxLength = hasMaxLength ? config.maxLength : undefined;
     const hasBoth = hasMaxLength && config.showCounter;


### PR DESCRIPTION
Passed `{scrollIntoView: false}` to `useBlinkAttention` in `TextLineInput` and `TextAreaInput` so the inner blink only highlights, leaving scroll to the parent `InputField` gate (`RevealOptions.scroll`).

Closes #4494

<sub>*Drafted with AI assistance*</sub>
