### PR TITLE
InputField registers under schema path, colliding across set occurrences #4496

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
@@ -763,6 +763,52 @@ describe('InputField', () => {
             mocks.useEffect.mockReset();
         });
 
+        it('registers under the data path including occurrence indices for nested PropertySets', async () => {
+            const {FieldRegistry} = await import('../../FieldRegistry');
+            const registry = new FieldRegistry();
+            const registerSpy = vi.spyOn(registry, 'register');
+            const {useFieldRegistry} = await import('../../FieldRegistryContext');
+            vi.mocked(useFieldRegistry).mockReturnValueOnce(registry);
+
+            mocks.useOccurrenceManager.mockReturnValue({
+                state: makeManagerState(),
+                add: vi.fn(() => true),
+                remove: vi.fn(() => true),
+                move: vi.fn(() => true),
+                set: vi.fn(),
+                sync: vi.fn(() => []),
+                setTransientError: vi.fn(() => false),
+                clearTransientError: vi.fn(() => false),
+                clearAllTransientErrors: vi.fn(),
+                getOccurrenceIds: vi.fn(() => []),
+            });
+
+            mocks.useEffect.mockImplementation((effect: () => unknown) => {
+                effect();
+            });
+
+            // Build a tree with `.itemSet[1]` so the input mounted against that
+            // occurrence registers under `.itemSet[1].testField`.
+            const tree = new PropertyTree();
+            const root = tree.getRoot();
+            root.addPropertySet('itemSet');
+            const secondOccurrence = root.addPropertySet('itemSet');
+
+            const component: InputTypeComponent = () => null;
+            const descriptor = makeDescriptor();
+            const definition = {mode: 'single' as const, descriptor, component};
+            const input = makeInput('TextLine');
+
+            InputFieldResolved({input, propertySet: secondOccurrence, enabled: true, definition});
+
+            expect(registerSpy).toHaveBeenCalled();
+            const lastCall = registerSpy.mock.calls.at(-1);
+            if (lastCall == null) throw new Error('register was not called');
+            expect(lastCall[0]).toBe('.itemSet[1].testField');
+
+            mocks.useEffect.mockReset();
+        });
+
         it('blurs the focused input without emitting active-path null to subscribers', async () => {
             const {FieldRegistry} = await import('../../FieldRegistry');
             const registry = new FieldRegistry();

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
@@ -1,6 +1,7 @@
 import {type ReactElement, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {PropertyArray} from '../../../data/PropertyArray';
+import {PropertyPath, PropertyPathElement} from '../../../data/PropertyPath';
 import type {PropertySet} from '../../../data/PropertySet';
 import type {Value} from '../../../data/Value';
 import type {Input} from '../../../form/Input';
@@ -254,7 +255,11 @@ export const InputFieldResolved = ({
     }, [state.ids, forceRender]);
 
     const fieldRegistry = useFieldRegistry();
-    const fieldPath = useMemo(() => input.getPath().toString(), [input]);
+    // No useMemo: parent reorders mutate propertySet's index without changing identity.
+    const fieldPath = PropertyPath.fromParent(
+        propertySet.getPropertyPath(),
+        new PropertyPathElement(input.getName(), 0),
+    ).toString();
 
     useEffect(() => {
         const managerValues = sync(values);


### PR DESCRIPTION
Switched `InputField` to register its `FieldRegistry` handle under the full data path (e.g. `.itemSet[1].field`) derived from `propertySet.getPropertyPath()`, so each Item Set / Option Set occurrence's input gets a unique key. Dropped `useMemo` on `fieldPath` because parent PropertyArray reorders mutate the propertySet's index without changing its JS identity. Added a test that mounts an input under `root.itemSet[1]` and verifies it registers under `.itemSet[1].testField`.

Unblocks enonic/app-contentstudio#10537.

Closes #4496

<sub>*Drafted with AI assistance*</sub>
