### PR TITLE
Settings app: error on app re-deploy #4588

### DIFF
--- a/src/main/resources/assets/admin/common/js/form/FormItemFactoryImpl.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemFactoryImpl.ts
@@ -10,14 +10,15 @@ import {FormOptionSetOption} from './set/optionset/FormOptionSetOption';
 import {FormItem} from './FormItem';
 import {Input} from './Input';
 import {FieldSet} from './set/fieldset/FieldSet';
-import {Store} from '../store/Store';
 import {ApplicationKey} from '../application/ApplicationKey';
-
-export const FORM_ITEM_FACTORY_KEY: string = 'FormItemFactory';
 
 export interface FormItemFactory {
     createFormItem(formItemTypeWrapperJson: FormItemTypeWrapperJson, applicationKey?: ApplicationKey): FormItem;
 }
+
+// Not cached in the window-global Store: bundles sharing it would reuse a foreign
+// factory whose objects fail this bundle's instanceof checks (lib-admin-ui#4588).
+let instance: FormItemFactoryImpl;
 
 export class FormItemFactoryImpl
     implements FormItemFactory {
@@ -26,11 +27,8 @@ export class FormItemFactoryImpl
     }
 
     static get(): FormItemFactoryImpl {
-        let instance: FormItemFactoryImpl = Store.parentInstance().get(FORM_ITEM_FACTORY_KEY);
-
         if (instance == null) {
             instance = new FormItemFactoryImpl();
-            Store.parentInstance().set(FORM_ITEM_FACTORY_KEY, instance);
         }
 
         return instance;

--- a/src/main/resources/assets/admin/common/js/form/FormItemLayerFactory.ts
+++ b/src/main/resources/assets/admin/common/js/form/FormItemLayerFactory.ts
@@ -1,6 +1,5 @@
 import {FormContext} from './FormContext';
 import {FormItemLayer} from './FormItemLayer';
-import {Store} from '../store/Store';
 import {FormItemState} from './FormItemState';
 
 export interface CreatedFormItemLayerConfig {
@@ -13,18 +12,17 @@ export interface FormItemLayerFactory {
     createLayer(config: CreatedFormItemLayerConfig): FormItemLayer;
 }
 
-export const FORM_ITEM_LAYER_FACTORY_KEY: string = 'FormItemLayerFactory';
+// Not cached in the window-global Store: bundles sharing it would reuse a foreign
+// factory whose objects fail this bundle's instanceof checks (lib-admin-ui#4588).
+let instance: FormItemLayerFactoryImpl;
 
 export class FormItemLayerFactoryImpl implements FormItemLayerFactory {
 
     protected constructor() {}
 
     static get(): FormItemLayerFactoryImpl {
-        let instance: FormItemLayerFactoryImpl = Store.parentInstance().get(FORM_ITEM_LAYER_FACTORY_KEY);
-
         if (instance == null) {
             instance = new FormItemLayerFactoryImpl();
-            Store.parentInstance().set(FORM_ITEM_LAYER_FACTORY_KEY, instance);
         }
 
         return instance;


### PR DESCRIPTION
FormItemFactoryImpl and FormItemLayerFactoryImpl were cached in the window-global Store. Bundles on the same page share that Store but embed separate class copies, so one bundle reused the other's factory and the created FormItems failed instanceof check