### PR TITLE
Invalid value in the DateTime input is not cleared after saving the content #4540

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/date-input/DateInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/date-input/DateInput.tsx
@@ -31,29 +31,29 @@ export const DateInput = ({
     const [open, setOpen] = useState(false);
     // ? DatePicker API uses null for "no selection" — applies to draftDate, selectedDate, calendarValue
     const [draftDate, setDraftDate] = useState<Date | null>(null);
-    const lastEmitted = useRef<string | undefined>(undefined);
+    const isLocalChange = useRef(false);
     const inputRef = useRef<HTMLInputElement>(null);
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const t = useI18n();
 
-    // Sync from parent only on external value changes (e.g. form reset).
-    // Skip when the string representation matches what we last emitted.
+    // Sync from parent only on external value changes (e.g. save, form reset).
+    // Skip when the change was triggered by handleInputChange/handleConfirm below.
     useEffect(() => {
-        const parentStr = valueToString(value);
-        if (lastEmitted.current === parentStr) return;
-        setRawInput(parentStr);
+        if (isLocalChange.current) {
+            isLocalChange.current = false;
+            return;
+        }
+        setRawInput(valueToString(value));
     }, [value]);
 
     const handleInputChange = (e: JSX.TargetedEvent<HTMLInputElement>) => {
         const inputValue = e.currentTarget.value;
+        isLocalChange.current = true;
         setRawInput(inputValue);
         if (inputValue === '') {
-            lastEmitted.current = '';
             onChange(ValueTypes.LOCAL_DATE.newNullValue());
         } else {
-            const newValue = ValueTypes.LOCAL_DATE.newValue(inputValue);
-            lastEmitted.current = valueToString(newValue);
-            onChange(newValue, inputValue);
+            onChange(ValueTypes.LOCAL_DATE.newValue(inputValue), inputValue);
         }
     };
 
@@ -64,8 +64,8 @@ export const DateInput = ({
     const handleConfirm = () => {
         if (draftDate == null) return;
         const formatted = DateHelper.formatDate(draftDate);
+        isLocalChange.current = true;
         setRawInput(formatted);
-        lastEmitted.current = formatted;
         onChange(ValueTypes.LOCAL_DATE.newValue(formatted));
         setOpen(false);
     };

--- a/src/main/resources/assets/admin/common/js/form2/components/date-time-input/DateTimeInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/date-time-input/DateTimeInput.tsx
@@ -70,28 +70,30 @@ export const DateTimeInput = ({
     // ? DatePicker/TimePicker API uses null for "no selection"
     const [draftDate, setDraftDate] = useState<Date | null>(null);
     const [draftTime, setDraftTime] = useState<string | null>(null);
-    const lastEmitted = useRef<string | undefined>(undefined);
+    const isLocalChange = useRef(false);
     const inputRef = useRef<HTMLInputElement>(null);
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const t = useI18n();
 
+    // Sync from parent only on external value changes (e.g. save, form reset).
+    // Skip when the change was triggered by handleInputChange/handleConfirm below.
     useEffect(() => {
-        const parentDisplay = valueToDisplay(value);
-        if (lastEmitted.current === parentDisplay) return;
-        setRawInput(parentDisplay);
+        if (isLocalChange.current) {
+            isLocalChange.current = false;
+            return;
+        }
+        setRawInput(valueToDisplay(value));
     }, [value]);
 
     const handleInputChange = (e: JSX.TargetedEvent<HTMLInputElement>) => {
         const inputValue = e.currentTarget.value;
+        isLocalChange.current = true;
         setRawInput(inputValue);
         if (inputValue === '') {
-            lastEmitted.current = '';
             onChange(ValueTypes.LOCAL_DATE_TIME.newNullValue());
         } else {
             const storageValue = displayToStorage(inputValue);
-            const newValue = ValueTypes.LOCAL_DATE_TIME.newValue(storageValue);
-            lastEmitted.current = valueToDisplay(newValue);
-            onChange(newValue, inputValue);
+            onChange(ValueTypes.LOCAL_DATE_TIME.newValue(storageValue), inputValue);
         }
     };
 
@@ -107,10 +109,9 @@ export const DateTimeInput = ({
         if (draftDate == null) return;
         const display = formatDisplay(draftDate, draftTime);
         const storageValue = displayToStorage(display);
-        const newValue = ValueTypes.LOCAL_DATE_TIME.newValue(storageValue);
+        isLocalChange.current = true;
         setRawInput(display);
-        lastEmitted.current = valueToDisplay(newValue);
-        onChange(newValue);
+        onChange(ValueTypes.LOCAL_DATE_TIME.newValue(storageValue));
         setOpen(false);
         inputRef.current?.focus();
     };

--- a/src/main/resources/assets/admin/common/js/form2/components/instant-input/InstantInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/instant-input/InstantInput.tsx
@@ -105,30 +105,32 @@ export const InstantInput = ({
     // ? DatePicker/TimePicker API uses null for "no selection"
     const [draftDate, setDraftDate] = useState<Date | null>(null);
     const [draftTime, setDraftTime] = useState<string | null>(null);
-    const lastEmitted = useRef<string | undefined>(undefined);
+    const isLocalChange = useRef(false);
     const inputRef = useRef<HTMLInputElement>(null);
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const t = useI18n();
 
     const timezoneLabel = useMemo(() => formatTimezoneLabel(draftDate, draftTime), [draftDate, draftTime]);
 
+    // Sync from parent only on external value changes (e.g. save, form reset).
+    // Skip when the change was triggered by handleInputChange/handleConfirm below.
     useEffect(() => {
-        const parentDisplay = valueToDisplay(value);
-        if (lastEmitted.current === parentDisplay) return;
-        setRawInput(parentDisplay);
+        if (isLocalChange.current) {
+            isLocalChange.current = false;
+            return;
+        }
+        setRawInput(valueToDisplay(value));
     }, [value]);
 
     const handleInputChange = (e: JSX.TargetedEvent<HTMLInputElement>) => {
         const inputValue = e.currentTarget.value;
+        isLocalChange.current = true;
         setRawInput(inputValue);
         if (inputValue === '') {
-            lastEmitted.current = '';
             onChange(ValueTypes.DATE_TIME.newNullValue());
         } else {
             const storageValue = displayToStorage(inputValue);
-            const newValue = ValueTypes.DATE_TIME.newValue(storageValue);
-            lastEmitted.current = valueToDisplay(newValue);
-            onChange(newValue, inputValue);
+            onChange(ValueTypes.DATE_TIME.newValue(storageValue), inputValue);
         }
     };
 
@@ -144,10 +146,9 @@ export const InstantInput = ({
         if (draftDate == null) return;
         const display = formatDisplay(draftDate, draftTime);
         const storageValue = displayToStorage(display);
-        const newValue = ValueTypes.DATE_TIME.newValue(storageValue);
+        isLocalChange.current = true;
         setRawInput(display);
-        lastEmitted.current = valueToDisplay(newValue);
-        onChange(newValue);
+        onChange(ValueTypes.DATE_TIME.newValue(storageValue));
         setOpen(false);
         inputRef.current?.focus();
     };

--- a/src/main/resources/assets/admin/common/js/form2/components/time-input/TimeInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/time-input/TimeInput.tsx
@@ -46,27 +46,29 @@ export const TimeInput = ({
     const [open, setOpen] = useState(false);
     // ? Uses `null` instead of `undefined` because TimePicker API uses `null` for empty value
     const [draftTime, setDraftTime] = useState<string | null>(null);
-    const lastEmitted = useRef<string | undefined>(undefined);
+    const isLocalChange = useRef(false);
     const inputRef = useRef<HTMLInputElement>(null);
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const t = useI18n();
 
+    // Sync from parent only on external value changes (e.g. save, form reset).
+    // Skip when the change was triggered by handleInputChange/handleConfirm below.
     useEffect(() => {
-        const parentStr = valueToString(value);
-        if (lastEmitted.current === parentStr) return;
-        setRawInput(parentStr);
+        if (isLocalChange.current) {
+            isLocalChange.current = false;
+            return;
+        }
+        setRawInput(valueToString(value));
     }, [value]);
 
     const handleInputChange = (e: JSX.TargetedEvent<HTMLInputElement>) => {
         const inputValue = e.currentTarget.value;
+        isLocalChange.current = true;
         setRawInput(inputValue);
         if (inputValue === '') {
-            lastEmitted.current = '';
             onChange(ValueTypes.LOCAL_TIME.newNullValue());
         } else {
-            const newValue = ValueTypes.LOCAL_TIME.newValue(inputValue);
-            lastEmitted.current = valueToString(newValue);
-            onChange(newValue, inputValue);
+            onChange(ValueTypes.LOCAL_TIME.newValue(inputValue), inputValue);
         }
     };
 
@@ -76,8 +78,8 @@ export const TimeInput = ({
 
     const handleConfirm = () => {
         if (draftTime == null) return;
+        isLocalChange.current = true;
         setRawInput(draftTime);
-        lastEmitted.current = draftTime;
         onChange(ValueTypes.LOCAL_TIME.newValue(draftTime));
         setOpen(false);
         inputRef.current?.focus();


### PR DESCRIPTION
## Changes

- Replaced the `lastEmitted` string-comparison sync guard with a one-shot `isLocalChange` flag in `DateInput`, `DateTimeInput`, `TimeInput`, and `InstantInput`.
- Invalid entries resolve to a null value, so the old guard treated the stored null as already-emitted and never re-synced — leaving stale invalid text after save. The flag now skips only the immediate echo and re-syncs on the next external value change, clearing invalid values on save.
- Mirrors the GeoPoint fix in #4517.

Closes #4540

<sub>*Drafted with AI assistance*</sub>
