### PR TITLE
Tags validation fires immediately for a new content #4566

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
@@ -48,6 +48,7 @@ const mocks = vi.hoisted(() => ({
     iconButton: vi.fn(),
     tooltip: vi.fn(({children}: {children: unknown}) => children),
     cn: vi.fn((...tokens: Array<string | false | undefined>) => tokens.filter(Boolean).join(' ')),
+    useValidationVisibility: vi.fn(() => 'all'),
 }));
 
 const SUGGESTION_DEBOUNCE_MS = 300;
@@ -85,6 +86,10 @@ vi.mock('@dnd-kit/sortable', () => ({
 
 vi.mock('../../I18nContext', () => ({
     useI18n: mocks.useI18n,
+}));
+
+vi.mock('../../ValidationContext', () => ({
+    useValidationVisibility: mocks.useValidationVisibility,
 }));
 
 function makeInput(min: number, max: number) {
@@ -416,6 +421,7 @@ describe('TagInput', () => {
             typeof initial === 'function' ? (initial as () => unknown)() : initial,
             vi.fn(),
         ]);
+        mocks.useValidationVisibility.mockReturnValue('all');
     });
 
     afterEach(() => {
@@ -508,6 +514,44 @@ describe('TagInput', () => {
                 errors: [makeHiddenBlankValidation(0, 'Hidden server error', {custom: true})],
             }),
         ).toBe('Hidden server error');
+    });
+
+    it('does not surface the occurrence error border on untouched new content in interactive mode', () => {
+        mocks.useValidationVisibility.mockReturnValue('interactive');
+
+        expect(
+            getFieldWrapperProps({
+                values: [],
+                occurrences: Occurrences.minmax(1, 3),
+                errors: [],
+            }).className,
+        ).not.toContain('border-error');
+    });
+
+    it('surfaces the occurrence error border for an empty required field once validation is fully visible', () => {
+        expect(
+            getFieldWrapperProps({
+                values: [],
+                occurrences: Occurrences.minmax(1, 3),
+                errors: [],
+            }).className,
+        ).toContain('border-error');
+    });
+
+    it('surfaces the occurrence error on new content once the field has been interacted with', () => {
+        mocks.useValidationVisibility.mockReturnValue('interactive');
+        mocks.useState.mockImplementation((initial: unknown) => [
+            initial === false ? true : typeof initial === 'function' ? (initial as () => unknown)() : initial,
+            vi.fn(),
+        ]);
+
+        expect(
+            getFieldWrapperProps({
+                values: [],
+                occurrences: Occurrences.minmax(1, 3),
+                errors: [],
+            }).className,
+        ).toContain('border-error');
     });
 
     it('keeps interactive-suppressed hidden blanks from surfacing error styling on the wrapper', () => {
@@ -1079,12 +1123,14 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => [0, vi.fn()])
             .mockImplementationOnce(() => [[], vi.fn()])
             .mockImplementationOnce(() => [-1, vi.fn()])
+            .mockImplementationOnce(() => [false, vi.fn()])
             .mockImplementationOnce(() => ['beta', vi.fn()])
             .mockImplementationOnce(() => [true, vi.fn()])
             .mockImplementationOnce(() => [false, vi.fn()])
             .mockImplementationOnce(() => [0, vi.fn()])
             .mockImplementationOnce(() => [[], vi.fn()])
-            .mockImplementationOnce(() => [-1, vi.fn()]);
+            .mockImplementationOnce(() => [-1, vi.fn()])
+            .mockImplementationOnce(() => [false, vi.fn()]);
 
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
@@ -1154,6 +1200,23 @@ describe('TagInput', () => {
         expect(onAdd).toHaveBeenCalledWith(ValueTypes.STRING.newValue('alpha'));
         expect(setDraft).toHaveBeenLastCalledWith('');
         expect(setIsInputActive).toHaveBeenCalledWith(false);
+    });
+
+    it('marks the field touched on blur even when no tag is committed', () => {
+        const setTouched = vi.fn();
+        mocks.useState
+            .mockImplementationOnce(() => ['', vi.fn()])
+            .mockImplementationOnce(() => [false, vi.fn()])
+            .mockImplementationOnce(() => [false, vi.fn()])
+            .mockImplementationOnce(() => [0, vi.fn()])
+            .mockImplementationOnce(() => [[], vi.fn()])
+            .mockImplementationOnce(() => [-1, vi.fn()])
+            .mockImplementationOnce(() => [false, setTouched]);
+
+        renderTagInput({values: [], errors: []});
+        getLastInputProps().onBlur({currentTarget: {value: ''}});
+
+        expect(setTouched).toHaveBeenCalledWith(true);
     });
 
     it('requests async suggestions only for non-blank drafts', () => {

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
@@ -21,6 +21,7 @@ import type {InputTypeConfig} from '../../descriptor';
 import {useI18n} from '../../I18nContext';
 import type {SelfManagedComponentProps} from '../../types';
 import {getFirstError, getInputAccessibleName, getOccurrenceErrorMessage} from '../../utils';
+import {useValidationVisibility} from '../../ValidationContext';
 import {FieldError} from '../field-error';
 import {
     getPastedTagLabels,
@@ -640,6 +641,7 @@ export const TagInput = ({
     suggestTags,
 }: TagInputProps): ReactElement => {
     const t = useI18n();
+    const visibility = useValidationVisibility();
     const suggestionListId = `${SUGGESTION_LIST_ID}-${useId()}`;
     const [draft, setDraft] = useState('');
     const [isInputActive, setIsInputActive] = useState(false);
@@ -680,6 +682,7 @@ export const TagInput = ({
     const [dragContextKey, setDragContextKey] = useState(0);
     const [suggestions, setSuggestions] = useState<string[]>([]);
     const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
+    const [touched, setTouched] = useState(false);
     const sensors = useSensors(
         useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
         useSensor(KeyboardSensor, {coordinateGetter: tagKeyboardCoordinates}),
@@ -699,9 +702,11 @@ export const TagInput = ({
     const hasSuppressedHiddenEntries = hiddenErrors.some(
         entry => !entry.breaksRequired && entry.validationResults.length === 0,
     );
-    const occurrenceError = hasSuppressedHiddenEntries
-        ? undefined
-        : getOccurrenceErrorMessage(occurrences, visibleErrors, t);
+    const occurrenceErrorVisible = visibility === 'all' || (visibility === 'interactive' && touched);
+    const occurrenceError =
+        !occurrenceErrorVisible || hasSuppressedHiddenEntries
+            ? undefined
+            : getOccurrenceErrorMessage(occurrences, visibleErrors, t);
     const firstVisibleFieldError = tagEntries
         .map(entry => getFirstError(errors[entry.originalIndex]?.validationResults ?? []))
         .find(Boolean);
@@ -710,6 +715,7 @@ export const TagInput = ({
         .map(result => result.message)
         .find(Boolean);
     const fieldErrorText = firstVisibleFieldError ?? hiddenCustomError;
+    const fieldMessage = fieldErrorText ?? (visibility !== 'all' ? occurrenceError : undefined);
     const hasErrors = fieldErrorText != null || occurrenceError != null;
     const focusInput = () => {
         setIsInputActive(true);
@@ -806,6 +812,7 @@ export const TagInput = ({
         rawLabels: string[],
         {focusTarget, clearDraft = false}: CommitTagLabelsOptions = {},
     ): CommitTagLabelsResult => {
+        setTouched(true);
         const maximum = occurrences.getMaximum();
         const remainingCapacity = maximum === 0 ? Number.POSITIVE_INFINITY : Math.max(maximum - visibleTagCount, 0);
 
@@ -918,6 +925,7 @@ export const TagInput = ({
     };
 
     const handleRemove = (index: number, options: RemoveTagOptions = {}) => {
+        setTouched(true);
         const {activateInput = false, focusPreviousTag = false, commitCurrentDraft = false} = options;
         let removeIndex = index;
 
@@ -1076,6 +1084,7 @@ export const TagInput = ({
             return;
         }
 
+        setTouched(true);
         commitDraft(undefined, undefined, event.currentTarget.value);
         setIsInputActive(false);
     };
@@ -1214,7 +1223,7 @@ export const TagInput = ({
                     </ul>
                 ) : null}
             </div>
-            <FieldError message={fieldErrorText} />
+            <FieldError message={fieldMessage} />
         </div>
     );
 };


### PR DESCRIPTION
TagInput surfaced the min/required occurrence error immediately on new content, before any interaction, because it derived the occurrence error itself from `occurrences` and ignored validation visibility.

Gated the occurrence error (border and message) on validation visibility: shown when visibility is `all`, or — on new content (`interactive`) — only after the field is touched. The field is marked touched on add, remove, and blur, matching how text inputs activate validation.

Closes #10937

<sub>*Drafted with AI assistance*</sub>