### PR TITLE
Fix Biome config deprecation and use minimal test reporter

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,7 +57,7 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true,
+            "preset": "recommended",
             "correctness": {
                 "noUnusedVariables": "off",
                 "noUnusedImports": "off",
@@ -109,7 +109,7 @@
                 "noControlCharactersInRegex": "off"
             },
             "a11y": {
-                "recommended": false
+                "preset": "none"
             }
         }
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         ],
         environment: 'node',
         passWithNoTests: true,
-        reporters: ['dot'],
+        reporters: ['minimal'],
         onConsoleLog: () => false,
     },
     resolve: {


### PR DESCRIPTION
## Changes

- Migrated the deprecated `recommended` field to `preset` in `biome.json` (`preset: "recommended"` and `a11y.preset: "none"`) — clears the Biome 2.5 deprecation notice with no change to rule behavior.
- Switched the Vitest reporter from `dot` to `minimal` so passing runs print only the summary tally and failures still show full detail.

<sub>*Drafted with AI assistance*</sub>
