### PR TITLE
Drag handle should not move when validation fires #4521

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.test.ts
@@ -4,7 +4,7 @@ import {ValueTypes} from '../../../data/ValueTypes';
 import {InputBuilder} from '../../../form/Input';
 import {InputTypeName} from '../../../form/InputTypeName';
 import {Occurrences} from '../../../form/Occurrences';
-import type {OccurrenceManagerState} from '../../descriptor/OccurrenceManager';
+import type {OccurrenceManagerState} from '../../descriptor';
 import type {InputTypeComponent} from '../../types';
 import {OccurrenceList, type OccurrenceListRootProps} from './OccurrenceList';
 
@@ -100,19 +100,33 @@ function makeProps(overrides: Partial<OccurrenceListRootProps> = {}): Occurrence
 
 type VNode = {type: unknown; props: Record<string, any>};
 
-function findFieldError(tree: unknown): VNode | undefined {
+function findNodeByType(tree: unknown, type: unknown): VNode | undefined {
     if (tree == null || typeof tree !== 'object') return undefined;
     if (Array.isArray(tree)) {
         for (const child of tree) {
-            const found = findFieldError(child);
+            const found = findNodeByType(child, type);
             if (found != null) return found;
         }
         return undefined;
     }
     if (!('type' in tree) || !('props' in tree)) return undefined;
     const vnode = tree as VNode;
-    if (vnode.type === mocks.fieldError) return vnode;
-    return findFieldError(vnode.props.children);
+    if (vnode.type === type) return vnode;
+    return findNodeByType(vnode.props.children, type);
+}
+
+function findFieldError(tree: unknown): VNode | undefined {
+    return findNodeByType(tree, mocks.fieldError);
+}
+
+function renderSortableItem(tree: unknown): VNode[] {
+    const sortableList = findNodeByType(tree, mocks.sortableGridList);
+    expect(sortableList).toBeDefined();
+    if (sortableList == null) throw new Error('Expected SortableGridList to render');
+
+    const renderedItem = sortableList.props.renderItem({index: 0, isMovable: true}) as VNode;
+    const children = renderedItem.props.children;
+    return Array.isArray(children) ? children : [children];
 }
 
 function getFieldErrorMessage(tree: unknown): string | undefined {
@@ -175,5 +189,32 @@ describe('OccurrenceList', () => {
         const tree = OccurrenceList.Root(makeProps({input, state}));
 
         expect(getFieldErrorMessage(tree)).toBeUndefined();
+    });
+
+    it('externalizes field errors for draggable occurrence rows and suppresses them while processing', () => {
+        const Component: InputTypeComponent = () => null;
+        const input = makeInput(0, 5);
+        const state = makeState([ValueTypes.STRING.newValue('a'), ValueTypes.STRING.newValue('b')], 0, 5);
+        const stateWithError: OccurrenceManagerState = {
+            ...state,
+            occurrenceValidation: state.occurrenceValidation.map((entry, index) =>
+                index === 0 ? {...entry, validationResults: [{message: 'Invalid value entered'}]} : entry,
+            ),
+        };
+
+        const tree = OccurrenceList.Root(makeProps({Component, input, state: stateWithError}));
+        const [contentNode, fieldErrorNode] = renderSortableItem(tree);
+
+        expect(contentNode?.props.errors.validationResults).toEqual([]);
+        expect(fieldErrorNode?.props.message).toBe('Invalid value entered');
+
+        const processingTree = OccurrenceList.Root(
+            makeProps({Component, input, state: stateWithError, processingOccurrenceIds: new Set(['occurrence-0'])}),
+        );
+        const [processingContentNode, processingFieldErrorNode] = renderSortableItem(processingTree);
+
+        expect(processingContentNode?.props.errors.validationResults).toEqual([]);
+        expect(processingContentNode?.props.processing).toBe(true);
+        expect(processingFieldErrorNode?.props.message).toBeUndefined();
     });
 });

--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -6,7 +6,7 @@ import type {Input} from '../../../form/Input';
 import type {InputTypeConfig, OccurrenceManagerState} from '../../descriptor';
 import {useI18n} from '../../I18nContext';
 import type {InputTypeComponent} from '../../types';
