### PR TITLE
SortableList: support correct drop placement in tree-shaped lists #4512

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.stories.tsx
@@ -1,8 +1,9 @@
 import {cn} from '@enonic/ui';
 import type {Meta, StoryObj} from '@storybook/preact-vite';
-import {useCallback, useState} from 'react';
-import type {SortableListProps} from './SortableList';
+import {useCallback, useMemo, useState} from 'react';
+import type {SortableDragInfo, SortableListProps} from './SortableList';
 import {SortableList} from './SortableList';
+import {type DropProjection, projectTreeDrop} from './treeProjection';
 
 //
 // * Helpers
@@ -123,6 +124,208 @@ function ButtonDemo({fullRowDraggable}: ButtonDemoProps) {
 }
 
 //
+// * Tree projection demo (mirrors Content Studio page components)
+//
+
+type TreeItemKind = 'part' | 'text' | 'layout';
+
+type TreeItem = {
+    id: string;
+    label: string;
+    kind: TreeItemKind;
+    regions?: TreeRegion[];
+};
+
+type TreeRegion = {
+    id: string;
+    name: string;
+    items: TreeItem[];
+};
+
+type TreeRow = {
+    id: string;
+    parentId: string | null;
+    depth: number;
+    kind: 'container' | 'item';
+    label: string;
+    rowKind: 'page' | 'region' | TreeItemKind;
+};
+
+const TREE_INDENT = 16;
+
+const INITIAL_TREE: TreeRegion[] = [
+    {
+        id: 'main',
+        name: 'main',
+        items: [
+            {id: 'text-1', label: 'Heading', kind: 'text'},
+            {
+                id: 'layout-1',
+                label: '2-column layout',
+                kind: 'layout',
+                regions: [
+                    {
+                        id: 'left',
+                        name: 'left',
+                        items: [
+                            {id: 'part-a', label: 'Article', kind: 'part'},
+                            {id: 'part-b', label: 'Image', kind: 'part'},
+                        ],
+                    },
+                    {id: 'right', name: 'right', items: []},
+                ],
+            },
+            {id: 'text-2', label: 'Footer', kind: 'text'},
+        ],
+    },
+];
+
+function flattenTree(regions: TreeRegion[]): TreeRow[] {
+    const rows: TreeRow[] = [{id: 'page', parentId: null, depth: 1, kind: 'item', label: 'Page', rowKind: 'page'}];
+
+    function walkItem(item: TreeItem, parentId: string, depth: number): void {
+        rows.push({id: item.id, parentId, depth, kind: 'item', label: item.label, rowKind: item.kind});
+        item.regions?.forEach(region => {
+            walkRegion(region, item.id, depth + 1);
+        });
+    }
+
+    function walkRegion(region: TreeRegion, parentId: string, depth: number): void {
+        rows.push({id: region.id, parentId, depth, kind: 'container', label: region.name, rowKind: 'region'});
+        region.items.forEach(item => {
+            walkItem(item, region.id, depth + 1);
+        });
+    }
+
+    for (const region of regions) {
+        walkRegion(region, 'page', 2);
+    }
+    return rows;
+}
+
+function moveTreeItem(regions: TreeRegion[], itemId: string, targetRegionId: string, index: number): TreeRegion[] {
+    let moved: TreeItem | null = null;
+
+    const remove = (list: TreeRegion[]): TreeRegion[] =>
+        list.map(region => {
+            const kept: TreeItem[] = [];
+            for (const item of region.items) {
+                if (item.id === itemId) {
+                    moved = item;
+                } else {
+                    kept.push({...item, regions: item.regions ? remove(item.regions) : undefined});
+                }
+            }
+            return {...region, items: kept};
+        });
+
+    const withoutSource = remove(regions);
+    if (moved == null) return regions;
+
+    const insert = (list: TreeRegion[]): TreeRegion[] =>
+        list.map(region => {
+            const items: TreeItem[] = region.items.map(item => ({
+                ...item,
+                regions: item.regions ? insert(item.regions) : undefined,
+            }));
+            if (region.id === targetRegionId) {
+                items.splice(Math.min(index, items.length), 0, moved as TreeItem);
+            }
+            return {...region, items};
+        });
+
+    return insert(withoutSource);
+}
+
+function hasLayoutAncestor(rowById: Map<string, TreeRow>, containerId: string): boolean {
+    let parentId = rowById.get(containerId)?.parentId ?? null;
+    while (parentId != null) {
+        const parent = rowById.get(parentId);
+        if (parent == null) break;
+        if (parent.rowKind === 'layout') return true;
+        parentId = parent.parentId;
+    }
+    return false;
+}
+
+function TreeDemo() {
+    const [regions, setRegions] = useState(INITIAL_TREE);
+    const rows = useMemo(() => flattenTree(regions), [regions]);
+    const rowById = useMemo(() => new Map(rows.map(row => [row.id, row])), [rows]);
+
+    const keyExtractor = useCallback((row: TreeRow) => row.id, []);
+    const isItemMovable = useCallback((row: TreeRow) => row.kind === 'item' && row.rowKind !== 'page', []);
+
+    const project = useCallback(
+        (info: SortableDragInfo): DropProjection | null => {
+            const active = rows[info.activeIndex];
+            const over = rows[info.overIndex];
+            if (active == null || over == null) return null;
+            return projectTreeDrop({
+                nodes: rows,
+                activeId: active.id,
+                overId: over.id,
+                side: info.side,
+                direction: info.direction,
+                isContainerAllowed: containerId =>
+                    active.rowKind !== 'layout' || !hasLayoutAncestor(rowById, containerId),
+            });
+        },
+        [rows, rowById],
+    );
+
+    return (
+        <div className='w-96'>
+            <p className='mb-3 text-subtle text-xs'>
+                Drag a row up or down — it walks through the valid drop slots. Dragging up enters the region above
+                (incl. the empty one); dragging down steps out past the layout when a region ends. The dragged row
+                re-indents to show its level. It dims when the drop is not allowed (no layout in a layout).
+            </p>
+            <SortableList
+                items={rows}
+                keyExtractor={keyExtractor}
+                isItemMovable={isItemMovable}
+                enabled={rows.length > 1}
+                fullRowDraggable
+                controlGrip
+                dragLabel='Drag to move'
+                resolveDrop={info => {
+                    const projection = project(info);
+                    return projection == null
+                        ? null
+                        : {indent: projection.depth * TREE_INDENT, allowed: projection.allowed};
+                }}
+                onMove={(_from, _to, info) => {
+                    if (info == null) return;
+                    const projection = project(info);
+                    if (projection == null || !projection.allowed) return;
+                    setRegions(prev =>
+                        moveTreeItem(prev, rows[info.activeIndex].id, projection.containerId, projection.index),
+                    );
+                }}
+                className='flex flex-col gap-y-1'
+                renderItem={({item: row, projectedIndent}) => (
+                    <div
+                        style={{marginLeft: projectedIndent ?? row.depth * TREE_INDENT}}
+                        className={cn(
+                            'flex flex-1 items-center gap-2 rounded px-2 py-1 text-sm transition-[margin] duration-75',
+                            row.kind === 'container' ? 'text-subtle uppercase' : 'bg-surface-neutral font-medium',
+                        )}
+                    >
+                        {row.kind === 'item' && row.rowKind !== 'page' && (
+                            <span className='rounded bg-black/5 px-1 text-[10px] text-subtle uppercase'>
+                                {row.rowKind}
+                            </span>
+                        )}
+                        <span className='truncate'>{row.label}</span>
+                    </div>
+                )}
+            />
+        </div>
+    );
+}
+
+//
 // * Meta
 //
 
