### PR TITLE
Content Selector - selected options remain visible after reverting ve…

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
@@ -341,6 +341,41 @@ describe('InputField', () => {
         expect(propertySet.getPropertyArray('testField')?.getSize()).toBe(0);
     });
 
+    it('does not re-inject stale values into a server-replaced (shorter) PropertyArray', () => {
+        const component: SelfManagedInputTypeComponent = () => null;
+        const descriptor = makeDescriptor();
+        const definition = {mode: 'internal' as const, descriptor, component};
+        const input = makeInput('PrincipalSelector', 0);
+        const propertySet = new PropertyTree().getRoot();
+
+        const staleValues = [ValueTypes.STRING.newValue('a'), ValueTypes.STRING.newValue('b')];
+        mocks.usePropertyArray.mockReturnValue({values: staleValues, size: staleValues.length});
+
+        const sync = vi.fn(() => staleValues);
+        mocks.useOccurrenceManager.mockReturnValue({
+            state: {...makeManagerState(), values: staleValues, occurrenceValidation: []},
+            minFill: 0,
+            add: vi.fn(() => true),
+            remove: vi.fn(() => true),
+            move: vi.fn(() => true),
+            set: vi.fn(),
+            sync,
+        });
+
+        const effects: Array<{fn: () => unknown; deps?: unknown[]}> = [];
+        mocks.useEffect.mockImplementation((fn: () => unknown, deps?: unknown[]) => {
+            effects.push({fn, deps});
+        });
+
+        InputFieldResolved({input, propertySet, enabled: true, definition});
+
+        const syncEffect = effects.find(e => e.deps?.includes(sync));
+        syncEffect?.fn();
+
+        expect(sync).toHaveBeenCalledWith(staleValues);
+        expect(propertySet.getPropertyArray('testField')?.getSize() ?? 0).toBe(0);
+    });
+
     it('remaps touched indexes when internal inputs move occurrences', () => {
         const component: SelfManagedInputTypeComponent = () => null;
         const descriptor = makeDescriptor();

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
@@ -219,6 +219,7 @@ export const InputFieldResolved = ({
 
     const {
         state,
+        minFill,
         add,
         remove,
         move,
@@ -286,14 +287,11 @@ export const InputFieldResolved = ({
     const hasServerErrors = serverErrorsByOccurrence.size > 0;
 
     useEffect(() => {
-        const managerValues = sync(values);
-        // Push seeded values to PropertyArray so they stay in sync.
-        // OccurrenceManager seeds to minFill, but PropertyArray doesn't know about those values.
-        const paSize = propertyArray.getSize();
-        for (let i = paSize; i < managerValues.length; i++) {
-            propertyArray.add(managerValues[i]);
+        sync(values);
+        while (propertyArray.getSize() < minFill) {
+            propertyArray.add(defaultValue);
         }
-    }, [values, sync, propertyArray]);
+    }, [values, sync, propertyArray, minFill, defaultValue]);
 
     const markTouched = useCallback((index: number) => {
         setTouched(prev => {

--- a/src/main/resources/assets/admin/common/js/form2/hooks/useOccurrenceManager.ts
+++ b/src/main/resources/assets/admin/common/js/form2/hooks/useOccurrenceManager.ts
@@ -19,6 +19,7 @@ type UseOccurrenceManagerParams<C extends InputTypeConfig = InputTypeConfig> = {
 
 type UseOccurrenceManagerResult = {
     state: OccurrenceManagerState;
+    minFill: number;
     add: (value?: Value) => boolean;
     remove: (index: number) => boolean;
     move: (fromIndex: number, toIndex: number) => boolean;
@@ -137,6 +138,7 @@ export function useOccurrenceManager<C extends InputTypeConfig = InputTypeConfig
 
     return {
         state,
+        minFill,
         add,
         remove,
         move,


### PR DESCRIPTION
…rsions #4568

On a server update (e.g. reverting a version) the wizard swaps the draft `PropertyTree`, but `InputField`'s sync effect wrote the occurrence manager's values back into the new `PropertyArray`; for one render `usePropertyArray` still returns the old (longer) values while the new array is empty, so the seeding loop re-added them and selectors stayed stuck on the old selection. Text inputs and the display name were unaffected only because their value count never shrank. The fix no longer pushes manager values back: it seeds only the required (`minFill`) occurrences against the array's live size, so values flow from the server tree via `sync(values)`. Selectors have `minFill` 0 and just reflect the new tree. Exposes `minFill` from `useOccurrenceManager` and adds a regression test.

Closes #4568

<sub>*Drafted with AI assistance*</sub>


