### PR TITLE
Bump @enonic/ui from 1.0.1 to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@biomejs/biome": "~2.4.16",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
-    "@enonic/ui": "^1.0.1",
+    "@enonic/ui": "^1.0.3",
     "@rollup/plugin-inject": "^5.0.5",
     "@storybook/addon-docs": "~10.4.2",
     "@storybook/addon-themes": "~10.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@enonic/ui':
-        specifier: ^1.0.1
-        version: 1.0.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.7))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(lucide-react@1.17.0(react@19.2.7))(preact@10.29.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tw-animate-css@1.4.0)
+        specifier: ^1.0.3
+        version: 1.0.3(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.7))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(lucide-react@1.17.0(react@19.2.7))(preact@10.29.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tw-animate-css@1.4.0)
       '@rollup/plugin-inject':
         specifier: ^5.0.5
         version: 5.0.5
@@ -259,8 +259,8 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@enonic/ui@1.0.1':
-    resolution: {integrity: sha512-5AdL0lXOYBt0epG/KFZSRmg8y9N2kTYNNVX0baE1rKdqDrq3iWysUzMDfx5Pcf3RqL1QIu3q7pJPhdfsJJQHwg==}
+  '@enonic/ui@1.0.3':
+    resolution: {integrity: sha512-VTKyj/5hgv1GtL6LeQwnobZGfSthuztlNlPw3oU3bxDcNCkVetUVFus7WuiH49fD0MWc1BsSbhI3fTg7ohYUxw==}
     engines: {node: '>=24.16.0', pnpm: '>=11.1.1'}
     peerDependencies:
       '@radix-ui/react-slot': ^1.2.0
@@ -2260,7 +2260,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@enonic/ui@1.0.1(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.7))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(lucide-react@1.17.0(react@19.2.7))(preact@10.29.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tw-animate-css@1.4.0)':
+  '@enonic/ui@1.0.3(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.7))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(lucide-react@1.17.0(react@19.2.7))(preact@10.29.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tw-animate-css@1.4.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.7)
       class-variance-authority: 0.7.1


### PR DESCRIPTION
Bumps `@enonic/ui` from 1.0.1 to 1.0.3 (the devDependencies entry). The `peerDependencies` range stays at `^1.0.1`, which already permits 1.0.3.

- [Release v1.0.2](https://github.com/enonic/npm-enonic-ui/releases/tag/v1.0.2)
- [Release v1.0.3](https://github.com/enonic/npm-enonic-ui/releases/tag/v1.0.3)

`pnpm check` passes — types, lint, and 1044 tests.

<sub>*Drafted with AI assistance*</sub>