### PR TITLE
Add .gitattributes for script line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+gradlew eol=lf
+*.sh eol=lf
+*.bat -text


### PR DESCRIPTION
This repo has no `.gitattributes`, so wrapper script line endings depend on each contributor's `core.autocrlf`. A Windows checkout with `autocrlf=true` converts `gradlew` to CRLF, which breaks it under Git Bash/WSL, and nothing protects `gradlew.bat` from the normalization churn fixed in app-contentstudio and app-contentstudio-plus.

Added the same rules used in those repos: `gradlew` and `*.sh` check out as LF everywhere, `*.bat` is stored verbatim (CRLF, as Gradle generates it). The current blobs already match these rules, so nothing is renormalized and existing checkouts stay clean. Companion to enonic/app-contentstudio-plus#1829.

<sub>*Drafted with AI assistance*</sub>
