### PR TITLE
Show server-side validation errors on form fields #4534

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/ServerErrorsContext.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/ServerErrorsContext.tsx
@@ -1,0 +1,32 @@
+import type {ReactNode} from 'react';
+import {createContext, useContext, useMemo} from 'react';
+
+export type ServerErrorEntry = {
+    path: string;
+    message: string;
+};
+
+export type ServerErrorsValue = {
+    entries: readonly ServerErrorEntry[];
+    clear: (occurrencePath: string) => void;
+    clearField: (fieldPath: string) => void;
+};
+
+export type ServerErrorsProviderProps = ServerErrorsValue & {
+    children?: ReactNode;
+};
+
+const SERVER_ERRORS_PROVIDER_NAME = 'ServerErrorsProvider';
+
+const ServerErrorsContext = createContext<ServerErrorsValue | undefined>(undefined);
+
+export const ServerErrorsProvider = ({entries, clear, clearField, children}: ServerErrorsProviderProps): ReactNode => {
+    const value = useMemo<ServerErrorsValue>(() => ({entries, clear, clearField}), [entries, clear, clearField]);
+    return <ServerErrorsContext.Provider value={value}>{children}</ServerErrorsContext.Provider>;
+};
+
+ServerErrorsProvider.displayName = SERVER_ERRORS_PROVIDER_NAME;
+
+export const useServerErrors = (): ServerErrorsValue | undefined => {
+    return useContext(ServerErrorsContext);
+};

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
@@ -47,6 +47,10 @@ vi.mock('../../RawValueContext', () => ({
     useRawValueMap: mocks.useRawValueMap,
 }));
 
+vi.mock('../../ServerErrorsContext', () => ({
+    useServerErrors: vi.fn(() => undefined),
+}));
+
 vi.mock('../../FieldRegistryContext', () => ({
     useFieldRegistry: vi.fn(() => undefined),
 }));

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
@@ -14,7 +14,9 @@ import {usePropertyArray} from '../../hooks/usePropertyArray';
 import {useI18n} from '../../I18nContext';
 import {useRawValueMap} from '../../RawValueContext';
 import {InputTypeRegistry} from '../../registry/InputTypeRegistry';
+import {useServerErrors} from '../../ServerErrorsContext';
 import type {InputTypeComponent, InputTypeDefinition, SelfManagedInputTypeComponent} from '../../types';
+import {bucketServerErrorsByOccurrence, mergeServerErrors} from '../../utils/serverErrors';
 import {getOccurrenceErrorMessage} from '../../utils/validation';
 import {useValidationVisibility} from '../../ValidationContext';
 import {FieldError} from '../field-error';
@@ -255,11 +257,20 @@ export const InputFieldResolved = ({
     }, [state.ids, forceRender]);
 
     const fieldRegistry = useFieldRegistry();
+    const serverErrors = useServerErrors();
     // No useMemo: parent reorders mutate propertySet's index without changing identity.
     const fieldPath = PropertyPath.fromParent(
         propertySet.getPropertyPath(),
         new PropertyPathElement(input.getName(), 0),
     ).toString();
