### PR TITLE
mobile friendly dnd #4606

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-grid-list/SortableGridList.test.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-grid-list/SortableGridList.test.tsx
@@ -66,6 +66,7 @@ const mocks = vi.hoisted(() => ({
     sortableContext: vi.fn(({children}: {children: unknown}) => children),
     cn: vi.fn((...tokens: Array<string | false | undefined>) => tokens.filter(Boolean).join(' ')),
     gripVertical: vi.fn(() => null),
+    mouseSensor: class MouseSensor {},
 }));
 
 vi.mock('react', () => ({
@@ -81,7 +82,8 @@ vi.mock('@dnd-kit/core', () => ({
     DndContext: mocks.dndContext,
     closestCenter: 'closestCenter',
     KeyboardSensor: 'KeyboardSensor',
-    PointerSensor: 'PointerSensor',
+    MouseSensor: mocks.mouseSensor,
+    TouchSensor: 'TouchSensor',
     useSensor: mocks.useSensor,
     useSensors: mocks.useSensors,
 }));
@@ -489,6 +491,54 @@ describe('SortableGridList', () => {
             .map(([config]) => config as {disabled: boolean});
 
         expect(sortableConfigs.map(config => config.disabled)).toEqual([false, true, false]);
+    });
+
+    it('configures primary-button mouse and mode-specific touch activation', () => {
+        getRowElements();
+
+        const handleSensorCalls = mocks.useSensor.mock.calls.slice(-3);
+        expect(handleSensorCalls).toEqual([
+            [expect.any(Function), {activationConstraint: {distance: 5}}],
+            ['TouchSensor', {activationConstraint: {distance: 5}}],
+            ['KeyboardSensor', {coordinateGetter: expect.any(Function)}],
+        ]);
+
+        const mouseSensor = handleSensorCalls[0]?.[0] as {
+            activators: Array<{
+                handler: (
+                    event: {nativeEvent: {button: number}},
+                    options: {onActivation?: (args: {event: {button: number}}) => void},
+                ) => boolean;
+            }>;
+        };
+        const mouseActivator = mouseSensor.activators[0]?.handler;
+        const onActivation = vi.fn();
+
+        expect(mouseActivator?.({nativeEvent: {button: 1}}, {onActivation})).toBe(false);
+        expect(mouseActivator?.({nativeEvent: {button: 2}}, {onActivation})).toBe(false);
+        expect(onActivation).not.toHaveBeenCalled();
+
+        const primaryEvent = {button: 0};
+        expect(mouseActivator?.({nativeEvent: primaryEvent}, {onActivation})).toBe(true);
+        expect(onActivation).toHaveBeenCalledWith({event: primaryEvent});
+
+        getRowElements({fullRowDraggable: true});
+
+        expect(mocks.useSensor.mock.calls.slice(-3)).toEqual([
+            [expect.any(Function), {activationConstraint: {distance: 5}}],
+            ['TouchSensor', {activationConstraint: {delay: 200, tolerance: 5}}],
+            ['KeyboardSensor', {coordinateGetter: expect.any(Function)}],
+        ]);
+    });
+
+    it('disables every sortable row when enabled is false', () => {
+        getRowElements({enabled: false});
+
+        const sortableConfigs = mocks.useSortable.mock.calls
+            .slice(-ITEMS.length)
+            .map(([config]) => config as {disabled: boolean});
+
+        expect(sortableConfigs.map(config => config.disabled)).toEqual([true, true, true]);
     });
 
     it('omits draggable semantics for rows where isItemMovable returns false', () => {

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-grid-list/SortableGridList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-grid-list/SortableGridList.tsx
@@ -4,7 +4,7 @@ import {
     type DragEndEvent,
     type DragStartEvent,
     KeyboardSensor,
-    PointerSensor,
+    TouchSensor,
     useSensor,
     useSensors,
 } from '@dnd-kit/core';
@@ -18,6 +18,12 @@ import {cn} from '@enonic/ui';
 import {GripVertical} from 'lucide-react';
 import type {JSX, ReactElement, ReactNode} from 'react';
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {
+    FULL_ROW_TOUCH_SENSOR_OPTIONS,
+    HANDLE_TOUCH_SENSOR_OPTIONS,
+    MOUSE_SENSOR_OPTIONS,
+    PrimaryButtonMouseSensor,
+} from '../sortableSensors';
 
 //
 // * Types
@@ -105,6 +111,9 @@ const NON_EDITABLE_INPUT_TYPES = new Set([
     'reset',
     'submit',
 ]);
+const KEYBOARD_SENSOR_OPTIONS = {
+    coordinateGetter: sortableKeyboardCoordinates,
+};
 
 function clampIndex(index: number, itemCount: number): number {
     if (itemCount <= 0) {
@@ -339,7 +348,7 @@ const SortableGridListItem = <T,>({
     const rowRef = useRef<HTMLDivElement | null>(null);
     const {attributes, listeners, setNodeRef, transform, transition, isDragging} = useSortable({
         id,
-        disabled: !isMovable,
+        disabled: !enabled || !isMovable,
     });
 
     const handleNodeRef = (node: HTMLDivElement | null) => {
@@ -409,7 +418,6 @@ const SortableGridListItem = <T,>({
         (listeners?.onKeyDown as JSX.KeyboardEventHandler<HTMLDivElement>)?.(e);
     };
 
-    // ? useSortable returns a fresh listeners object each render, so memoizing is a no-op
     // When fullRowDraggable, dnd-kit listeners must not override the guarded handleKeyDown
     let rowListenersSafe: Omit<NonNullable<typeof listeners>, 'onKeyDown'> | undefined;
     if (fullRowDraggable && isMovable && listeners != null) {
@@ -471,7 +479,8 @@ const SortableGridListItem = <T,>({
                 'relative flex items-center rounded outline-none',
                 'focus-visible:ring-2 focus-visible:ring-ring/25 focus-visible:ring-inset',
                 isDragging && 'bg-surface-neutral shadow-[0_2px_8px_2px] shadow-main/10 ring-1 ring-main/5',
-                fullRowDraggable && isMovable && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
+                enabled && fullRowDraggable && isMovable && 'select-none',
+                enabled && fullRowDraggable && isMovable && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
                 resolvedClassName,
             )}
             {...rowListenersSafe}
@@ -483,7 +492,7 @@ const SortableGridListItem = <T,>({
                         'flex shrink-0 items-center text-subtle',
                         fullRowDraggable
                             ? 'pointer-events-none'
-                            : cn('cursor-grab', 'hover:text-foreground', isDragging && 'cursor-grabbing'),
+                            : cn('cursor-grab touch-none', 'hover:text-foreground', isDragging && 'cursor-grabbing'),
                         'focus-visible:outline-none',
                         !enabled && 'pointer-events-none opacity-30',
                     )}
@@ -530,10 +539,9 @@ export const SortableGridList = <T,>({
     const pendingBlurClearVersionRef = useRef(0);
 
     const sensors = useSensors(
-        useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
-        useSensor(KeyboardSensor, {
-            coordinateGetter: sortableKeyboardCoordinates,
-        }),
+        useSensor(PrimaryButtonMouseSensor, MOUSE_SENSOR_OPTIONS),
+        useSensor(TouchSensor, fullRowDraggable ? FULL_ROW_TOUCH_SENSOR_OPTIONS : HANDLE_TOUCH_SENSOR_OPTIONS),
+        useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
     );
 
     const getIsItemMovable = useCallback(

--- a/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortable-list/SortableList.tsx
@@ -8,7 +8,7 @@ import {
     KeyboardSensor,
     type MeasuringConfiguration,
     MeasuringStrategy,
-    PointerSensor,
+    TouchSensor,
     useSensor,
     useSensors,
 } from '@dnd-kit/core';
@@ -22,6 +22,12 @@ import {cn} from '@enonic/ui';
 import {GripVertical} from 'lucide-react';
 import type {JSX, ReactElement, ReactNode} from 'react';
 import {useCallback, useMemo, useState} from 'react';
+import {
+    FULL_ROW_TOUCH_SENSOR_OPTIONS,
+    HANDLE_TOUCH_SENSOR_OPTIONS,
+    MOUSE_SENSOR_OPTIONS,
+    PrimaryButtonMouseSensor,
+} from '../sortableSensors';
 
 //
 // * Types
@@ -173,6 +179,9 @@ function restrictToVerticalAxis({transform}: {transform: {x: number; y: number; 
 const PROJECTION_MEASURING: MeasuringConfiguration = {
     droppable: {strategy: MeasuringStrategy.Always},
 };
+const KEYBOARD_SENSOR_OPTIONS = {
+    coordinateGetter: sortableKeyboardCoordinates,
+};
 
 //
 // * SortableListItem
@@ -268,7 +277,7 @@ const SortableListItem = <T,>({
                 'flex shrink-0 items-center text-subtle',
                 fullRowDraggable
                     ? 'pointer-events-none'
-                    : cn('cursor-grab', 'hover:text-foreground', isDragging && 'cursor-grabbing'),
+                    : cn('cursor-grab touch-none', 'hover:text-foreground', isDragging && 'cursor-grabbing'),
                 'focus-visible:outline-none',
                 !enabled && 'pointer-events-none opacity-30',
             )}
@@ -310,8 +319,8 @@ const SortableListItem = <T,>({
                 isDragging && 'bg-surface-neutral shadow-[0_2px_8px_2px] shadow-main/10 ring-1 ring-main/5',
                 isDragging && !dropAllowed && 'opacity-40',
                 // Full-row drag targets must not turn a press-drag into a text selection.
-                fullRowDraggable && isMovable && 'touch-none select-none',
-                fullRowDraggable && isMovable && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
+                enabled && fullRowDraggable && isMovable && 'select-none',
+                enabled && fullRowDraggable && isMovable && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
                 resolvedClassName,
             )}
             {...rowListenersSafe}
@@ -357,10 +366,9 @@ export const SortableList = <T,>({
     const [drop, setDrop] = useState<{info: SortableDragInfo; hint: SortableDropHint | null} | null>(null);
 
     const sensors = useSensors(
-        useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
-        useSensor(KeyboardSensor, {
-            coordinateGetter: sortableKeyboardCoordinates,
-        }),
+        useSensor(PrimaryButtonMouseSensor, MOUSE_SENSOR_OPTIONS),
+        useSensor(TouchSensor, fullRowDraggable ? FULL_ROW_TOUCH_SENSOR_OPTIONS : HANDLE_TOUCH_SENSOR_OPTIONS),
+        useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
     );
 
     const handleDragStart = useCallback(

--- a/src/main/resources/assets/admin/common/js/form2/components/sortableSensors.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortableSensors.ts
@@ -15,13 +15,9 @@ export const FULL_ROW_TOUCH_SENSOR_OPTIONS: TouchSensorOptions = {
 export class PrimaryButtonMouseSensor extends MouseSensor {
     static activators: typeof MouseSensor.activators = [
         {
-            eventName: 'onMouseDown' as const,
-            handler: (syntheticEvent, {onActivation}): boolean => {
-                const event = (syntheticEvent as unknown as {nativeEvent: MouseEvent}).nativeEvent;
-
-                if (event.button !== 0) {
-                    return false;
-                }
+            eventName: 'onMouseDown',
+            handler: ({nativeEvent: event}: {nativeEvent: MouseEvent}, {onActivation}): boolean => {
+                if (event.button !== 0) return false;
 
                 onActivation?.({event});
                 return true;

--- a/src/main/resources/assets/admin/common/js/form2/components/sortableSensors.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/sortableSensors.ts
@@ -1,0 +1,31 @@
+import {MouseSensor, type MouseSensorOptions, type TouchSensorOptions} from '@dnd-kit/core';
+
+export const MOUSE_SENSOR_OPTIONS: MouseSensorOptions = {
+    activationConstraint: {distance: 5},
+};
+
+export const HANDLE_TOUCH_SENSOR_OPTIONS: TouchSensorOptions = {
+    activationConstraint: {distance: 5},
+};
+
+export const FULL_ROW_TOUCH_SENSOR_OPTIONS: TouchSensorOptions = {
+    activationConstraint: {delay: 200, tolerance: 5},
+};
+
+export class PrimaryButtonMouseSensor extends MouseSensor {
+    static activators: typeof MouseSensor.activators = [
+        {
+            eventName: 'onMouseDown' as const,
+            handler: (syntheticEvent, {onActivation}): boolean => {
+                const event = (syntheticEvent as unknown as {nativeEvent: MouseEvent}).nativeEvent;
+
+                if (event.button !== 0) {
+                    return false;
+                }
+
+                onActivation?.({event});
+                return true;
+            },
+        },
+    ];
+}

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
     tooltip: vi.fn(({children}: {children: unknown}) => children),
     cn: vi.fn((...tokens: Array<string | false | undefined>) => tokens.filter(Boolean).join(' ')),
     useValidationVisibility: vi.fn(() => 'all'),
+    mouseSensor: class MouseSensor {},
 }));
 
 const SUGGESTION_DEBOUNCE_MS = 300;
@@ -72,7 +73,8 @@ vi.mock('@dnd-kit/core', () => ({
     DndContext: mocks.dndContext,
     closestCenter: 'closestCenter',
     KeyboardSensor: 'KeyboardSensor',
-    PointerSensor: 'PointerSensor',
+    MouseSensor: mocks.mouseSensor,
+    TouchSensor: 'TouchSensor',
     useSensor: mocks.useSensor,
     useSensors: mocks.useSensors,
 }));
@@ -436,6 +438,21 @@ describe('TagInput', () => {
         expect(mocks.button).not.toHaveBeenCalled();
     });
 
+    it('focuses the mounted input after a completed field tap', () => {
+        const focus = vi.fn();
+        const requestFrame = vi.fn();
+        vi.stubGlobal('requestAnimationFrame', requestFrame);
+        mocks.useRef.mockImplementationOnce(() => ({current: null})).mockImplementationOnce(() => ({current: {focus}}));
+        const wrapperProps = getFieldWrapperProps({values: [], errors: []});
+        const field = {};
+
+        wrapperProps.onClick({target: field, currentTarget: field});
+
+        expect(wrapperProps.onPointerDown).toBeUndefined();
+        expect(focus).toHaveBeenCalledOnce();
+        expect(requestFrame).not.toHaveBeenCalled();
+    });
+
     it('keeps the tag wrapper out of the tab order', () => {
         const wrapperProps = getFieldWrapperProps({
             values: [ValueTypes.STRING.newValue('alpha')],
@@ -674,6 +691,17 @@ describe('TagInput', () => {
         expect(mocks.useSortable).toHaveBeenCalledTimes(2);
         expect(mocks.useSortable).toHaveBeenNthCalledWith(1, expect.objectContaining({disabled: true}));
         expect(mocks.useSortable).toHaveBeenNthCalledWith(2, expect.objectContaining({disabled: true}));
+    });
+
+    it('configures immediate handle dragging for mouse and touch', () => {
+        renderDraggableTagInput();
+
+        expect(mocks.useSensor.mock.calls.slice(-3)).toEqual([
+            [expect.any(Function), {activationConstraint: {distance: 5}}],
+            ['TouchSensor', {activationConstraint: {distance: 5}}],
+            ['KeyboardSensor', {coordinateGetter: expect.any(Function)}],
+        ]);
+        expect(getFirstDragButtonProps().className).toContain('touch-none');
     });
 
     it('disables dnd-kit auto-scroll for tag dragging', () => {

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
@@ -5,7 +5,7 @@ import {
     type DragStartEvent,
     type KeyboardCoordinateGetter,
     KeyboardSensor,
-    PointerSensor,
+    TouchSensor,
     useSensor,
     useSensors,
 } from '@dnd-kit/core';
@@ -23,6 +23,7 @@ import type {SelfManagedComponentProps} from '../../types';
 import {getFirstError, getInputAccessibleName, getOccurrenceErrorMessage} from '../../utils';
 import {useValidationVisibility} from '../../ValidationContext';
 import {FieldError} from '../field-error';
+import {HANDLE_TOUCH_SENSOR_OPTIONS, MOUSE_SENSOR_OPTIONS, PrimaryButtonMouseSensor} from '../sortableSensors';
 import {
     getPastedTagLabels,
     getSuggestedTagLabels,
@@ -244,6 +245,7 @@ const tagKeyboardCoordinates: KeyboardCoordinateGetter = (event, args) => {
         y: targetRect.top,
     };
 };
+const KEYBOARD_SENSOR_OPTIONS = {coordinateGetter: tagKeyboardCoordinates};
 
 function toTransformCSS(transform: SortableTransform | null): string | undefined {
     if (transform == null) {
@@ -584,7 +586,7 @@ const TagItem = ({
                     iconSize='sm'
                     variant='text'
                     className={cn(
-                        'size-5 focus-visible:ring-2 focus-visible:ring-offset-2',
+                        'size-5 touch-none focus-visible:ring-2 focus-visible:ring-offset-2',
                         enabled && (isDragging ? 'cursor-grabbing' : 'cursor-grab'),
                     )}
                     disabled={!enabled}
@@ -684,8 +686,9 @@ export const TagInput = ({
     const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
     const [touched, setTouched] = useState(false);
     const sensors = useSensors(
-        useSensor(PointerSensor, {activationConstraint: {distance: 5}}),
-        useSensor(KeyboardSensor, {coordinateGetter: tagKeyboardCoordinates}),
+        useSensor(PrimaryButtonMouseSensor, MOUSE_SENSOR_OPTIONS),
+        useSensor(TouchSensor, HANDLE_TOUCH_SENSOR_OPTIONS),
+        useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
     );
 
     const ids = tagEntries.map(entry => entry.id);
@@ -719,7 +722,7 @@ export const TagInput = ({
     const hasErrors = fieldErrorText != null || occurrenceError != null;
     const focusInput = () => {
         setIsInputActive(true);
-        requestAnimationFrame(() => inputRef.current?.focus());
+        inputRef.current?.focus();
     };
 
     useEffect(() => {
@@ -972,7 +975,7 @@ export const TagInput = ({
         focusTagAt(targetIndex);
     };
 
-    const handleFieldPointerDown: preact.JSX.PointerEventHandler<HTMLElement> = event => {
+    const handleFieldClick: preact.JSX.MouseEventHandler<HTMLElement> = event => {
         if (event.target === event.currentTarget) {
             handleFieldActivate();
         }
@@ -1146,7 +1149,7 @@ export const TagInput = ({
                     canAdd && 'cursor-text',
                     hasErrors && 'border-error focus-within:border-error focus-within:ring-error hover:outline-error',
                 )}
-                onPointerDown={handleFieldPointerDown}
+                onClick={handleFieldClick}
                 onFocus={() => setHasFocusWithin(true)}
                 onBlur={() => {
                     requestAnimationFrame(() => {
@@ -1166,7 +1169,7 @@ export const TagInput = ({
                     onDragCancel={handleDragCancel}
                 >
                     <SortableContext items={ids} strategy={rectSortingStrategy}>
-                        <ul className='flex flex-wrap items-center gap-2' onPointerDown={handleFieldPointerDown}>
+                        <ul className='flex flex-wrap items-center gap-2' onClick={handleFieldClick}>
                             {tagEntries.map((entry, index) => (
                                 <TagItem key={entry.id} {...getTagItemProps(entry, index)} />
                             ))}


### PR DESCRIPTION
replace PointerSensor with separate mouse and touch sensors add delayed touch activation while preserving native scrolling remove touch-none from full-row sortable lists
prevent dragging when disabled in row and handle modes update dnd-kit sensor mocks