### PR TITLE
Input field does not align with the Add button #4572

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/occurrence-list/OccurrenceList.tsx
@@ -287,7 +287,10 @@ const OccurrenceListRoot = <C extends InputTypeConfig = InputTypeConfig>({
                                 <OccurrenceListItemContent
                                     {...props}
                                     errors={{...props.errors, validationResults: []}}
-                                    className={isMovable ? 'col-start-2' : 'col-start-1'}
+                                    className={cn(
+                                        isMovable ? 'col-start-2' : 'col-start-1',
+                                        !showRemove && 'col-span-2',
+                                    )}
                                 />
                                 <FieldError
                                     className={cn(


### PR DESCRIPTION
The single-value input row reserved an (empty) column for the remove button plus its 8px gap, shifting the input's right edge left of the "Add" button. Fixed by letting the input span that empty column when no remove button is shown, so it aligns with "Add".