+
+    const fieldDataPath = fieldPath.startsWith('.') ? fieldPath.slice(1) : fieldPath;
+    const serverEntries = serverErrors?.entries;
+    const serverErrorsByOccurrence = useMemo(
+        () => bucketServerErrorsByOccurrence(serverEntries ?? [], fieldDataPath),
+        [serverEntries, fieldDataPath],
+    );
+    const hasServerErrors = serverErrorsByOccurrence.size > 0;
 
     useEffect(() => {
         const managerValues = sync(values);
@@ -300,8 +311,26 @@ export const InputFieldResolved = ({
                     : value;
             set(index, storedValue, rawValue);
             propertyArray.set(index, storedValue);
+            if (serverErrorsByOccurrence.has(index)) {
+                const occurrencePath = PropertyPath.fromParent(
+                    propertySet.getPropertyPath(),
+                    new PropertyPathElement(inputName, index),
+                ).toString();
+                serverErrors?.clear(occurrencePath.startsWith('.') ? occurrencePath.slice(1) : occurrencePath);
+            }
         },
-        [markTouched, rawValueMap, inputName, set, propertyArray, descriptor, config],
+        [
+            markTouched,
+            rawValueMap,
+            inputName,
+            set,
+            propertyArray,
+            descriptor,
+            config,
+            serverErrors,
+            serverErrorsByOccurrence,
+            propertySet,
+        ],
     );
 
     const handleBlur = useCallback(
@@ -316,8 +345,9 @@ export const InputFieldResolved = ({
             const newValue = value ?? defaultValue;
             if (!add(newValue)) return;
             propertyArray.add(newValue);
+            if (hasServerErrors) serverErrors?.clearField(fieldDataPath);
         },
-        [add, propertyArray, defaultValue],
+        [add, propertyArray, defaultValue, hasServerErrors, serverErrors, fieldDataPath],
     );
 
     const handleRemove = useCallback(
@@ -331,8 +361,9 @@ export const InputFieldResolved = ({
                 }
             }
             propertyArray.remove(index);
+            if (hasServerErrors) serverErrors?.clearField(fieldDataPath);
         },
-        [remove, rawValueMap, inputName, propertyArray],
+        [remove, rawValueMap, inputName, propertyArray, hasServerErrors, serverErrors, fieldDataPath],
     );
 
     const handleMove = useCallback(
@@ -346,12 +377,15 @@ export const InputFieldResolved = ({
                 }
             }
             propertyArray.move(fromIndex, toIndex);
+            if (hasServerErrors) serverErrors?.clearField(fieldDataPath);
         },
-        [move, rawValueMap, inputName, propertyArray],
+        [move, rawValueMap, inputName, propertyArray, hasServerErrors, serverErrors, fieldDataPath],
     );
 
     const filteredValidation = filterErrors(state.occurrenceValidation, visibility, touched);
-    const filteredState = visibility === 'all' ? state : {...state, occurrenceValidation: filteredValidation};
+    const displayValidation = mergeServerErrors(filteredValidation, serverErrorsByOccurrence);
+    const filteredState =
+        visibility === 'all' && !hasServerErrors ? state : {...state, occurrenceValidation: displayValidation};
 
     const isOccurrenceProcessing = useCallback((occurrenceId: string | undefined): boolean => {
         if (occurrenceId == null) return false;
@@ -514,7 +548,7 @@ export const InputFieldResolved = ({
             const Component = definition.component;
             const occId = state.ids[0];
             const processing = isOccurrenceProcessing(occId);
-            const fieldErrors = filteredValidation[0]?.validationResults ?? [];
+            const fieldErrors = displayValidation[0]?.validationResults ?? [];
             const occurrenceError = getOccurrenceErrorMessage(occurrences, filteredValidation, t);
             const allErrors = occurrenceError != null ? [...fieldErrors, {message: occurrenceError}] : fieldErrors;
             return (
@@ -562,7 +596,7 @@ export const InputFieldResolved = ({
                         config={config}
                         input={input}
                         enabled={enabled}
-                        errors={filteredValidation}
+                        errors={displayValidation}
                     />
                     {occurrenceError != null && <FieldError className='mt-2' message={occurrenceError} />}
                 </div>

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/ValidationResult.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/ValidationResult.ts
@@ -1,6 +1,7 @@
 export type ValidationResult = {
     readonly message: string;
     readonly custom?: boolean;
+    readonly server?: boolean;
     /**
      * Marks an error injected from outside the descriptor pipeline (e.g. a translation
      * failure) so renderers can offer dismiss affordances. Transient entries are cleared

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/validateForm.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/validateForm.test.ts
@@ -888,7 +888,7 @@ describe('validateForm', () => {
         }
     });
 
-    it('attaches server errors matched by path with custom flag', () => {
+    it('attaches server errors matched by path tagged server (and custom)', () => {
         const input = makeInput('myField', 0, 1);
         const form = new FormBuilder().addFormItem(input).build();
         const tree = new PropertyTree();
@@ -901,8 +901,23 @@ describe('validateForm', () => {
         const node = result.children[0];
         if (node.type === 'input') {
             const allErrors = node.errors.flat();
-            expect(allErrors).toContainEqual({message: 'Server says no', custom: true});
+            expect(allErrors).toContainEqual({message: 'Server says no', custom: true, server: true});
         }
+    });
+
+    it('keeps an optional Input valid when it has a client-only custom error (not server)', () => {
+        mocks.getDefinition.mockReturnValue(
+            makeDefinition({validate: () => [{message: 'Client custom', custom: true}]}),
+        );
+
+        const input = makeInput('email', 0, 1);
+        const form = new FormBuilder().addFormItem(input).build();
+        const tree = new PropertyTree();
+        tree.getRoot().addProperty('email', ValueTypes.STRING.newValue('bad'));
+
+        const result = validateForm(form, tree.getRoot());
+
+        expect(result.isValid).toBe(true);
     });
 
     it('does not attach server errors that do not match path', () => {
@@ -919,6 +934,86 @@ describe('validateForm', () => {
         if (node.type === 'input') {
             const allErrors = node.errors.flat();
             expect(allErrors).not.toContainEqual(expect.objectContaining({custom: true}));
+        }
+    });
+
+    it('invalidates the form when an optional Input has a server error', () => {
+        const input = makeInput('myField', 0, 1);
+        const form = new FormBuilder().addFormItem(input).build();
+        const tree = new PropertyTree();
+        tree.getRoot().addProperty('myField', ValueTypes.STRING.newValue('val'));
+
+        const serverError = ValidationError.create().setPropertyPath('myField').setMessage('Server says no').build();
+
+        const result = validateForm(form, tree.getRoot(), {serverErrors: [serverError]});
+
+        expect(result.isValid).toBe(false);
+    });
+
+    it('does not match a server error on a different field with a shared prefix', () => {
+        const input = makeInput('myField', 0, 1);
+        const form = new FormBuilder().addFormItem(input).build();
+        const tree = new PropertyTree();
+        tree.getRoot().addProperty('myField', ValueTypes.STRING.newValue('val'));
+
+        const serverError = ValidationError.create().setPropertyPath('myFieldExtra').setMessage('Other').build();
+
+        const result = validateForm(form, tree.getRoot(), {serverErrors: [serverError]});
+
+        expect(result.isValid).toBe(true);
+        const node = result.children[0];
+        if (node.type === 'input') {
+            expect(node.errors.flat()).not.toContainEqual(expect.objectContaining({custom: true}));
+        }
+    });
+
+    it('matches a server error on a field in a non-first FormItemSet occurrence', () => {
+        const formItemSet = new FormItemSet(
+            {
+                name: 'mySet',
+                label: 'My Set',
+                occurrences: {minimum: 0, maximum: 0},
+                helpText: '',
+                items: [
+                    {
+                        Input: {
+                            name: 'title',
+                            inputType: 'TestType',
+                            label: 'Title',
+                            occurrences: {minimum: 0, maximum: 1},
+                            config: {},
+                            helpText: '',
+                        },
+                    },
+                ],
+            },
+            inputFactory,
+        );
+
+        const form = new FormBuilder().addFormItem(formItemSet).build();
+        const tree = new PropertyTree();
+        const first = tree.getRoot().addPropertySet('mySet');
+        first.addProperty('title', ValueTypes.STRING.newValue('Hello'));
+        const second = tree.getRoot().addPropertySet('mySet');
+        second.addProperty('title', ValueTypes.STRING.newValue('World'));
+
+        const serverError = ValidationError.create()
+            .setPropertyPath('mySet[1].title')
+            .setMessage('Server says no')
+            .build();
+
+        const result = validateForm(form, tree.getRoot(), {serverErrors: [serverError]});
+
+        expect(result.isValid).toBe(false);
+        const node = result.children[0];
+        expect(node.type).toBe('itemset');
+        if (node.type === 'itemset') {
+            expect(node.occurrences[0].isValid).toBe(true);
+            expect(node.occurrences[1].isValid).toBe(false);
+            const inputNode = node.occurrences[1].children[0];
+            if (inputNode.type === 'input') {
+                expect(inputNode.errors.flat()).toContainEqual({message: 'Server says no', custom: true, server: true});
+            }
         }
     });
 

--- a/src/main/resources/assets/admin/common/js/form2/descriptor/validateForm.ts
+++ b/src/main/resources/assets/admin/common/js/form2/descriptor/validateForm.ts
@@ -1,3 +1,4 @@
+import {PropertyPath, PropertyPathElement} from '../../data/PropertyPath';
 import type {PropertySet} from '../../data/PropertySet';
 import type {Form} from '../../form/Form';
 import type {FormItem} from '../../form/FormItem';
@@ -8,6 +9,7 @@ import {FormOptionSet} from '../../form/set/optionset/FormOptionSet';
 import {ObjectHelper} from '../../ObjectHelper';
 import type {ValidationError} from '../../ValidationError';
 import {InputTypeRegistry} from '../registry/InputTypeRegistry';
+import {matchesFieldPath} from '../utils/serverErrors';
 import type {
     FieldSetValidationNode,
     FormValidationNode,
@@ -34,11 +36,10 @@ function stripLeadingDot(path: string): string {
     return path.startsWith('.') ? path.slice(1) : path;
 }
 
-function matchServerErrors(formPath: string, serverErrors: ValidationError[]): ValidationResult[] {
-    const stripped = stripLeadingDot(formPath);
+function matchServerErrors(dataPath: string, serverErrors: ValidationError[]): ValidationResult[] {
     return serverErrors
-        .filter(error => error.getPropertyPath().startsWith(stripped))
-        .map(error => ({message: error.getMessage(), custom: true}));
+        .filter(error => matchesFieldPath(error.getPropertyPath(), dataPath))
+        .map(error => ({message: error.getMessage(), custom: true, server: true}));
 }
 
 function isNodeValid(child: FormValidationNode): boolean {
@@ -47,7 +48,7 @@ function isNodeValid(child: FormValidationNode): boolean {
             return true;
         case 'input':
             if (child.occurrenceError != null) return false;
-            if (child.optional) return true;
+            if (child.optional) return !child.errors.some(occ => occ.some(e => e.server));
             return child.errors.every(e => e.length === 0);
         case 'fieldset':
             return child.isValid !== false;
@@ -93,12 +94,13 @@ function validateInput(input: Input, propertySet: PropertySet, options?: Validat
         errors.push(validationResults);
     }
 
-    // Append server errors
     const serverErrors = options?.serverErrors;
     if (serverErrors != null && serverErrors.length > 0) {
-        const matched = matchServerErrors(path, serverErrors);
+        const dataPath = stripLeadingDot(
+            PropertyPath.fromParent(propertySet.getPropertyPath(), new PropertyPathElement(name, 0)).toString(),
+        );
+        const matched = matchServerErrors(dataPath, serverErrors);
         if (matched.length > 0) {
-            // Attach server errors to the first occurrence
             errors[0] = [...(errors[0] ?? []), ...matched];
         }
     }
@@ -184,8 +186,6 @@ function validateItemSet(
         const max = itemSet.getOccurrences().getMaximum();
         occurrenceError = `set.occurrence.breaks.max:${max}`;
     }
-
-    // TODO: propagate serverErrors into nested set occurrences (Phase 8)
 
     return {type: 'itemset', path, name, occurrenceError, occurrences};
 }

--- a/src/main/resources/assets/admin/common/js/form2/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/index.ts
@@ -48,6 +48,13 @@ export {LocaleProvider, type LocaleProviderProps, useLocale} from './LocaleConte
 export {RawValueProvider, type RawValueProviderProps, useRawValueMap} from './RawValueContext';
 // React input type system (for CS and future consumers)
 export {InputTypeRegistry} from './registry/InputTypeRegistry';
+export {
+    type ServerErrorEntry,
+    ServerErrorsProvider,
+    type ServerErrorsProviderProps,
+    type ServerErrorsValue,
+    useServerErrors,
+} from './ServerErrorsContext';
 export type {
     InputTypeComponent,
     InputTypeComponentProps,
@@ -56,6 +63,7 @@ export type {
     SelfManagedComponentProps,
     SelfManagedInputTypeComponent,
 } from './types';
+export {matchesFieldPath, matchesOccurrencePath, serverErrorOccurrenceIndex} from './utils/serverErrors';
 export {
     findByPath,
     getFirstError,

--- a/src/main/resources/assets/admin/common/js/form2/utils/index.ts
+++ b/src/main/resources/assets/admin/common/js/form2/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './accessibility';
 export * from './getLangAttributes';
+export * from './serverErrors';
 export * from './validation';

--- a/src/main/resources/assets/admin/common/js/form2/utils/serverErrors.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/utils/serverErrors.test.ts
@@ -1,0 +1,121 @@
+import {describe, expect, it} from 'vitest';
+import type {OccurrenceValidationState} from '../descriptor/OccurrenceManager';
+import {
+    bucketServerErrorsByOccurrence,
+    matchesFieldPath,
+    matchesOccurrencePath,
+    mergeServerErrors,
+    serverErrorOccurrenceIndex,
+} from './serverErrors';
+
+function occ(index: number, ...messages: string[]): OccurrenceValidationState {
+    return {index, breaksRequired: false, validationResults: messages.map(message => ({message}))};
+}
+
+describe('matchesFieldPath', () => {
+    it('matches the field itself and descendants', () => {
+        expect(matchesFieldPath('myField', 'myField')).toBe(true);
+        expect(matchesFieldPath('mySet.title', 'mySet')).toBe(true);
+        expect(matchesFieldPath('mySet[1].title', 'mySet')).toBe(true);
+    });
+
+    it('matches sibling occurrences of the field (field-level)', () => {
+        expect(matchesFieldPath('tags[2]', 'tags')).toBe(true);
+    });
+
+    it('does not match a field sharing a prefix', () => {
+        expect(matchesFieldPath('myFieldExtra', 'myField')).toBe(false);
+        expect(matchesFieldPath('other', 'myField')).toBe(false);
+    });
+});
+
+describe('matchesOccurrencePath', () => {
+    it('matches the occurrence itself and its descendants', () => {
+        expect(matchesOccurrencePath('tags', 'tags')).toBe(true);
+        expect(matchesOccurrencePath('mySet[1].title', 'mySet[1].title')).toBe(true);
+        expect(matchesOccurrencePath('mySet[1].title.x', 'mySet[1].title')).toBe(true);
+    });
+
+    it('does not match sibling occurrences', () => {
+        expect(matchesOccurrencePath('tags[1]', 'tags')).toBe(false);
+        expect(matchesOccurrencePath('tags[2]', 'tags[1]')).toBe(false);
+    });
+});
+
+describe('serverErrorOccurrenceIndex', () => {
+    it('resolves occurrence 0 when the index is omitted', () => {
+        expect(serverErrorOccurrenceIndex('tags', 'tags')).toBe(0);
+        expect(serverErrorOccurrenceIndex('tags.sub', 'tags')).toBe(0);
+    });
+
+    it('parses the occurrence index from the bracket', () => {
+        expect(serverErrorOccurrenceIndex('tags[2]', 'tags')).toBe(2);
+        expect(serverErrorOccurrenceIndex('tags[1].sub', 'tags')).toBe(1);
+    });
+});
+
+describe('bucketServerErrorsByOccurrence', () => {
+    it("groups a field's errors by occurrence index and tags them server+custom", () => {
+        const entries = [
+            {path: 'tags', message: 'a'},
+            {path: 'tags[1]', message: 'b'},
+            {path: 'tags[2]', message: 'c'},
+        ];
+
+        const map = bucketServerErrorsByOccurrence(entries, 'tags');
+
+        expect([...map.keys()].sort()).toEqual([0, 1, 2]);
+        expect(map.get(0)).toEqual([{message: 'a', custom: true, server: true}]);
+        expect(map.get(1)).toEqual([{message: 'b', custom: true, server: true}]);
+        expect(map.get(2)).toEqual([{message: 'c', custom: true, server: true}]);
+    });
+
+    it('ignores entries for other fields (boundary-safe)', () => {
+        const map = bucketServerErrorsByOccurrence([{path: 'tagsExtra', message: 'x'}], 'tags');
+        expect(map.size).toBe(0);
+    });
+
+    it('maps an exact nested-occurrence path to occurrence 0 of that leaf', () => {
+        const map = bucketServerErrorsByOccurrence([{path: 'mySet[1].title', message: 'x'}], 'mySet[1].title');
+        expect([...map.keys()]).toEqual([0]);
+    });
+});
+
+describe('mergeServerErrors', () => {
+    it('returns the same validation when there are no server errors', () => {
+        const validation = [occ(0), occ(1)];
+        expect(mergeServerErrors(validation, new Map())).toBe(validation);
+    });
+
+    it('places each error on its occurrence, ahead of client errors', () => {
+        const validation = [occ(0), occ(1, 'client')];
+        const map = new Map([[1, [{message: 'server', custom: true, server: true}]]]);
+
+        const merged = mergeServerErrors(validation, map);
+
+        expect(merged[0].validationResults).toEqual([]);
+        expect(merged[1].validationResults).toEqual([
+            {message: 'server', custom: true, server: true},
+            {message: 'client'},
+        ]);
+    });
+
+    it('falls back to occurrence 0 for indices past the current occurrence count', () => {
+        const validation = [occ(0), occ(1)];
+        const map = new Map([[5, [{message: 'stale', custom: true, server: true}]]]);
+
+        const merged = mergeServerErrors(validation, map);
+
+        expect(merged[0].validationResults).toEqual([{message: 'stale', custom: true, server: true}]);
+        expect(merged[1].validationResults).toEqual([]);
+    });
+
+    it('synthesizes occurrence 0 when there is no validation yet', () => {
+        const map = new Map([[0, [{message: 'server', custom: true, server: true}]]]);
+
+        const merged = mergeServerErrors([], map);
+
+        expect(merged).toHaveLength(1);
+        expect(merged[0].validationResults).toEqual([{message: 'server', custom: true, server: true}]);
+    });
+});

--- a/src/main/resources/assets/admin/common/js/form2/utils/serverErrors.ts
+++ b/src/main/resources/assets/admin/common/js/form2/utils/serverErrors.ts
@@ -1,0 +1,61 @@
+import type {OccurrenceValidationState} from '../descriptor/OccurrenceManager';
+import type {ValidationResult} from '../descriptor/ValidationResult';
+
+export type ServerErrorEntryLike = {
+    path: string;
+    message: string;
+};
+
+export function matchesFieldPath(serverPath: string, fieldPath: string): boolean {
+    return serverPath === fieldPath || serverPath.startsWith(`${fieldPath}.`) || serverPath.startsWith(`${fieldPath}[`);
+}
+
+export function matchesOccurrencePath(serverPath: string, occurrencePath: string): boolean {
+    return serverPath === occurrencePath || serverPath.startsWith(`${occurrencePath}.`);
+}
+
+export function serverErrorOccurrenceIndex(serverPath: string, fieldPath: string): number {
+    if (serverPath.startsWith(`${fieldPath}[`)) {
+        const rest = serverPath.slice(fieldPath.length + 1);
+        const end = rest.indexOf(']');
+        const index = end > 0 ? Number.parseInt(rest.slice(0, end), 10) : Number.NaN;
+        return Number.isNaN(index) ? 0 : index;
+    }
+    return 0;
+}
+
+export function bucketServerErrorsByOccurrence(
+    entries: readonly ServerErrorEntryLike[],
+    fieldPath: string,
+): Map<number, ValidationResult[]> {
+    const byOccurrence = new Map<number, ValidationResult[]>();
+    for (const entry of entries) {
+        if (!matchesFieldPath(entry.path, fieldPath)) continue;
+        const occurrence = serverErrorOccurrenceIndex(entry.path, fieldPath);
+        const results = byOccurrence.get(occurrence) ?? [];
+        results.push({message: entry.message, custom: true, server: true});
+        byOccurrence.set(occurrence, results);
+    }
+    return byOccurrence;
+}
+
+export function mergeServerErrors(
+    validation: OccurrenceValidationState[],
+    serverErrorsByOccurrence: Map<number, ValidationResult[]>,
+): OccurrenceValidationState[] {
+    if (serverErrorsByOccurrence.size === 0) return validation;
+    if (validation.length === 0) {
+        const all = [...serverErrorsByOccurrence.values()].flat();
+        return [{index: 0, breaksRequired: false, validationResults: all}];
+    }
+
+    const overflow: ValidationResult[] = [];
+    serverErrorsByOccurrence.forEach((results, index) => {
+        if (index >= validation.length) overflow.push(...results);
+    });
+
+    return validation.map((entry, index) => {
+        const extra = [...(serverErrorsByOccurrence.get(index) ?? []), ...(index === 0 ? overflow : [])];
+        return extra.length > 0 ? {...entry, validationResults: [...extra, ...entry.validationResults]} : entry;
+    });
+}


### PR DESCRIPTION
- Added a ServerErrors context so consumers can feed content validation errors into form2. InputField now displays server errors per occurrence, ahead of client errors, and clears them on value edit (that occurrence) and on occurrence add/remove/move (the whole field). validateForm matches server errors by data path with occurrence indices and counts them toward validity — including optional fields — via a dedicated `server` flag on ValidationResult.