### PR TITLE
Update @enonic/ui to 1.0.0-beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~1.0.0-beta.7",
+    "@enonic/ui": "~1.0.0-beta.9",
     "@radix-ui/react-slot": "^1.2.0",
     "focus-trap-react": "^11.0.0",
     "lucide-react": ">=0.500.0",
@@ -52,7 +52,7 @@
     "@biomejs/biome": "~2.4.15",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "~1.0.0-beta.7",
+    "@enonic/ui": "~1.0.0-beta.9",
     "@rollup/plugin-inject": "^5.0.5",
     "@storybook/addon-docs": "~10.4.1",
     "@storybook/addon-themes": "~10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@enonic/ui':
-        specifier: ~1.0.0-beta.7
-        version: 1.0.0-beta.7(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.6))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(lucide-react@1.16.0(react@19.2.6))(preact@10.29.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tw-animate-css@1.4.0)
+        specifier: ~1.0.0-beta.9
+        version: 1.0.0-beta.9(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.6))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(lucide-react@1.16.0(react@19.2.6))(preact@10.29.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5
@@ -259,9 +259,9 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@enonic/ui@1.0.0-beta.7':
-    resolution: {integrity: sha512-edo7ET1Q8g/oiLj0Dicf/TIHDTPuTZ78J0MnLbtOEQEPVDZ0laZMEX456KO9d++DEZDRpsaVbaPSKfyoJ4xv6Q==}
-    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
+  '@enonic/ui@1.0.0-beta.9':
+    resolution: {integrity: sha512-1z7q+yuDTJ7MnwGC3CLlBmu1lcqEY/A+k3OUl9Qt8ko+cJxKU9ELxkBebXOJzTt2nWXgHBmH7PBw0f0/Qapqkw==}
+    engines: {node: '>=24.16.0', pnpm: '>=11.1.1'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
       focus-trap-react: ^11.0.0
@@ -2264,7 +2264,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@enonic/ui@1.0.0-beta.7(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.6))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(lucide-react@1.16.0(react@19.2.6))(preact@10.29.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tw-animate-css@1.4.0)':
+  '@enonic/ui@1.0.0-beta.9(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.6))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(lucide-react@1.16.0(react@19.2.6))(preact@10.29.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.6)
       class-variance-authority: 0.7.1


### PR DESCRIPTION
Updated `@enonic/ui` from `~1.0.0-beta.7` to `~1.0.0-beta.9` in `peerDependencies` and `devDependencies`, refreshed `pnpm-lock.yaml` via the Gradle build.

<sub>*Drafted with AI assistance*</sub>