@@ -195,4 +398,9 @@ export const WithButtons: Story = {
 export const WithButtonsFullRow: Story = {
     name: 'Behavior / With Buttons (Full Row Draggable)',
     render: () => <ButtonDemo fullRowDraggable />,
+};
+
+export const TreeProjection: Story = {
+    name: 'Behavior / Tree Projection',
+    render: () => <TreeDemo />,
 };

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.tsx
@@ -2,9 +2,12 @@ import {
     closestCenter,
     DndContext,
     type DragEndEvent,
+    type DragMoveEvent,
     type DragOverEvent,
     type DragStartEvent,
     KeyboardSensor,
+    type MeasuringConfiguration,
+    MeasuringStrategy,
     PointerSensor,
     useSensor,
     useSensors,
@@ -38,6 +41,39 @@ export type SortableListItemContext<T> = {
     isFocused: boolean;
     /** `true` when the list has 2+ items (drag handles visible). */
     isMovable: boolean;
+    /**
+     * Projection mode only: the live indent (px) of the dragged row's projected drop level.
+     * Set on the dragged row mid-drag, `undefined` otherwise — apply it as the row's indent so
+     * the dragged element itself shows the level it will land at.
+     */
+    projectedIndent?: number;
+};
+
+/** Which side of the over row the dragged item lands on. */
+export type SortableDropSide = 'above' | 'below';
+
+/** Net vertical travel direction during a drag. */
+export type SortableDragDirection = 'up' | 'down';
+
+/** Live drag state surfaced in projection mode for resolving a tree-shaped drop. */
+export type SortableDragInfo = {
+    /** Index of the dragged item. */
+    activeIndex: number;
+    /** Index of the row currently under the pointer (equals `activeIndex` at the list edge). */
+    overIndex: number;
+    /** Side relative to the over row, from the dnd-kit displacement gap (below when the
+     *  dragged item comes from above the over row, above when it comes from below). */
+    side: SortableDropSide;
+    /** Net vertical travel from the drag start (sign of the cumulative offset). */
+    direction: SortableDragDirection;
+};
+
+/** Consumer's resolution of a drag state into a drop hint for the dragged row. */
+export type SortableDropHint = {
+    /** Indent in px the dragged row should adopt to show its projected drop level. */
+    indent: number;
+    /** Whether the drop is permitted; drives the dragged row's styling and the commit. */
+    allowed: boolean;
 };
 
 /** Vertical drag-to-reorder list with built-in drag handles. */
@@ -49,8 +85,11 @@ export type SortableListProps<T> = {
     keyExtractor: (item: T, index: number) => string;
     /** Called when a drag starts with the index of the dragged item. */
     onDragStart?: (index: number) => void;
-    /** Called after a drag completes with the old and new indices. */
-    onMove: (fromIndex: number, toIndex: number) => void;
+    /**
+     * Called after a drag completes with the old and new indices. In projection mode
+     * (`resolveDrop` set) it also receives the final drag state for tree-aware commits.
+     */
+    onMove: (fromIndex: number, toIndex: number, info?: SortableDragInfo) => void;
     /** Controls whether drag handles are interactive. */
     enabled: boolean;
     /** When `true`, the entire row becomes the drag target instead of just the grip handle. Defaults to `false`. */
@@ -67,6 +106,14 @@ export type SortableListProps<T> = {
     isDropAllowed?: (fromIndex: number, toIndex: number) => boolean;
     /** Custom function to control when layout-change animations run. Passed to `useSortable`. */
     animateLayoutChanges?: (args: {isSorting: boolean; wasDragging: boolean}) => boolean;
+    /**
+     * Projection mode for tree-shaped lists. When provided, the list reports the live drag
+     * state (hovered row, displacement `side`, travel `direction`) and feeds `hint.indent` back
+     * to the dragged row (via `context.projectedIndent`) so it re-indents to its projected drop
+     * level. The drag stays vertical; the level comes from the neighbours plus travel direction.
+     * Return `null` for no projection. The commit arrives through `onMove`'s `info` argument.
+     */
+    resolveDrop?: (info: SortableDragInfo, items: T[]) => SortableDropHint | null;
     /** Extra classes on each row wrapper; function form receives item context. */
     itemClassName?: string | ((context: SortableListItemContext<T>) => string);
     className?: string;
@@ -91,6 +138,12 @@ function restrictToVerticalAxis({transform}: {transform: {x: number; y: number; 
     return {...transform, x: 0};
 }
 
+// Re-measure droppables continuously in projection mode — the tree can collapse the
+// dragged node and shift rows, which would otherwise leave the `over` rects stale.
+const PROJECTION_MEASURING: MeasuringConfiguration = {
+    droppable: {strategy: MeasuringStrategy.Always},
+};
+
 //
 // * SortableListItem
 //
@@ -105,6 +158,7 @@ type SortableListItemInternalProps<T> = {
     controlGrip: boolean;
     fullRowDraggable: boolean;
     dropAllowed: boolean;
+    projectedIndent?: number;
     dragLabel?: string;
     animateLayoutChanges?: (args: {isSorting: boolean; wasDragging: boolean}) => boolean;
     renderItem: (context: SortableListItemContext<T>, grip?: ReactNode) => ReactNode;
@@ -122,6 +176,7 @@ const SortableListItem = <T,>({
     controlGrip,
     fullRowDraggable,
     dropAllowed,
+    projectedIndent,
     dragLabel,
     animateLayoutChanges,
     renderItem,
@@ -166,6 +221,7 @@ const SortableListItem = <T,>({
         isDragActive,
         isFocused,
         isMovable,
+        projectedIndent,
     };
 
     const resolvedClassName = typeof itemClassName === 'function' ? itemClassName(context) : itemClassName;
@@ -209,6 +265,8 @@ const SortableListItem = <T,>({
                 'focus-visible:ring-2 focus-visible:ring-ring/25 focus-visible:ring-inset',
                 isDragging && 'bg-surface-neutral shadow-[0_2px_8px_2px] shadow-main/10 ring-1 ring-main/5',
                 isDragging && !dropAllowed && 'opacity-40',
+                // Full-row drag targets must not turn a press-drag into a text selection.
+                fullRowDraggable && isMovable && 'touch-none select-none',
                 fullRowDraggable && isMovable && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
                 resolvedClassName,
             )}
@@ -236,6 +294,7 @@ export const SortableList = <T,>({
     isItemMovable,
     isDropAllowed,
     animateLayoutChanges,
+    resolveDrop,
     dragLabel,
     controlGrip = false,
     renderItem,
@@ -248,6 +307,7 @@ export const SortableList = <T,>({
     const isMovable = items.length >= 2;
     const [dropAllowed, setDropAllowed] = useState(true);
     const [isDragActive, setIsDragActive] = useState(false);
+    const [drop, setDrop] = useState<{info: SortableDragInfo; hint: SortableDropHint | null} | null>(null);
 
     const sensors = useSensors(
         useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
@@ -270,8 +330,50 @@ export const SortableList = <T,>({
         [ids, onDragStartProp],
     );
 
+    // Projection mode: recompute the drop from the live drag state. Driven by both
+    // `onDragMove` (pointer moved) and `onDragOver` (dnd-kit re-measured and changed
+    // `over`) so the indicator never lags the displacement.
+    const applyProjection = useCallback(
+        (event: DragMoveEvent) => {
+            if (resolveDrop == null) return;
+
+            const {active, over, delta} = event;
+            const direction: SortableDragDirection = delta.y < 0 ? 'up' : 'down';
+
+            // `over === active` only carries intent at the list edge — a down-drag past the
+            // last row, which steps the item out a level. Otherwise it means "no move yet".
+            const atOwnSlot = over == null || active.id === over.id;
+            if (atOwnSlot && (direction !== 'down' || delta.y <= 0)) {
+                setDrop(null);
+                setDropAllowed(true);
+                return;
+            }
+
+            const overId = over == null ? String(active.id) : String(over.id);
+            const activeIndex = ids.indexOf(String(active.id));
+            const overIndex = ids.indexOf(overId);
+            if (activeIndex === -1 || overIndex === -1) {
+                setDrop(null);
+                return;
+            }
+
+            // Side matches dnd-kit's displacement gap: the item lands at the over row's slot,
+            // so it sits after the over row when coming from above and before it when from below.
+            const side: SortableDropSide = overIndex > activeIndex ? 'below' : 'above';
+            const info: SortableDragInfo = {activeIndex, overIndex, side, direction};
+            const hint = resolveDrop(info, items);
+            setDrop({info, hint});
+            setDropAllowed(hint?.allowed ?? true);
+        },
+        [ids, items, resolveDrop],
+    );
+
     const handleDragOver = useCallback(
         (event: DragOverEvent) => {
+            if (resolveDrop != null) {
+                applyProjection(event);
+                return;
+            }
             if (isDropAllowed == null) return;
 
             const {active, over} = event;
@@ -284,29 +386,46 @@ export const SortableList = <T,>({
             const toIndex = ids.indexOf(String(over.id));
             setDropAllowed(fromIndex !== -1 && toIndex !== -1 && isDropAllowed(fromIndex, toIndex));
         },
-        [ids, isDropAllowed],
+        [ids, isDropAllowed, resolveDrop, applyProjection],
     );
+
+    const handleDragMove = useCallback((event: DragMoveEvent) => applyProjection(event), [applyProjection]);
 
     const handleDragEnd = useCallback(
         (event: DragEndEvent) => {
             setDropAllowed(true);
             setIsDragActive(false);
+            setDrop(null);
 
-            const {active, over} = event;
-            if (over == null || active.id === over.id) return;
-
+            const {active, over, delta} = event;
             const oldIndex = ids.indexOf(String(active.id));
+            if (oldIndex === -1) return;
+
+            if (resolveDrop != null) {
+                const direction: SortableDragDirection = delta.y < 0 ? 'up' : 'down';
+                const atOwnSlot = over == null || active.id === over.id;
+                if (atOwnSlot && (direction !== 'down' || delta.y <= 0)) return;
+                const overId = over == null ? String(active.id) : String(over.id);
+                const overIndex = ids.indexOf(overId);
+                if (overIndex === -1) return;
+                const side: SortableDropSide = overIndex > oldIndex ? 'below' : 'above';
+                onMove(oldIndex, overIndex, {activeIndex: oldIndex, overIndex, side, direction});
+                return;
+            }
+
+            if (over == null || active.id === over.id) return;
             const newIndex = ids.indexOf(String(over.id));
-            if (oldIndex === -1 || newIndex === -1) return;
+            if (newIndex === -1) return;
 
             onMove(oldIndex, newIndex);
         },
-        [ids, onMove],
+        [ids, onMove, resolveDrop],
     );
 
     const handleDragCancel = useCallback(() => {
         setDropAllowed(true);
         setIsDragActive(false);
+        setDrop(null);
     }, []);
 
     return (
@@ -319,8 +438,10 @@ export const SortableList = <T,>({
                 sensors={sensors}
                 collisionDetection={closestCenter}
                 modifiers={[restrictToVerticalAxis]}
+                measuring={resolveDrop != null ? PROJECTION_MEASURING : undefined}
                 onDragStart={handleDragStart}
                 onDragOver={handleDragOver}
+                onDragMove={handleDragMove}
                 onDragEnd={handleDragEnd}
                 onDragCancel={handleDragCancel}
             >
@@ -337,6 +458,9 @@ export const SortableList = <T,>({
                             enabled={enabled}
                             fullRowDraggable={fullRowDraggable}
                             dropAllowed={dropAllowed}
+                            projectedIndent={
+                                drop?.hint != null && i === drop.info.activeIndex ? drop.hint.indent : undefined
+                            }
                             dragLabel={dragLabel}
                             animateLayoutChanges={animateLayoutChanges}
                             renderItem={renderItem}

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/index.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/index.tsx
@@ -1,1 +1,16 @@
-export {SortableList, type SortableListItemContext, type SortableListProps} from './SortableList';
+export {
+    type SortableDragDirection,
+    type SortableDragInfo,
+    type SortableDropHint,
+    type SortableDropSide,
+    SortableList,
+    type SortableListItemContext,
+    type SortableListProps,
+} from './SortableList';
+export {
+    type DropNode,
+    type DropNodeKind,
+    type DropProjection,
+    type ProjectTreeDropParams,
+    projectTreeDrop,
+} from './treeProjection';

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/treeProjection.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/treeProjection.test.ts
@@ -1,0 +1,211 @@
+import {describe, expect, it} from 'vitest';
+import {type DropNode, projectTreeDrop} from './treeProjection';
+
+//
+// * Fixtures
+//
+
+function node(id: string, parentId: string | null, depth: number, kind: 'container' | 'item'): DropNode {
+    return {id, parentId, depth, kind};
+}
+
+/**
+ * Single region with `count` item children.
+ *
+ * /          page    depth 1
+ * /r         region  depth 2
+ * /r/0..n    item    depth 3
+ */
+function simpleRegion(count: number): DropNode[] {
+    const nodes: DropNode[] = [node('/', null, 1, 'item'), node('/r', '/', 2, 'container')];
+    for (let i = 0; i < count; i++) {
+        nodes.push(node(`/r/${i}`, '/r', 3, 'item'));
+    }
+    return nodes;
+}
+
+/**
+ * Page with a layout; the trailing item lives in MAIN (Footer last).
+ *
+ * [8] /main/2  is the dragged "Footer"; [7] /main/1/right is an empty region.
+ */
+function footerInMain(): DropNode[] {
+    return [
+        node('/', null, 1, 'item'),
+        node('/main', '/', 2, 'container'),
+        node('/main/0', '/main', 3, 'item'),
+        node('/main/1', '/main', 3, 'item'),
+        node('/main/1/left', '/main/1', 4, 'container'),
+        node('/main/1/left/0', '/main/1/left', 5, 'item'),
+        node('/main/1/left/1', '/main/1/left', 5, 'item'),
+        node('/main/1/right', '/main/1', 4, 'container'),
+        node('/main/2', '/main', 3, 'item'),
+    ];
+}
+
+/**
+ * Same tree after Footer has been dropped inside the empty right region, where it is
+ * the only child and the last row overall.
+ */
+function footerInRight(): DropNode[] {
+    return [
+        node('/', null, 1, 'item'),
+        node('/main', '/', 2, 'container'),
+        node('/main/0', '/main', 3, 'item'),
+        node('/main/1', '/main', 3, 'item'),
+        node('/main/1/left', '/main/1', 4, 'container'),
+        node('/main/1/left/0', '/main/1/left', 5, 'item'),
+        node('/main/1/left/1', '/main/1/left', 5, 'item'),
+        node('/main/1/right', '/main/1', 4, 'container'),
+        node('/main/1/right/0', '/main/1/right', 5, 'item'),
+    ];
+}
+
+//
+// * Reordering within a region (single slot — direction is irrelevant)
+//
+
+describe('projectTreeDrop — reorder within a region', () => {
+    it('drops after the over item on the lower half', () => {
+        const result = projectTreeDrop({
+            nodes: simpleRegion(3),
+            activeId: '/r/0',
+            overId: '/r/2',
+            side: 'below',
+            direction: 'down',
+        });
+        expect(result).toEqual({containerId: '/r', index: 2, depth: 3, allowed: true});
+    });
+
+    it('drops before the over item on the upper half', () => {
+        const result = projectTreeDrop({
+            nodes: simpleRegion(3),
+            activeId: '/r/0',
+            overId: '/r/2',
+            side: 'above',
+            direction: 'up',
+        });
+        expect(result).toEqual({containerId: '/r', index: 1, depth: 3, allowed: true});
+    });
+
+    it('reaches the top slot from the first item', () => {
+        const result = projectTreeDrop({
+            nodes: simpleRegion(3),
+            activeId: '/r/2',
+            overId: '/r/0',
+            side: 'above',
+            direction: 'up',
+        });
+        expect(result).toEqual({containerId: '/r', index: 0, depth: 3, allowed: true});
+    });
+});
+
+//
+// * The walker: up enters, down steps out (the two reported examples)
+//
+
+describe('projectTreeDrop — enter / step out via direction', () => {
+    it('enters the empty region when dragging the trailing item up onto it', () => {
+        const result = projectTreeDrop({
+            nodes: footerInMain(),
+            activeId: '/main/2',
+            overId: '/main/1/right',
+            side: 'below',
+            direction: 'up',
+        });
+        expect(result).toEqual({containerId: '/main/1/right', index: 0, depth: 5, allowed: true});
+    });
+
+    it('steps out past the layout when dragging the same gap down', () => {
+        const result = projectTreeDrop({
+            nodes: footerInMain(),
+            activeId: '/main/2',
+            overId: '/main/1/right',
+            side: 'below',
+            direction: 'down',
+        });
+        expect(result).toEqual({containerId: '/main', index: 2, depth: 3, allowed: true});
+    });
+
+    it('steps out below the last row when the item is alone inside the trailing region', () => {
+        // over === active: the item is the last row, so a down-drag steps it out a level.
+        const result = projectTreeDrop({
+            nodes: footerInRight(),
+            activeId: '/main/1/right/0',
+            overId: '/main/1/right/0',
+            side: 'below',
+            direction: 'down',
+        });
+        expect(result).toEqual({containerId: '/main', index: 2, depth: 3, allowed: true});
+    });
+});
+
+//
+// * Crossing into / out of a region by the hovered neighbour
+//
+
+describe('projectTreeDrop — hovered neighbour level', () => {
+    it('nests into a region by hovering one of its items', () => {
+        const result = projectTreeDrop({
+            nodes: footerInMain(),
+            activeId: '/main/0',
+            overId: '/main/1/left/1',
+            side: 'above',
+            direction: 'up',
+        });
+        expect(result).toEqual({containerId: '/main/1/left', index: 1, depth: 5, allowed: true});
+    });
+
+    it('climbs out to the parent level by hovering a parent-level item', () => {
+        const result = projectTreeDrop({
+            nodes: footerInMain(),
+            activeId: '/main/1/left/0',
+            overId: '/main/2',
+            side: 'above',
+            direction: 'down',
+        });
+        expect(result).toEqual({containerId: '/main', index: 2, depth: 3, allowed: true});
+    });
+});
+
+//
+// * Allowed predicate
+//
+
+describe('projectTreeDrop — allowed predicate', () => {
+    it('flags the projection disallowed when the target container is rejected', () => {
+        const result = projectTreeDrop({
+            nodes: simpleRegion(3),
+            activeId: '/r/0',
+            overId: '/r/2',
+            side: 'below',
+            direction: 'down',
+            isContainerAllowed: () => false,
+        });
+        expect(result).toEqual({containerId: '/r', index: 2, depth: 3, allowed: false});
+    });
+});
+
+//
+// * Guards
+//
+
+describe('projectTreeDrop — guards', () => {
+    it('returns null when the over row is missing', () => {
+        expect(
+            projectTreeDrop({
+                nodes: simpleRegion(3),
+                activeId: '/r/0',
+                overId: '/nope',
+                side: 'above',
+                direction: 'up',
+            }),
+        ).toBeNull();
+    });
+
+    it('returns null at the top edge (nothing above the gap)', () => {
+        expect(
+            projectTreeDrop({nodes: simpleRegion(3), activeId: '/r/2', overId: '/', side: 'above', direction: 'up'}),
+        ).toBeNull();
+    });
+});

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/treeProjection.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/treeProjection.ts
@@ -1,0 +1,190 @@
+/**
+ * Pure drop-target projection for tree-shaped sortable lists.
+ *
+ * The list renders flat (depth-first) but items live inside containers, so a drag
+ * must resolve to a `{container, index}` target. This walks the tree's valid
+ * insertion slots: at the drag gap it builds the stack of candidate slots from
+ * deepest (entering the region above / after the nearest item) to shallowest
+ * (climbing out past the owning layouts), and the drag direction picks within the
+ * stack — dragging up enters the deeper slot, dragging down steps out to the
+ * shallower one. The horizontal axis stays locked; level comes from the neighbours
+ * plus travel direction, so a small up/down nudge moves between levels.
+ */
+
+export type DropNodeKind = 'container' | 'item';
+
+export type DropNode = {
+    /** Stable id, unique within the list. */
+    id: string;
+    /** Parent row id; null for the root row. */
+    parentId: string | null;
+    /** Visual indent level (1-based; matches the flattened tree level). */
+    depth: number;
+    /** `container` rows hold ordered `item` children; `item` rows are draggable. */
+    kind: DropNodeKind;
+};
+
+export type DropDirection = 'up' | 'down';
+
+export type ProjectTreeDropParams = {
+    /** Visible rows in display order, including the dragged row. */
+    nodes: DropNode[];
+    /** Id of the dragged item row. */
+    activeId: string;
+    /** Id of the row currently under the pointer (may equal `activeId` at the list edge). */
+    overId: string;
+    /** Pointer position relative to the over row's vertical midpoint. */
+    side: 'above' | 'below';
+    /** Net travel direction; picks the deeper (up) or shallower (down) slot in a stack. */
+    direction: DropDirection;
+    /** Optional guard; when it returns false the projection is flagged not allowed. */
+    isContainerAllowed?: (containerId: string, activeId: string) => boolean;
+};
+
+export type DropProjection = {
+    /** Target container the dragged item lands in. */
+    containerId: string;
+    /** Insertion index within the target container (source already excluded). */
+    index: number;
+    /** Resulting item depth (`container.depth + 1`); drives the drop indicator indent. */
+    depth: number;
+    /** False when `isContainerAllowed` rejects the target. */
+    allowed: boolean;
+};
+
+type Slot = {
+    containerId: string;
+    index: number;
+    depth: number;
+};
+
+export function projectTreeDrop(params: ProjectTreeDropParams): DropProjection | null {
+    const {nodes, activeId, direction, isContainerAllowed} = params;
+
+    const byId = new Map<string, DropNode>();
+    for (const node of nodes) byId.set(node.id, node);
+
+    const active = byId.get(activeId);
+    if (active == null) return null;
+
+    // Indices/neighbours are computed with the dragged subtree removed, so the result
+    // reflects the post-removal list (matching the move semantics).
+    const visible = excludeSubtree(nodes, active);
+
+    const gap = resolveGap(params, nodes, visible, active);
+    if (gap == null) return null;
+
+    const stack = buildSlotStack(gap.before, gap.after, gap.flatIndex, visible, byId);
+    if (stack.length === 0) return null;
+
+    const chosen = direction === 'up' ? stack[0] : stack[stack.length - 1];
+    const allowed = isContainerAllowed?.(chosen.containerId, activeId) ?? true;
+
+    return {containerId: chosen.containerId, index: chosen.index, depth: chosen.depth, allowed};
+}
+
+type Gap = {
+    before: DropNode | undefined;
+    after: DropNode | undefined;
+    /** Insertion position within `visible` (number of visible rows above the gap). */
+    flatIndex: number;
+};
+
+function resolveGap(
+    params: ProjectTreeDropParams,
+    nodes: DropNode[],
+    visible: DropNode[],
+    active: DropNode,
+): Gap | null {
+    const {activeId, overId, side} = params;
+
+    // Hovering own slot (typically the list edge): anchor on the dragged item's own
+    // neighbours so a down-drag can step out below the last row.
+    if (overId === activeId) {
+        const activeFullIndex = nodes.findIndex(node => node.id === activeId);
+        if (activeFullIndex <= 0) return null;
+        const before = nodes[activeFullIndex - 1];
+        let end = activeFullIndex + 1;
+        while (end < nodes.length && nodes[end].depth > active.depth) end++;
+        const after = nodes[end];
+        const beforeVisibleIndex = visible.findIndex(node => node.id === before.id);
+        if (beforeVisibleIndex === -1) return null;
+        return {before, after, flatIndex: beforeVisibleIndex + 1};
+    }
+
+    const overIndex = visible.findIndex(node => node.id === overId);
+    if (overIndex === -1) return null;
+
+    if (side === 'below') {
+        return {before: visible[overIndex], after: visible[overIndex + 1], flatIndex: overIndex + 1};
+    }
+    return {before: visible[overIndex - 1], after: visible[overIndex], flatIndex: overIndex};
+}
+
+function buildSlotStack(
+    before: DropNode | undefined,
+    after: DropNode | undefined,
+    flatIndex: number,
+    visible: DropNode[],
+    byId: Map<string, DropNode>,
+): Slot[] {
+    if (before == null) return [];
+
+    const region = before.kind === 'container' ? before : byId.get(before.parentId ?? '');
+    if (region == null || region.kind !== 'container') return [];
+
+    const stack: Slot[] = [];
+
+    // Entering the region directly below the gap, when it opens right under its layout.
+    if (after != null && after.kind === 'container' && after.parentId === before.id) {
+        stack.push({containerId: after.id, index: 0, depth: after.depth + 1});
+    }
+
+    // Deepest item slot: inside `before` (a region header) or right after `before` (an item).
+    stack.push({
+        containerId: region.id,
+        index: countItemsBefore(visible, region.id, flatIndex),
+        depth: region.depth + 1,
+    });
+
+    // Climb out region by region, after each owning layout, down to the next row's level.
+    let current = region;
+    while (true) {
+        const owner = byId.get(current.parentId ?? '');
+        if (owner == null || owner.parentId == null) break;
+        const parentRegion = byId.get(owner.parentId);
+        if (parentRegion == null || parentRegion.kind !== 'container') break;
+        stack.push({
+            containerId: parentRegion.id,
+            index: countItemsBefore(visible, parentRegion.id, flatIndex),
+            depth: parentRegion.depth + 1,
+        });
+        current = parentRegion;
+    }
+
+    // A region header or item below the gap pins how shallow the drop may climb.
+    const minRegionDepth = after == null ? 1 : after.kind === 'item' ? after.depth - 1 : after.depth;
+    const filtered = stack.filter(slot => slot.depth - 1 >= minRegionDepth);
+    return filtered.length > 0 ? filtered : [stack[0]];
+}
+
+function excludeSubtree(nodes: DropNode[], active: DropNode): DropNode[] {
+    const activeIndex = nodes.findIndex(node => node.id === active.id);
+    if (activeIndex === -1) return nodes;
+
+    let end = activeIndex + 1;
+    while (end < nodes.length && nodes[end].depth > active.depth) {
+        end++;
+    }
+    return [...nodes.slice(0, activeIndex), ...nodes.slice(end)];
+}
+
+function countItemsBefore(visible: DropNode[], regionId: string, flatIndex: number): number {
+    let count = 0;
+    const limit = Math.min(flatIndex, visible.length);
+    for (let i = 0; i < limit; i++) {
+        const node = visible[i];
+        if (node.kind === 'item' && node.parentId === regionId) count++;
+    }
+    return count;
+}


### PR DESCRIPTION
Adds an opt-in projection mode to `SortableList` so consumers that render a flattened tree can resolve correct drop targets, instead of the flat `onMove(fromIndex, toIndex)` that always reordered within a single list.

- New pure `projectTreeDrop` resolves a `{container, index}` target by walking the tree's valid insertion slots (deepest-first, direction picks enter vs. step out); covered by `treeProjection.test.ts`.
- `SortableList` projection mode: `resolveDrop` reports `SortableDragInfo` (hovered row, displacement side, travel direction) and feeds `context.projectedIndent` back so the dragged row re-indents to its target level; commit arrives through `onMove`'s `info` argument.
- Drop side is derived from the dnd-kit displacement gap (`overIndex` vs `activeIndex`) so the commit matches the visible gap; projection recomputes on both `onDragMove` and `onDragOver`.
- Horizontal axis stays locked; full-row drag rows get `select-none` so a press-drag cannot become a text selection.
- Existing flat consumers (item-set, option-set) are unaffected — all new props are optional. Adds a `Tree Projection` Storybook story.

Closes #4512

<sub>*Drafted with AI assistance*</sub>