-import {getOccurrenceErrorMessage} from '../../utils';
+import {getFirstError, getOccurrenceErrorMessage} from '../../utils';
 import {FieldError} from '../field-error';
 import {InputLabel} from '../input-label';
 import {SortableGridList} from '../sortable-grid-list';
@@ -59,6 +59,7 @@ type OccurrenceListItemContentProps<C extends InputTypeConfig = InputTypeConfig>
     processing: boolean;
     inputRef?: (el: HTMLElement | null) => void;
     highlight?: number;
+    className?: string;
     onChange: (index: number, value: Value, rawValue?: string) => void;
     onBlur?: (index: number) => void;
     onFocus?: () => void;
@@ -85,6 +86,7 @@ const OccurrenceListItemContent = <C extends InputTypeConfig = InputTypeConfig>(
     processing,
     inputRef,
     highlight,
+    className,
     onChange,
     onBlur,
     onFocus,
@@ -94,7 +96,7 @@ const OccurrenceListItemContent = <C extends InputTypeConfig = InputTypeConfig>(
 
     return (
         <>
-            <div className='min-w-0 flex-1'>
+            <div className={cn('min-w-0 flex-1', className)}>
                 <Component
                     value={value}
                     onChange={(v: Value, raw?: string) => onChange(index, v, raw)}
@@ -267,8 +269,36 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
                     enabled={enabled}
                     dragLabel={t('field.occurrence.action.reorder')}
                     className='flex flex-col gap-y-2.5'
-                    itemClassName={({isMovable}) => cn('-my-1 gap-2 py-1', isMovable && 'pl-2', showRemove && 'pr-2')}
-                    renderItem={({index}) => <OccurrenceListItemContent {...contentProps(index)} />}
+                    itemClassName={({isMovable}) =>
+                        cn(
+                            '-my-1 grid gap-2 py-1',
+                            isMovable ? 'grid-cols-[auto_minmax(0,1fr)_auto] pl-2' : 'grid-cols-[minmax(0,1fr)_auto]',
+                            showRemove && 'pr-2',
+                        )
+                    }
+                    renderItem={({index, isMovable}) => {
+                        const props = contentProps(index);
+                        const fieldError = !props.processing
+                            ? getFirstError(props.errors.validationResults)
+                            : undefined;
+
+                        return (
+                            <>
+                                <OccurrenceListItemContent
+                                    {...props}
+                                    errors={{...props.errors, validationResults: []}}
+                                    className={isMovable ? 'col-start-2' : 'col-start-1'}
+                                />
+                                <FieldError
+                                    className={cn(
+                                        'min-w-0',
+                                        isMovable ? 'col-span-2 col-start-2' : 'col-span-2 col-start-1',
+                                    )}
+                                    message={fieldError}
+                                />
+                            </>
+                        );
+                    }}
                 />
                 {(occurrenceError != null || addButton) && (
                     <div className='flex items-start gap-x-2'>

--- a/src/main/resources/assets/admin/common/js/form2/types.ts
+++ b/src/main/resources/assets/admin/common/js/form2/types.ts
@@ -2,10 +2,7 @@ import type {ComponentType} from 'react';
 import type {Value} from '../data/Value';
 import type {Input} from '../form/Input';
 import type {Occurrences} from '../form/Occurrences';
-import type {InputTypeConfig} from './descriptor/InputTypeConfig';
-import type {InputTypeDescriptor} from './descriptor/InputTypeDescriptor';
-import type {OccurrenceManagerState} from './descriptor/OccurrenceManager';
-import type {ValidationResult} from './descriptor/ValidationResult';
+import type {InputTypeConfig, InputTypeDescriptor, OccurrenceManagerState, ValidationResult} from './descriptor';
 
 export type InputTypeMode = 'list' | 'single' | 'internal';
 


### PR DESCRIPTION
Keep sortable occurrence controls aligned with field errors Externalized draggable occurrence field errors into the row grid. Forwarded showErrorMessage through built-in list input types. Suppressed externalized field errors while occurrence processing.