### PR TITLE
Improve TagInput #4643

### DIFF
--- a/src/main/resources/assets/admin/common/js/form2/components/combo-box-input/ComboBoxInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/combo-box-input/ComboBoxInput.stories.tsx
@@ -51,6 +51,7 @@ function makeState(values: string[], min: number, max: number): OccurrenceManage
 function makeDefaultArgs(values: string[], min: number, max: number): SelfManagedComponentProps<ComboBoxConfig> {
     const state = makeState(values, min, max);
     return {
+        occurrenceIds: state.ids,
         values: state.values,
         onChange: () => {
             /* empty */
@@ -266,6 +267,7 @@ const InteractiveDemo = (): ReactElement => {
                 </ul>
             </div>
             <ComboBoxInput
+                occurrenceIds={state.ids}
                 values={state.values}
                 onChange={handleChange}
                 onAdd={handleAdd}

--- a/src/main/resources/assets/admin/common/js/form2/components/combo-box-input/ComboBoxInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/combo-box-input/ComboBoxInput.test.ts
@@ -58,6 +58,7 @@ type ComboBoxInputProps = SelfManagedComponentProps<ComboBoxConfig>;
 
 function makeProps(overrides: Partial<ComboBoxInputProps> = {}): ComboBoxInputProps {
     return {
+        occurrenceIds: [],
         values: [],
         onChange: vi.fn(),
         onAdd: vi.fn(),

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.test.ts
@@ -259,7 +259,7 @@ describe('InputField', () => {
         const propertySet = new PropertyTree().getRoot();
         const move = vi.fn(() => false);
         mocks.useOccurrenceManager.mockReturnValue({
-            state: {...makeManagerState(), values: [], occurrenceValidation: []},
+            state: {...makeManagerState(), ids: [], values: [], occurrenceValidation: []},
             add: vi.fn(() => true),
             remove: vi.fn(() => true),
             move,
@@ -271,6 +271,7 @@ describe('InputField', () => {
         const child = getChildAt(element, 1);
 
         expect(child.type).toBe(component);
+        expect(child.props.occurrenceIds).toEqual([]);
         expect(mocks.occurrenceListRoot).not.toHaveBeenCalled();
         expect(mocks.useOccurrenceManager).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/input-field/InputField.tsx
@@ -604,6 +604,7 @@ export const InputFieldResolved = ({
                 <div data-component={INPUT_FIELD_NAME} className='flex flex-col'>
                     <InputLabel className='mb-2' input={input} />
                     <Component
+                        occurrenceIds={state.ids}
                         values={state.values}
                         onChange={handleChange}
                         onAdd={handleAdd}

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.stories.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.stories.tsx
@@ -80,6 +80,7 @@ function DemoTagInput({
     return (
         <div className='flex w-[32rem] flex-col gap-y-2'>
             <TagInput
+                occurrenceIds={state.ids}
                 values={values}
                 onChange={(index, value) =>
                     setValues(prev => prev.map((current, currentIndex) => (currentIndex === index ? value : current)))

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
@@ -24,7 +24,9 @@ const mocks = vi.hoisted(() => ({
     ]),
     useEffect: vi.fn(),
     useId: vi.fn(() => 'test-id'),
+    useLayoutEffect: vi.fn(),
     useRef: vi.fn((initial: unknown) => ({current: initial})),
+    useSyncExternalStore: vi.fn((_subscribe: unknown, getSnapshot: () => unknown) => getSnapshot()),
     useSensor: vi.fn(() => null),
     useSensors: vi.fn((...sensors: unknown[]) => sensors),
     sortableKeyboardCoordinates: vi.fn(() => ({x: 999, y: 555})),
@@ -49,6 +51,8 @@ const mocks = vi.hoisted(() => ({
     tooltip: vi.fn(({children}: {children: unknown}) => children),
     cn: vi.fn((...tokens: Array<string | false | undefined>) => tokens.filter(Boolean).join(' ')),
     useValidationVisibility: vi.fn(() => 'all'),
+    getIsMobile: vi.fn(() => false),
+    subscribeToMobileChanges: vi.fn(),
     mouseSensor: class MouseSensor {},
 }));
 
@@ -58,7 +62,9 @@ vi.mock('react', () => ({
     useState: mocks.useState,
     useEffect: mocks.useEffect,
     useId: mocks.useId,
+    useLayoutEffect: mocks.useLayoutEffect,
     useRef: mocks.useRef,
+    useSyncExternalStore: mocks.useSyncExternalStore,
 }));
 
 vi.mock('@enonic/ui', () => ({
@@ -67,6 +73,8 @@ vi.mock('@enonic/ui', () => ({
     IconButton: mocks.iconButton,
     Tooltip: mocks.tooltip,
     cn: mocks.cn,
+    getIsMobile: mocks.getIsMobile,
+    subscribeToMobileChanges: mocks.subscribeToMobileChanges,
 }));
 
 vi.mock('@dnd-kit/core', () => ({
@@ -341,6 +349,70 @@ function getSuggestionButton(label: string, overrides: Partial<TagInputProps> = 
     return match.props;
 }
 
+function getTagLabelButton(overrides: Partial<TagInputProps> = {}, index = 0): Record<string, any> {
+    let currentIndex = 0;
+    const match = findElementInTree(getTagInputElement(overrides), element => {
+        if (element.type !== 'button' || element.props['data-tag-label'] !== true) {
+            return false;
+        }
+        return currentIndex++ === index;
+    });
+
+    if (match == null) {
+        throw new Error('Tag label button was not rendered');
+    }
+
+    return match.props;
+}
+
+function getTagEditorElement(overrides: Partial<TagInputProps> = {}) {
+    const match = findElementInTree(
+        getTagInputElement(overrides),
+        element => element.type === 'input' && element.props['data-tag-editor'] === true,
+    );
+
+    if (match == null) {
+        throw new Error('Tag editor was not rendered');
+    }
+
+    return match;
+}
+
+function getTagEditor(overrides: Partial<TagInputProps> = {}): Record<string, any> {
+    return getTagEditorElement(overrides).props;
+}
+
+function mockTagEditingState({
+    draft = '',
+    isInputActive = false,
+    editingId = null,
+    selectText = true,
+    editDraft = '',
+    setEditingId = vi.fn(),
+    setEditDraft = vi.fn(),
+    setIsInputActive = vi.fn(),
+}: {
+    draft?: string;
+    isInputActive?: boolean;
+    editingId?: string | null;
+    selectText?: boolean;
+    editDraft?: string;
+    setEditingId?: ReturnType<typeof vi.fn>;
+    setEditDraft?: ReturnType<typeof vi.fn>;
+    setIsInputActive?: ReturnType<typeof vi.fn>;
+} = {}): void {
+    mocks.useState
+        .mockImplementationOnce(() => [draft, vi.fn()])
+        .mockImplementationOnce(() => [isInputActive, setIsInputActive])
+        .mockImplementationOnce(() => [false, vi.fn()])
+        .mockImplementationOnce(() => [0, vi.fn()])
+        .mockImplementationOnce(() => [[], vi.fn()])
+        .mockImplementationOnce(() => [-1, vi.fn()])
+        .mockImplementationOnce(() => [false, vi.fn()])
+        .mockImplementationOnce(() => [editingId == null ? null : {id: editingId, selectText}, setEditingId])
+        .mockImplementationOnce(() => [editDraft, setEditDraft]);
+}
+
 describe('TagInput helpers', () => {
     it('trims whitespace and trailing separators from draft values', () => {
         expect(normalizeTagDraft('  alpha,  ')).toBe('alpha');
@@ -424,6 +496,7 @@ describe('TagInput', () => {
             vi.fn(),
         ]);
         mocks.useValidationVisibility.mockReturnValue('all');
+        mocks.getIsMobile.mockReturnValue(false);
     });
 
     afterEach(() => {
@@ -622,27 +695,32 @@ describe('TagInput', () => {
         expect(getFirstDragButtonProps().tabIndex).toBe(-1);
     });
 
-    it('makes the last drag handle the tab entry point when max tags hide the inline input', () => {
-        renderTagInput({
+    it('makes the last tag label the tab entry point when max tags hide the inline input', () => {
+        const props = {
             values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
             occurrences: Occurrences.minmax(0, 2),
             errors: [makeOccurrenceValidation(0), makeOccurrenceValidation(1)],
-        });
+        };
+        renderTagInput(props);
 
         expect(getIconButtonProps('field.occurrence.action.reorder', 0).tabIndex).toBe(-1);
-        expect(getIconButtonProps('field.occurrence.action.reorder', 1).tabIndex).toBe(0);
+        expect(getIconButtonProps('field.occurrence.action.reorder', 1).tabIndex).toBe(-1);
         expect(getIconButtonProps('field.occurrence.action.remove', 0).tabIndex).toBe(-1);
         expect(getIconButtonProps('field.occurrence.action.remove', 1).tabIndex).toBe(-1);
+        expect(getTagLabelButton(props).tabIndex).toBe(-1);
+        expect(getTagLabelButton(props, 1).tabIndex).toBe(0);
     });
 
-    it('makes the last remove button the tab entry point when max tags hide the inline input and dragging is unavailable', () => {
-        renderTagInput({
+    it('makes the tag label the tab entry point when max tags hide the inline input and dragging is unavailable', () => {
+        const props = {
             values: [ValueTypes.STRING.newValue('alpha')],
             occurrences: Occurrences.minmax(0, 1),
             errors: [makeOccurrenceValidation(0)],
-        });
+        };
+        renderTagInput(props);
 
-        expect(getFirstRemoveButtonProps().tabIndex).toBe(0);
+        expect(getFirstRemoveButtonProps().tabIndex).toBe(-1);
+        expect(getTagLabelButton(props).tabIndex).toBe(0);
     });
 
     it('keeps tag items themselves out of the tab order when focus is within the component', () => {
@@ -654,6 +732,257 @@ describe('TagInput', () => {
 
         expect(tagItemProps.tabIndex).toBeUndefined();
         expect(tagItemProps.onKeyDown).toBeUndefined();
+    });
+
+    it('starts editing a tag when its label is clicked', () => {
+        const setEditingIndex = vi.fn();
+        const setEditDraft = vi.fn();
+        mockTagEditingState({setEditingId: setEditingIndex, setEditDraft});
+
+        getTagLabelButton({
+            values: [ValueTypes.STRING.newValue('alpha')],
+        }).onClick();
+
+        expect(setEditingIndex).toHaveBeenCalledWith({id: 'tag-0', selectText: true});
+        expect(setEditDraft).toHaveBeenCalledWith('alpha');
+    });
+
+    it.each([
+        {key: 'Enter', draft: 'alpha', selectText: true},
+        {key: ' ', draft: 'alpha', selectText: true},
+        {key: 'z', draft: 'z', selectText: false},
+    ])('starts editing a focused tag label with "$key"', ({key, draft, selectText}) => {
+        const setEditingState = vi.fn();
+        const setEditDraft = vi.fn();
+        const preventDefault = vi.fn();
+        const stopPropagation = vi.fn();
+        mockTagEditingState({setEditingId: setEditingState, setEditDraft});
+
+        const labelButton = getTagLabelButton({values: [ValueTypes.STRING.newValue('alpha')]});
+        labelButton.onKeyDown({
+            key,
+            altKey: false,
+            ctrlKey: false,
+            metaKey: false,
+            preventDefault,
+            stopPropagation,
+        });
+
+        expect(preventDefault).toHaveBeenCalledOnce();
+        expect(stopPropagation).toHaveBeenCalledOnce();
+        expect(labelButton['aria-label']).toBe('action.edit: alpha');
+        expect(setEditingState).toHaveBeenCalledWith({id: 'tag-0', selectText});
+        expect(setEditDraft).toHaveBeenCalledWith(draft);
+    });
+
+    it('commits an edited tag with Enter', () => {
+        const onChange = vi.fn();
+        const setEditingIndex = vi.fn();
+        const setEditDraft = vi.fn();
+        const setIsInputActive = vi.fn();
+        const focusDraft = vi.fn();
+        const preventDefault = vi.fn();
+        const stopPropagation = vi.fn();
+        mocks.useRef
+            .mockImplementationOnce(() => ({current: null}))
+            .mockImplementationOnce(() => ({current: {focus: focusDraft}}));
+        mockTagEditingState({
+            editingId: 'tag-0',
+            editDraft: 'stale draft',
+            setEditingId: setEditingIndex,
+            setEditDraft,
+            setIsInputActive,
+        });
+
+        const editor = getTagEditor({
+            onChange,
+            values: [ValueTypes.STRING.newValue('alpha')],
+        });
+        editor.onKeyDown({key: 'Enter', preventDefault, stopPropagation, currentTarget: {value: 'renamed'}});
+        editor.onBlur({currentTarget: {value: 'stale draft'}});
+
+        expect(preventDefault).toHaveBeenCalledOnce();
+        expect(stopPropagation).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith(0, ValueTypes.STRING.newValue('renamed'), 'renamed');
+        expect(setEditingIndex).toHaveBeenCalledWith(null);
+        expect(setEditDraft).toHaveBeenCalledWith('');
+        expect(setIsInputActive).toHaveBeenCalledWith(true);
+        expect(focusDraft).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+        {name: 'selects existing text', draft: 'alpha', selectText: true},
+        {name: 'places caret after typed text', draft: 'z', selectText: false},
+    ])('$name when editing starts', ({draft, selectText}) => {
+        const layoutEffects: Array<() => void> = [];
+        const focus = vi.fn();
+        const select = vi.fn();
+        const setSelectionRange = vi.fn();
+        mocks.useLayoutEffect.mockImplementation((effect: () => void) => {
+            layoutEffects.push(effect);
+        });
+        mockTagEditingState({editingId: 'tag-0', editDraft: draft, selectText});
+
+        const editor = getTagEditorElement({
+            values: [ValueTypes.STRING.newValue('alpha')],
+        }) as {props: Record<string, any>; ref?: {current: unknown}};
+        if (editor.ref == null) {
+            throw new Error('Tag editor ref was not rendered');
+        }
+        editor.ref.current = {value: draft, focus, select, setSelectionRange};
+        layoutEffects.at(-1)?.();
+
+        expect(focus).toHaveBeenCalledOnce();
+        expect(select).toHaveBeenCalledTimes(selectText ? 1 : 0);
+        expect(setSelectionRange).toHaveBeenCalledTimes(selectText ? 0 : 1);
+        if (!selectText) {
+            expect(setSelectionRange).toHaveBeenCalledWith(draft.length, draft.length);
+        }
+    });
+
+    it('returns focus to the tag controls when Escape cancels editing', () => {
+        const focusTag = vi.fn();
+        const setEditingId = vi.fn();
+        const setEditDraft = vi.fn();
+        const preventDefault = vi.fn();
+        const stopPropagation = vi.fn();
+        mocks.useRef.mockImplementationOnce(() => ({
+            current: {querySelectorAll: vi.fn(() => ({item: vi.fn(() => ({focus: focusTag}))}))},
+        }));
+        mockTagEditingState({editingId: 'tag-0', editDraft: 'alpha', setEditingId, setEditDraft});
+
+        getTagEditor({values: [ValueTypes.STRING.newValue('alpha')]}).onKeyDown({
+            key: 'Escape',
+            preventDefault,
+            stopPropagation,
+        });
+
+        expect(preventDefault).toHaveBeenCalledOnce();
+        expect(stopPropagation).toHaveBeenCalledOnce();
+        expect(setEditingId).toHaveBeenCalledWith(null);
+        expect(setEditDraft).toHaveBeenCalledWith('');
+        expect(focusTag).toHaveBeenCalledOnce();
+    });
+
+    it('does not suppress blur when editing starts again after Escape', () => {
+        const layoutEffects: Array<() => void> = [];
+        const onChange = vi.fn();
+        mocks.useLayoutEffect.mockImplementation((effect: () => void) => {
+            layoutEffects.push(effect);
+        });
+        mockTagEditingState({editingId: 'tag-0', editDraft: 'alpha'});
+
+        const editor = getTagEditor({
+            onChange,
+            values: [ValueTypes.STRING.newValue('alpha')],
+        });
+        editor.onKeyDown({
+            key: 'Escape',
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+        });
+        layoutEffects.at(-1)?.();
+        editor.onBlur({currentTarget: {value: 'renamed'}});
+
+        expect(onChange).toHaveBeenCalledWith(0, ValueTypes.STRING.newValue('renamed'), 'renamed');
+    });
+
+    it('does not suppress a later blur after Enter rejects a duplicate edit', () => {
+        const onChange = vi.fn();
+        const preventDefault = vi.fn();
+        const stopPropagation = vi.fn();
+        mockTagEditingState({editingId: 'tag-1', editDraft: 'alpha'});
+
+        const editor = getTagEditor({
+            onChange,
+            values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
+        });
+        editor.onKeyDown({key: 'Enter', preventDefault, stopPropagation, currentTarget: {value: 'alpha'}});
+        editor.onBlur({currentTarget: {value: 'renamed'}});
+
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith(1, ValueTypes.STRING.newValue('renamed'), 'renamed');
+    });
+
+    it('focuses the next field after mobile Enter edits a tag at the maximum', () => {
+        const onChange = vi.fn();
+        const focusDisabled = vi.fn();
+        const focusNext = vi.fn();
+        const disabledInput = {focus: focusDisabled, disabled: true, hidden: false, tabIndex: 0};
+        const nextInput = {focus: focusNext, hidden: false, tabIndex: 0};
+        const currentInput: Record<string, any> = {
+            value: 'renamed',
+            closest: vi.fn(() => null),
+        };
+        currentInput.ownerDocument = {
+            querySelectorAll: vi.fn(() => [currentInput, disabledInput, nextInput]),
+        };
+        mocks.getIsMobile.mockReturnValue(true);
+        mockTagEditingState({editingId: 'tag-0', editDraft: 'alpha'});
+
+        const editor = getTagEditor({
+            onChange,
+            values: [ValueTypes.STRING.newValue('alpha')],
+            occurrences: Occurrences.minmax(0, 1),
+        });
+        editor.onKeyDown({
+            key: 'Enter',
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn(),
+            currentTarget: currentInput,
+        });
+
+        expect(onChange).toHaveBeenCalledWith(0, ValueTypes.STRING.newValue('renamed'), 'renamed');
+        expect(focusDisabled).not.toHaveBeenCalled();
+        expect(focusNext).toHaveBeenCalledOnce();
+    });
+
+    it('removes an empty edited tag and starts editing the previous tag on Backspace', () => {
+        const onRemove = vi.fn();
+        const setEditingId = vi.fn();
+        const setEditDraft = vi.fn();
+        const preventDefault = vi.fn();
+        const stopPropagation = vi.fn();
+        mockTagEditingState({editingId: 'tag-1', setEditingId, setEditDraft});
+
+        const editor = getTagEditor({
+            onRemove,
+            values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
+        });
+        editor.onKeyDown({key: 'Backspace', preventDefault, stopPropagation, currentTarget: {value: ''}});
+        editor.onBlur({currentTarget: {value: ''}});
+
+        expect(preventDefault).toHaveBeenCalledOnce();
+        expect(stopPropagation).toHaveBeenCalledOnce();
+        expect(onRemove).toHaveBeenCalledOnce();
+        expect(onRemove).toHaveBeenCalledWith(1);
+        expect(setEditingId).toHaveBeenCalledWith({id: 'tag-0', selectText: true});
+        expect(setEditDraft).toHaveBeenCalledWith('alpha');
+    });
+
+    it('removes an edited tag when its empty editor loses focus', () => {
+        const onChange = vi.fn();
+        const onRemove = vi.fn();
+        const setEditingId = vi.fn();
+        const setEditDraft = vi.fn();
+        mockTagEditingState({
+            editingId: 'tag-0',
+            editDraft: 'previous value',
+            setEditingId,
+            setEditDraft,
+        });
+
+        const editor = getTagEditor({
+            onChange,
+            onRemove,
+            values: [ValueTypes.STRING.newValue('previous value')],
+        });
+        editor.onBlur({currentTarget: {value: ''}});
+
+        expect(onRemove).toHaveBeenCalledWith(0);
+        expect(onChange).not.toHaveBeenCalled();
+        expect(setEditingId).toHaveBeenCalledWith(null);
+        expect(setEditDraft).toHaveBeenCalledWith('');
     });
 
     it('keeps tag removal available when the current count matches the minimum occurrences', () => {
@@ -930,6 +1259,67 @@ describe('TagInput', () => {
         expect(focus).toHaveBeenCalledOnce();
     });
 
+    it.each([
+        {
+            name: 'focuses next field at maximum',
+            values: ['one', 'two', 'three', 'four'],
+            maximum: 5,
+            focusesNext: true,
+        },
+        {name: 'keeps focus while another tag fits', values: ['one'], maximum: 3, focusesNext: false},
+    ])('mobile Enter $name', ({values, maximum, focusesNext}) => {
+        const onAdd = vi.fn();
+        const focusCurrent = vi.fn();
+        const focusNext = vi.fn();
+        const stopPropagation = vi.fn();
+        const nextInput = {focus: focusNext, hidden: false, tabIndex: 0};
+        const currentInput: Record<string, any> = {
+            focus: focusCurrent,
+            closest: vi.fn(() => null),
+        };
+        currentInput.ownerDocument = {
+            querySelectorAll: vi.fn(() => [currentInput, nextInput]),
+        };
+        mocks.getIsMobile.mockReturnValue(true);
+        mocks.useState.mockImplementationOnce(() => ['new', vi.fn()]).mockImplementationOnce(() => [true, vi.fn()]);
+
+        renderTagInput({
+            onAdd,
+            values: values.map(value => ValueTypes.STRING.newValue(value)),
+            occurrences: Occurrences.minmax(0, maximum),
+        });
+
+        getLastInputProps().onKeyDown({
+            key: 'Enter',
+            altKey: false,
+            ctrlKey: false,
+            metaKey: false,
+            preventDefault: vi.fn(),
+            stopPropagation,
+            currentTarget: currentInput,
+        });
+
+        expect(onAdd).toHaveBeenCalledWith(ValueTypes.STRING.newValue('new'));
+        expect(stopPropagation).toHaveBeenCalledOnce();
+        expect(focusCurrent).toHaveBeenCalledTimes(focusesNext ? 0 : 1);
+        expect(focusNext).toHaveBeenCalledTimes(focusesNext ? 1 : 0);
+    });
+
+    it('uses mobile keyboard action hints without changing the desktop input', () => {
+        for (const {mobile, maximum, expected} of [
+            {mobile: true, maximum: 2, expected: 'next'},
+            {mobile: true, maximum: 3, expected: 'enter'},
+            {mobile: false, maximum: 2, expected: undefined},
+        ]) {
+            mocks.getIsMobile.mockReturnValue(mobile);
+            renderTagInput({
+                values: [ValueTypes.STRING.newValue('alpha')],
+                occurrences: Occurrences.minmax(0, maximum),
+            });
+            expect(getLastInputProps().enterKeyHint).toBe(expected);
+        }
+    });
+
     it('creates one tag per pasted spreadsheet cell', () => {
         const onAdd = vi.fn();
         const preventDefault = vi.fn();
@@ -1152,13 +1542,17 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => [[], vi.fn()])
             .mockImplementationOnce(() => [-1, vi.fn()])
             .mockImplementationOnce(() => [false, vi.fn()])
+            .mockImplementationOnce(() => [null, vi.fn()])
+            .mockImplementationOnce(() => ['', vi.fn()])
             .mockImplementationOnce(() => ['beta', vi.fn()])
             .mockImplementationOnce(() => [true, vi.fn()])
             .mockImplementationOnce(() => [false, vi.fn()])
             .mockImplementationOnce(() => [0, vi.fn()])
             .mockImplementationOnce(() => [[], vi.fn()])
             .mockImplementationOnce(() => [-1, vi.fn()])
-            .mockImplementationOnce(() => [false, vi.fn()]);
+            .mockImplementationOnce(() => [false, vi.fn()])
+            .mockImplementationOnce(() => [null, vi.fn()])
+            .mockImplementationOnce(() => ['', vi.fn()]);
 
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
@@ -1551,11 +1945,13 @@ describe('TagInput', () => {
         expect(setIsInputActive).toHaveBeenCalledWith(false);
     });
 
-    it('closes an empty draft input and moves focus to the previous tag on Backspace', () => {
+    it('starts editing the last tag from an empty draft on Backspace', () => {
         const onRemove = vi.fn();
         const blur = vi.fn();
         const focusPreviousTag = vi.fn();
         const setIsInputActive = vi.fn();
+        const setEditingIndex = vi.fn();
+        const setEditDraft = vi.fn();
         const wrapperRef = {current: null};
         const inputRef = {current: null};
         const tagRefs = {current: [{focus: vi.fn()}, {focus: vi.fn()}]};
@@ -1567,9 +1963,7 @@ describe('TagInput', () => {
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
 
-        mocks.useState
-            .mockImplementationOnce(() => ['', vi.fn()])
-            .mockImplementationOnce(() => [true, setIsInputActive]);
+        mockTagEditingState({isInputActive: true, setEditingId: setEditingIndex, setEditDraft, setIsInputActive});
         mocks.useRef
             .mockImplementationOnce(() => wrapperRef)
             .mockImplementationOnce(() => inputRef)
@@ -1600,7 +1994,9 @@ describe('TagInput', () => {
 
         expect(onRemove).not.toHaveBeenCalled();
         expect(blur).toHaveBeenCalledOnce();
-        expect(focusPreviousTag).toHaveBeenCalledOnce();
+        expect(focusPreviousTag).not.toHaveBeenCalled();
+        expect(setEditingIndex).toHaveBeenCalledWith({id: 'tag-1', selectText: true});
+        expect(setEditDraft).toHaveBeenCalledWith('beta');
         expect(setIsInputActive).toHaveBeenCalledWith(false);
     });
 
@@ -1708,6 +2104,24 @@ describe('TagInput', () => {
         expect(blur).toHaveBeenCalledOnce();
         expect(focusPreviousTag).toHaveBeenCalledOnce();
         expect(setIsInputActive).toHaveBeenCalledWith(false);
+    });
+
+    it('moves focus from an empty draft to the last tag label on ArrowLeft', () => {
+        const focusLabel = vi.fn();
+        const blur = vi.fn();
+        mocks.useRef.mockImplementationOnce(() => ({
+            current: {querySelectorAll: vi.fn(() => ({item: vi.fn(() => ({focus: focusLabel}))}))},
+        }));
+
+        renderTagInput({values: [ValueTypes.STRING.newValue('alpha')]});
+        getLastInputProps().onKeyDown({
+            key: 'ArrowLeft',
+            preventDefault: vi.fn(),
+            currentTarget: {blur, value: '', selectionStart: 0, selectionEnd: 0},
+        });
+
+        expect(blur).toHaveBeenCalledOnce();
+        expect(focusLabel).toHaveBeenCalledOnce();
     });
 
     it('removes the focused tag when the remove button handles a keyboard activation', () => {
@@ -2016,6 +2430,7 @@ describe('TagInput', () => {
             ctrlKey: false,
             metaKey: false,
             preventDefault,
+            currentTarget: {closest: vi.fn(() => null)},
         });
 
         expect(preventDefault).toHaveBeenCalledOnce();
@@ -2069,127 +2484,38 @@ describe('TagInput', () => {
         expect(sortableKeyDown).not.toHaveBeenCalled();
     });
 
-    it('moves focus from drag button to remove button on ArrowRight', () => {
-        const focus = vi.fn();
-        const wrapperRef = {current: null};
-        const inputRef = {current: null};
-        const tagRefs = {current: []};
-        const removeTagRefs = {current: []};
-        const draftRef = {current: ''};
-        const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
-        const scrollListenerCleanupRef = {current: null};
-        const isDraggingRef = {current: false};
-        const dragButtonRef = {current: null};
-        const removeButtonRef = {current: {focus}};
-
-        mocks.useRef
-            .mockImplementationOnce(() => wrapperRef)
-            .mockImplementationOnce(() => inputRef)
-            .mockImplementationOnce(() => tagRefs)
-            .mockImplementationOnce(() => removeTagRefs)
-            .mockImplementationOnce(() => draftRef)
-            .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef)
-            .mockImplementationOnce(() => dragButtonRef)
-            .mockImplementationOnce(() => removeButtonRef);
-
-        renderTagInput({
+    it('navigates drag, label, and remove controls with arrow keys', () => {
+        const props = {
             values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
             occurrences: Occurrences.minmax(0, 3),
-            errors: [makeOccurrenceValidation(0), makeOccurrenceValidation(1)],
-        });
+        };
+        renderTagInput(props);
 
-        const preventDefault = vi.fn();
-        getFirstDragButtonProps().onKeyDown({
-            key: 'ArrowRight',
-            shiftKey: false,
-            altKey: false,
-            ctrlKey: false,
-            metaKey: false,
-            preventDefault,
-        });
+        const navigate = (handler: (event: Record<string, any>) => void, key: string) => {
+            const focus = vi.fn();
+            const preventDefault = vi.fn();
+            handler({
+                key,
+                altKey: false,
+                ctrlKey: false,
+                metaKey: false,
+                preventDefault,
+                currentTarget: {closest: vi.fn(() => ({querySelector: vi.fn(() => ({focus}))}))},
+            });
+            expect(preventDefault).toHaveBeenCalledOnce();
+            expect(focus).toHaveBeenCalledOnce();
+        };
 
-        expect(preventDefault).toHaveBeenCalledOnce();
-        expect(focus).toHaveBeenCalledOnce();
-    });
-
-    it('moves focus from remove button to drag button on ArrowLeft', () => {
-        const focus = vi.fn();
-        const wrapperRef = {current: null};
-        const inputRef = {current: null};
-        const tagRefs = {current: []};
-        const removeTagRefs = {current: []};
-        const draftRef = {current: ''};
-        const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
-        const scrollListenerCleanupRef = {current: null};
-        const isDraggingRef = {current: false};
-        const dragButtonRef = {current: {focus}};
-        const removeButtonRef = {current: null};
-
-        mocks.useRef
-            .mockImplementationOnce(() => wrapperRef)
-            .mockImplementationOnce(() => inputRef)
-            .mockImplementationOnce(() => tagRefs)
-            .mockImplementationOnce(() => removeTagRefs)
-            .mockImplementationOnce(() => draftRef)
-            .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef)
-            .mockImplementationOnce(() => dragButtonRef)
-            .mockImplementationOnce(() => removeButtonRef);
-
-        renderTagInput({
-            values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
-            occurrences: Occurrences.minmax(0, 3),
-            errors: [makeOccurrenceValidation(0), makeOccurrenceValidation(1)],
-        });
-
-        const preventDefault = vi.fn();
-        getFirstRemoveButtonProps().onKeyDown({
-            key: 'ArrowLeft',
-            altKey: false,
-            ctrlKey: false,
-            metaKey: false,
-            preventDefault,
-        });
-
-        expect(preventDefault).toHaveBeenCalledOnce();
-        expect(focus).toHaveBeenCalledOnce();
+        navigate(getFirstDragButtonProps().onKeyDown, 'ArrowRight');
+        navigate(getTagLabelButton(props).onKeyDown, 'ArrowRight');
+        navigate(getFirstRemoveButtonProps().onKeyDown, 'ArrowLeft');
     });
 
     it('navigates to the next tag on ArrowRight from remove button', () => {
         const focusNextTag = vi.fn();
-        const wrapperRef = {current: null};
-        const inputRef = {current: null};
-        const tagRefs = {current: [null, {focus: focusNextTag}]};
-        const removeTagRefs = {current: []};
-        const draftRef = {current: ''};
-        const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
-        const scrollListenerCleanupRef = {current: null};
-        const isDraggingRef = {current: false};
-
-        mocks.useRef
-            .mockImplementationOnce(() => wrapperRef)
-            .mockImplementationOnce(() => inputRef)
-            .mockImplementationOnce(() => tagRefs)
-            .mockImplementationOnce(() => removeTagRefs)
-            .mockImplementationOnce(() => draftRef)
-            .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef);
+        mocks.useRef.mockImplementationOnce(() => ({
+            current: {querySelectorAll: vi.fn(() => ({item: vi.fn(() => ({focus: focusNextTag}))}))},
+        }));
 
         renderTagInput({
             values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
@@ -2213,6 +2539,11 @@ describe('TagInput', () => {
     it('reorders immediately with left and right arrow keys during keyboard drag', () => {
         const sortableKeyDown = vi.fn();
         const onMove = vi.fn();
+        const focusMovedDragHandle = vi.fn();
+        mocks.useRef
+            .mockImplementationOnce(() => ({current: null}))
+            .mockImplementationOnce(() => ({current: null}))
+            .mockImplementationOnce(() => ({current: [null, {focus: focusMovedDragHandle}]}));
         mocks.useSortable.mockImplementation(() => ({
             attributes: {tabIndex: 0, 'aria-pressed': 'true'},
             listeners: {onKeyDown: sortableKeyDown},
@@ -2241,6 +2572,7 @@ describe('TagInput', () => {
 
         expect(preventDefault).toHaveBeenCalledOnce();
         expect(onMove).toHaveBeenCalledWith(0, 1);
+        expect(focusMovedDragHandle).toHaveBeenCalledOnce();
         expect(sortableKeyDown).not.toHaveBeenCalled();
     });
 

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.test.ts
@@ -121,6 +121,33 @@ function makeOccurrenceValidation(index: number, message?: string): OccurrenceVa
     };
 }
 
+function makeFocusableElement(
+    ownerDocument: Record<string, any>,
+    {
+        disabled = false,
+        hiddenAncestor = false,
+        rendered = true,
+    }: {
+        disabled?: boolean;
+        hiddenAncestor?: boolean;
+        rendered?: boolean;
+    } = {},
+): {element: Record<string, any>; focus: ReturnType<typeof vi.fn>} {
+    const element: Record<string, any> = {
+        ownerDocument,
+        isConnected: true,
+        tabIndex: 0,
+        matches: vi.fn((selector: string) => selector === ':disabled' && disabled),
+        closest: vi.fn((selector: string) => (selector === '[hidden], [inert]' && hiddenAncestor ? {} : null)),
+        getClientRects: vi.fn(() => (rendered ? [{}] : [])),
+    };
+    const focus = vi.fn(() => {
+        ownerDocument.activeElement = element;
+    });
+    element.focus = focus;
+    return {element, focus};
+}
+
 function makeHiddenBlankValidation(
     index: number,
     message?: string,
@@ -140,6 +167,7 @@ function makeProps(overrides: Partial<TagInputProps> = {}): TagInputProps {
     const input = overrides.input ?? makeInput(0, 3);
 
     return {
+        occurrenceIds: values.map((_, index) => `tag-${index}`),
         values,
         onChange: vi.fn(),
         onAdd: vi.fn(),
@@ -810,6 +838,33 @@ describe('TagInput', () => {
         expect(focusDraft).toHaveBeenCalledOnce();
     });
 
+    it('gives the inline editor an accessible name', () => {
+        mockTagEditingState({editingId: 'tag-0', editDraft: 'alpha'});
+
+        expect(
+            getTagEditor({
+                values: [ValueTypes.STRING.newValue('alpha')],
+            })['aria-label'],
+        ).toBe('action.edit: alpha');
+    });
+
+    it('keeps editing when a value instance is replaced under the same occurrence id', () => {
+        const props = {
+            occurrenceIds: ['stable-occurrence'],
+            values: [ValueTypes.STRING.newValue('alpha')],
+        };
+        mockTagEditingState({editingId: 'stable-occurrence', editDraft: 'draft'});
+        expect(getTagEditor(props).value).toBe('draft');
+
+        mockTagEditingState({editingId: 'stable-occurrence', editDraft: 'draft'});
+        expect(
+            getTagEditor({
+                ...props,
+                values: [ValueTypes.STRING.newValue('alpha')],
+            }).value,
+        ).toBe('draft');
+    });
+
     it.each([
         {name: 'selects existing text', draft: 'alpha', selectText: true},
         {name: 'places caret after typed text', draft: 'z', selectText: false},
@@ -906,17 +961,20 @@ describe('TagInput', () => {
 
     it('focuses the next field after mobile Enter edits a tag at the maximum', () => {
         const onChange = vi.fn();
-        const focusDisabled = vi.fn();
-        const focusNext = vi.fn();
-        const disabledInput = {focus: focusDisabled, disabled: true, hidden: false, tabIndex: 0};
-        const nextInput = {focus: focusNext, hidden: false, tabIndex: 0};
-        const currentInput: Record<string, any> = {
-            value: 'renamed',
-            closest: vi.fn(() => null),
+        const ownerDocument: Record<string, any> = {
+            activeElement: null,
+            defaultView: {
+                getComputedStyle: vi.fn(() => ({display: 'block', visibility: 'visible'})),
+            },
         };
-        currentInput.ownerDocument = {
-            querySelectorAll: vi.fn(() => [currentInput, disabledInput, nextInput]),
-        };
+        const {element: currentInput} = makeFocusableElement(ownerDocument);
+        const {element: hiddenInput, focus: focusHidden} = makeFocusableElement(ownerDocument, {
+            hiddenAncestor: true,
+        });
+        const {element: disabledInput, focus: focusDisabled} = makeFocusableElement(ownerDocument, {disabled: true});
+        const {element: nextInput, focus: focusNext} = makeFocusableElement(ownerDocument);
+        currentInput.value = 'renamed';
+        ownerDocument.querySelectorAll = vi.fn(() => [currentInput, hiddenInput, disabledInput, nextInput]);
         mocks.getIsMobile.mockReturnValue(true);
         mockTagEditingState({editingId: 'tag-0', editDraft: 'alpha'});
 
@@ -933,6 +991,7 @@ describe('TagInput', () => {
         });
 
         expect(onChange).toHaveBeenCalledWith(0, ValueTypes.STRING.newValue('renamed'), 'renamed');
+        expect(focusHidden).not.toHaveBeenCalled();
         expect(focusDisabled).not.toHaveBeenCalled();
         expect(focusNext).toHaveBeenCalledOnce();
     });
@@ -1269,17 +1328,16 @@ describe('TagInput', () => {
         {name: 'keeps focus while another tag fits', values: ['one'], maximum: 3, focusesNext: false},
     ])('mobile Enter $name', ({values, maximum, focusesNext}) => {
         const onAdd = vi.fn();
-        const focusCurrent = vi.fn();
-        const focusNext = vi.fn();
         const stopPropagation = vi.fn();
-        const nextInput = {focus: focusNext, hidden: false, tabIndex: 0};
-        const currentInput: Record<string, any> = {
-            focus: focusCurrent,
-            closest: vi.fn(() => null),
+        const ownerDocument: Record<string, any> = {
+            activeElement: null,
+            defaultView: {
+                getComputedStyle: vi.fn(() => ({display: 'block', visibility: 'visible'})),
+            },
         };
-        currentInput.ownerDocument = {
-            querySelectorAll: vi.fn(() => [currentInput, nextInput]),
-        };
+        const {element: currentInput, focus: focusCurrent} = makeFocusableElement(ownerDocument);
+        const {element: nextInput, focus: focusNext} = makeFocusableElement(ownerDocument);
+        ownerDocument.querySelectorAll = vi.fn(() => [currentInput, nextInput]);
         mocks.getIsMobile.mockReturnValue(true);
         mocks.useState.mockImplementationOnce(() => ['new', vi.fn()]).mockImplementationOnce(() => [true, vi.fn()]);
 
@@ -1531,9 +1589,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: []};
         const draftRef = {current: ''};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
-
         mocks.useState
             .mockImplementationOnce(() => ['alpha', vi.fn()])
             .mockImplementationOnce(() => [true, vi.fn()])
@@ -1563,20 +1618,16 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
             .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
             .mockImplementationOnce(() => isDraggingRef)
+            .mockImplementationOnce(() => scrollListenerCleanupRef)
             .mockImplementationOnce(() => wrapperRef)
             .mockImplementationOnce(() => inputRef)
             .mockImplementationOnce(() => tagRefs)
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
             .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef);
+            .mockImplementationOnce(() => isDraggingRef)
+            .mockImplementationOnce(() => scrollListenerCleanupRef);
 
         renderTagInput({onAdd, values: [], errors: []});
         getLastInputProps().onKeyDown({
@@ -1897,8 +1948,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: []};
         const draftRef = {current: 'gamma'};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
         const setIsInputActive = vi.fn();
@@ -1913,10 +1962,8 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
             .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef);
+            .mockImplementationOnce(() => isDraggingRef)
+            .mockImplementationOnce(() => scrollListenerCleanupRef);
 
         renderTagInput({
             onAdd,
@@ -1958,8 +2005,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: [{focus: vi.fn()}, {focus: focusPreviousTag}]};
         const draftRef = {current: ''};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
 
@@ -1971,10 +2016,8 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
             .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef);
+            .mockImplementationOnce(() => isDraggingRef)
+            .mockImplementationOnce(() => scrollListenerCleanupRef);
 
         renderTagInput({
             onRemove,
@@ -2011,8 +2054,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: [{focus: vi.fn()}, {focus: focusPreviousTag}]};
         const draftRef = {current: 'gamma'};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
 
@@ -2026,10 +2067,8 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
             .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef);
+            .mockImplementationOnce(() => isDraggingRef)
+            .mockImplementationOnce(() => scrollListenerCleanupRef);
 
         renderTagInput({
             onAdd,
@@ -2063,8 +2102,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: [{focus: focusPreviousTag}]};
         const draftRef = {current: 'beta'};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
         const scrollListenerCleanupRef = {current: null};
         const isDraggingRef = {current: false};
 
@@ -2078,10 +2115,8 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
             .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId)
-            .mockImplementationOnce(() => scrollListenerCleanupRef)
-            .mockImplementationOnce(() => isDraggingRef);
+            .mockImplementationOnce(() => isDraggingRef)
+            .mockImplementationOnce(() => scrollListenerCleanupRef);
 
         renderTagInput({
             onAdd,
@@ -2159,9 +2194,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: []};
         const draftRef = {current: ''};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
-
         mocks.useState
             .mockImplementationOnce(() => ['', vi.fn()])
             .mockImplementationOnce(() => [false, setIsInputActive]);
@@ -2171,9 +2203,7 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => tagRefs)
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
-            .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId);
+            .mockImplementationOnce(() => skipBlurCommit);
 
         renderTagInput({
             onRemove,
@@ -2284,9 +2314,6 @@ describe('TagInput', () => {
         const removeTagRefs = {current: []};
         const draftRef = {current: ''};
         const skipBlurCommit = {current: false};
-        const idsByValue = {current: new WeakMap()};
-        const nextId = {current: 0};
-
         mocks.useState
             .mockImplementationOnce(() => ['gamma', setDraft])
             .mockImplementationOnce(() => [true, setIsInputActive])
@@ -2297,9 +2324,7 @@ describe('TagInput', () => {
             .mockImplementationOnce(() => tagRefs)
             .mockImplementationOnce(() => removeTagRefs)
             .mockImplementationOnce(() => draftRef)
-            .mockImplementationOnce(() => skipBlurCommit)
-            .mockImplementationOnce(() => idsByValue)
-            .mockImplementationOnce(() => nextId);
+            .mockImplementationOnce(() => skipBlurCommit);
 
         renderTagInput({
             onAdd,
@@ -2511,11 +2536,12 @@ describe('TagInput', () => {
         navigate(getFirstRemoveButtonProps().onKeyDown, 'ArrowLeft');
     });
 
-    it('navigates to the next tag on ArrowRight from remove button', () => {
-        const focusNextTag = vi.fn();
-        mocks.useRef.mockImplementationOnce(() => ({
-            current: {querySelectorAll: vi.fn(() => ({item: vi.fn(() => ({focus: focusNextTag}))}))},
-        }));
+    it("navigates to the next tag's drag handle on ArrowRight from remove button", () => {
+        const focusNextDragHandle = vi.fn();
+        mocks.useRef
+            .mockImplementationOnce(() => ({current: null}))
+            .mockImplementationOnce(() => ({current: null}))
+            .mockImplementationOnce(() => ({current: [null, {focus: focusNextDragHandle}]}));
 
         renderTagInput({
             values: [ValueTypes.STRING.newValue('alpha'), ValueTypes.STRING.newValue('beta')],
@@ -2533,7 +2559,7 @@ describe('TagInput', () => {
         });
 
         expect(preventDefault).toHaveBeenCalledOnce();
-        expect(focusNextTag).toHaveBeenCalledOnce();
+        expect(focusNextDragHandle).toHaveBeenCalledOnce();
     });
 
     it('reorders immediately with left and right arrow keys during keyboard drag', () => {

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
@@ -10,9 +10,19 @@ import {
     useSensors,
 } from '@dnd-kit/core';
 import {rectSortingStrategy, SortableContext, sortableKeyboardCoordinates, useSortable} from '@dnd-kit/sortable';
-import {cn, IconButton, Input, Tooltip} from '@enonic/ui';
+import {cn, getIsMobile, IconButton, Input, subscribeToMobileChanges, Tooltip} from '@enonic/ui';
 import {GripVertical, X} from 'lucide-react';
-import {type JSX, type ReactElement, type RefObject, useEffect, useId, useRef, useState} from 'react';
+import {
+    type JSX,
+    type ReactElement,
+    type RefObject,
+    useEffect,
+    useId,
+    useLayoutEffect,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from 'react';
 
 import type {Value} from '../../../data/Value';
 import {ValueTypes} from '../../../data/ValueTypes';
@@ -63,6 +73,10 @@ type TagItemProps = {
     label: string;
     error?: string;
     enabled: boolean;
+    editing: boolean;
+    editDraft: string;
+    editInvalid: boolean;
+    selectEditText: boolean;
     isTabStop: boolean;
     showDrag: boolean;
     showRemove: boolean;
@@ -71,6 +85,11 @@ type TagItemProps = {
     onNavigate: (direction: -1 | 1) => void;
     onDragMove: (direction: -1 | 1) => void;
     onDeleteKey: () => void;
+    onEditStart: (initialDraft?: string, selectText?: boolean) => void;
+    onEditChange: (value: string) => void;
+    onEditCommit: (rawDraft: string, explicit?: boolean, focusTarget?: HTMLInputElement) => boolean;
+    onEditCancel: () => void;
+    onEditRemovePrevious: () => void;
     onRemovePointerDown: () => void;
     onRemoveKey: () => void;
     onRemove: () => void;
@@ -91,6 +110,7 @@ type TagViewState = {
 type TagDraftInputProps = {
     draft: string;
     accessibleName: string;
+    enterKeyHint?: 'enter' | 'next';
     enabled: boolean;
     invalid: boolean;
     visible: boolean;
@@ -145,6 +165,11 @@ type TagEntry = {
     value: Value;
     originalIndex: number;
     id: string;
+};
+
+type EditingState = {
+    id: string;
+    selectText: boolean;
 };
 
 type DragScrollListener = {
@@ -280,6 +305,29 @@ function focusElementNextFrame(element: HTMLElement | null | undefined): void {
     requestAnimationFrame(() => element?.focus());
 }
 
+function getNextFocusableElement(element: HTMLElement): HTMLElement | undefined {
+    const container = element.closest('[data-component="TagInput"]');
+    const focusableElements = Array.from(
+        element.ownerDocument.querySelectorAll<HTMLElement>(
+            'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])',
+        ),
+    );
+    const currentIndex = focusableElements.indexOf(element);
+    if (currentIndex < 0) {
+        return undefined;
+    }
+
+    return focusableElements
+        .slice(currentIndex + 1)
+        .find(
+            candidate =>
+                !container?.contains(candidate) &&
+                candidate.tabIndex >= 0 &&
+                !candidate.hidden &&
+                !('disabled' in candidate && candidate.disabled === true),
+        );
+}
+
 function clearCleanupRef(cleanupRef: RefObject<(() => void) | null>): void {
     cleanupRef.current?.();
     cleanupRef.current = null;
@@ -340,6 +388,7 @@ function getCompactedTagIndex(values: Value[], index: number): number {
 function renderTagDraftInput({
     draft,
     accessibleName,
+    enterKeyHint,
     enabled,
     invalid,
     visible,
@@ -365,6 +414,7 @@ function renderTagDraftInput({
             <Input
                 ref={inputRef}
                 aria-label={accessibleName}
+                enterKeyHint={enterKeyHint}
                 className={cn(
                     '[&_input]:px-2.5 [&_input]:text-sm',
                     '[&>div[data-state]]:h-7 [&>div[data-state]]:border-transparent! [&>div[data-state]]::text-sm',
@@ -398,6 +448,10 @@ const TagItem = ({
     label,
     error,
     enabled,
+    editing,
+    editDraft,
+    editInvalid,
+    selectEditText,
     isTabStop,
     showDrag,
     showRemove,
@@ -406,6 +460,11 @@ const TagItem = ({
     onNavigate,
     onDragMove,
     onDeleteKey,
+    onEditStart,
+    onEditChange,
+    onEditCommit,
+    onEditCancel,
+    onEditRemovePrevious,
     onRemovePointerDown,
     onRemoveKey,
     onRemove,
@@ -413,20 +472,29 @@ const TagItem = ({
     const t = useI18n();
     const visibleLabel = getVisibleTagLabel(label);
     const tooltipValue = isTagLabelCropped(label) ? label : undefined;
-    const dragButtonRef = useRef<HTMLButtonElement | null>(null);
-    const removeButtonRef = useRef<HTMLButtonElement | null>(null);
+    const editInputRef = useRef<HTMLInputElement | null>(null);
+    const skipEditBlur = useRef(false);
     const {attributes, listeners, setNodeRef, transform, transition, isDragging} = useSortable({
         id,
-        disabled: !showDrag,
+        disabled: !showDrag || editing,
     });
     const isKeyboardDragging = isKeyboardDragPressed(attributes['aria-pressed']);
+
+    useLayoutEffect(() => {
+        if (editing) {
+            skipEditBlur.current = false;
+            editInputRef.current?.focus();
+            if (selectEditText) {
+                editInputRef.current?.select();
+            } else {
+                const draftLength = editInputRef.current?.value.length ?? 0;
+                editInputRef.current?.setSelectionRange(draftLength, draftLength);
+            }
+        }
+    }, [editing, selectEditText]);
+
     const setRefs = (node: HTMLLIElement | null) => setNodeRef(node);
-    const setDragButtonRef = (node: HTMLButtonElement | null) => {
-        dragButtonRef.current = node;
-        registerFocusableRef(node);
-    };
     const setRemoveButtonRef = (node: HTMLButtonElement | null) => {
-        removeButtonRef.current = node;
         registerRemoveRef(node);
         if (!showDrag) {
             registerFocusableRef(node);
@@ -449,7 +517,7 @@ const TagItem = ({
     const dragAccessibilityProps = showDrag
         ? {
               role: attributes.role as preact.JSX.AriaRole,
-              tabIndex: enabled && isTabStop ? (attributes.tabIndex ?? 0) : -1,
+              tabIndex: -1,
               'aria-disabled': attributes['aria-disabled'],
               'aria-pressed': attributes['aria-pressed'],
               'aria-roledescription': attributes['aria-roledescription'],
@@ -504,11 +572,7 @@ const TagItem = ({
 
         if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
             event.preventDefault();
-            if (showRemove && removeButtonRef.current != null) {
-                removeButtonRef.current.focus();
-            } else {
-                onNavigate(1);
-            }
+            event.currentTarget.closest('li')?.querySelector<HTMLButtonElement>('[data-tag-label]')?.focus();
             return;
         }
 
@@ -520,6 +584,52 @@ const TagItem = ({
 
         if (event.key === ' ' || event.key === 'Enter') {
             (listeners?.onKeyDown as preact.JSX.KeyboardEventHandler<HTMLButtonElement>)?.(event);
+        }
+    };
+
+    const handleLabelButtonKeyDown: preact.JSX.KeyboardEventHandler<HTMLButtonElement> = event => {
+        if (event.altKey || event.ctrlKey || event.metaKey) {
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            event.currentTarget.blur();
+            return;
+        }
+
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            const dragButton = event.currentTarget.closest('li')?.querySelector<HTMLButtonElement>('[data-tag-drag]');
+            if (dragButton != null) {
+                dragButton.focus();
+            } else {
+                onNavigate(-1);
+            }
+            return;
+        }
+
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+            event.preventDefault();
+            const removeButton = event.currentTarget
+                .closest('li')
+                ?.querySelector<HTMLButtonElement>('[data-tag-remove]');
+            if (removeButton != null) {
+                removeButton.focus();
+            } else {
+                onNavigate(1);
+            }
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+            onEditStart();
+        } else if (event.key.length === 1) {
+            event.preventDefault();
+            event.stopPropagation();
+            onEditStart(event.key, false);
         }
     };
 
@@ -536,11 +646,7 @@ const TagItem = ({
 
         if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
             event.preventDefault();
-            if (showDrag && dragButtonRef.current != null) {
-                dragButtonRef.current.focus();
-            } else {
-                onNavigate(-1);
-            }
+            event.currentTarget.closest('li')?.querySelector<HTMLButtonElement>('[data-tag-label]')?.focus();
             return;
         }
 
@@ -557,6 +663,32 @@ const TagItem = ({
         event.preventDefault();
         event.stopPropagation();
         onRemoveKey();
+    };
+
+    const handleEditKeyDown: preact.JSX.KeyboardEventHandler<HTMLInputElement> = event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            skipEditBlur.current = onEditCommit(event.currentTarget.value, true, event.currentTarget);
+        } else if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopPropagation();
+            skipEditBlur.current = true;
+            onEditCancel();
+        } else if (event.key === 'Backspace' && event.currentTarget.value.length === 0) {
+            event.preventDefault();
+            event.stopPropagation();
+            skipEditBlur.current = true;
+            onEditRemovePrevious();
+        }
+    };
+
+    const handleEditBlur: preact.JSX.FocusEventHandler<HTMLInputElement> = event => {
+        if (skipEditBlur.current) {
+            skipEditBlur.current = false;
+            return;
+        }
+        onEditCommit(event.currentTarget.value);
     };
 
     return (
@@ -579,9 +711,10 @@ const TagItem = ({
                 !enabled && 'cursor-default border-bdr-subtle',
             )}
         >
-            {showDrag && (
+            {showDrag && !editing && (
                 <IconButton
-                    ref={setDragButtonRef}
+                    ref={registerFocusableRef}
+                    data-tag-drag
                     icon={GripVertical}
                     iconSize='sm'
                     variant='text'
@@ -597,17 +730,43 @@ const TagItem = ({
                     {...dragAccessibilityProps}
                 />
             )}
-            <Tooltip value={tooltipValue} side='top' className='max-w-64 whitespace-normal break-words'>
-                <span className='font-semibold'>{visibleLabel}</span>
-            </Tooltip>
-            {showRemove && (
+            {editing ? (
+                <input
+                    ref={editInputRef}
+                    data-tag-editor
+                    className={cn('h-5 w-36 bg-transparent font-semibold outline-none', editInvalid && 'text-error')}
+                    value={editDraft}
+                    disabled={!enabled}
+                    aria-invalid={editInvalid || undefined}
+                    onChange={event => onEditChange(event.currentTarget.value)}
+                    onKeyDown={handleEditKeyDown}
+                    onBlur={handleEditBlur}
+                />
+            ) : (
+                <Tooltip value={tooltipValue} side='top' className='max-w-64 whitespace-normal break-words'>
+                    <button
+                        data-tag-label
+                        type='button'
+                        className='font-semibold outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
+                        tabIndex={enabled && isTabStop ? 0 : -1}
+                        disabled={!enabled}
+                        aria-label={`${t('action.edit')}: ${label}`}
+                        onKeyDown={handleLabelButtonKeyDown}
+                        onClick={() => onEditStart()}
+                    >
+                        {visibleLabel}
+                    </button>
+                </Tooltip>
+            )}
+            {showRemove && !editing && (
                 <IconButton
                     ref={setRemoveButtonRef}
+                    data-tag-remove
                     icon={X}
                     iconSize='sm'
                     variant='text'
                     className='size-5 focus-visible:ring-2 focus-visible:ring-offset-2'
-                    tabIndex={enabled && isTabStop && !showDrag ? 0 : -1}
+                    tabIndex={-1}
                     disabled={!enabled}
                     aria-label={t('field.occurrence.action.remove')}
                     onPointerDown={event => {
@@ -644,6 +803,7 @@ export const TagInput = ({
 }: TagInputProps): ReactElement => {
     const t = useI18n();
     const visibility = useValidationVisibility();
+    const isMobile = useSyncExternalStore(subscribeToMobileChanges, getIsMobile);
     const suggestionListId = `${SUGGESTION_LIST_ID}-${useId()}`;
     const [draft, setDraft] = useState('');
     const [isInputActive, setIsInputActive] = useState(false);
@@ -679,12 +839,17 @@ export const TagInput = ({
     const hiddenErrors = errors.filter((_, index) => !visibleTagIndexes.has(index));
     const visibleTagCount = tagEntries.length;
     const {canAdd, canRemove, showDrag} = getTagViewState(occurrences, enabled, visibleTagCount);
-    const showInlineInput = canAdd;
+    const maximum = occurrences.getMaximum();
+    const nextTagReachesMaximum = maximum > 0 && visibleTagCount + 1 >= maximum;
+    const enterKeyHint = isMobile ? (nextTagReachesMaximum ? 'next' : 'enter') : undefined;
     const isDraftInputVisible = isInputActive || draft.length > 0;
     const [dragContextKey, setDragContextKey] = useState(0);
     const [suggestions, setSuggestions] = useState<string[]>([]);
     const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
     const [touched, setTouched] = useState(false);
+    const [editingState, setEditingState] = useState<EditingState | null>(null);
+    const [editDraft, setEditDraft] = useState('');
+    const showInlineInput = canAdd && editingState == null;
     const sensors = useSensors(
         useSensor(PrimaryButtonMouseSensor, MOUSE_SENSOR_OPTIONS),
         useSensor(TouchSensor, HANDLE_TOUCH_SENSOR_OPTIONS),
@@ -693,7 +858,8 @@ export const TagInput = ({
 
     const ids = tagEntries.map(entry => entry.id);
     const normalizedDraft = normalizeTagDraft(draft);
-    const suggestionsVisible = enabled && canAdd && hasRenderableTagLabel(normalizedDraft) && suggestions.length > 0;
+    const suggestionsVisible =
+        editingState == null && enabled && canAdd && hasRenderableTagLabel(normalizedDraft) && suggestions.length > 0;
     const activeSuggestion =
         suggestionsVisible && activeSuggestionIndex >= 0 ? suggestions[activeSuggestionIndex] : undefined;
     const activeSuggestionId = activeSuggestion != null ? `${suggestionListId}-${activeSuggestionIndex}` : undefined;
@@ -701,6 +867,12 @@ export const TagInput = ({
         tagEntries.map(entry => entry.value),
         normalizedDraft,
     );
+    const normalizedEditDraft = normalizeTagDraft(editDraft);
+    const editingEntry = tagEntries.find(entry => entry.id === editingState?.id);
+    const isEditInvalid =
+        editingEntry != null &&
+        (!hasRenderableTagLabel(normalizedEditDraft) ||
+            hasTagLabel(values, normalizedEditDraft, editingEntry.originalIndex));
 
     const hasSuppressedHiddenEntries = hiddenErrors.some(
         entry => !entry.breaksRequired && entry.validationResults.length === 0,
@@ -783,6 +955,19 @@ export const TagInput = ({
         });
     };
 
+    const focusLabelAt = (index: number) => {
+        requestAnimationFrame(() => {
+            if (index < 0) {
+                return;
+            }
+            if (index >= visibleTagCount) {
+                inputRef.current?.focus();
+                return;
+            }
+            wrapperRef.current?.querySelectorAll<HTMLButtonElement>('[data-tag-label]').item(index)?.focus();
+        });
+    };
+
     const focusRemoveAt = (index: number) => {
         requestAnimationFrame(() => {
             if (index < 0) {
@@ -816,7 +1001,6 @@ export const TagInput = ({
         {focusTarget, clearDraft = false}: CommitTagLabelsOptions = {},
     ): CommitTagLabelsResult => {
         setTouched(true);
-        const maximum = occurrences.getMaximum();
         const remainingCapacity = maximum === 0 ? Number.POSITIVE_INFINITY : Math.max(maximum - visibleTagCount, 0);
 
         if (remainingCapacity === 0) {
@@ -846,6 +1030,10 @@ export const TagInput = ({
             return {committedCount: 0, usedHiddenSlots: 0};
         }
 
+        const nextVisibleTagCount = visibleTagCount + labelsToCommit.length;
+        const hasRoomForAnother = maximum === 0 || nextVisibleTagCount < maximum;
+        const nextFocusableElement =
+            isMobile && focusTarget != null && !hasRoomForAnother ? getNextFocusableElement(focusTarget) : undefined;
         const usedHiddenSlots = Math.min(Math.max(values.length - visibleTagCount, 0), labelsToCommit.length);
 
         if (usedHiddenSlots > 0) {
@@ -862,9 +1050,6 @@ export const TagInput = ({
             onAdd(nextValue);
         });
 
-        const nextVisibleTagCount = visibleTagCount + labelsToCommit.length;
-        const hasRoomForAnother = maximum === 0 || nextVisibleTagCount < maximum;
-
         if (clearDraft || !hasRoomForAnother) {
             setDraftValue('');
         }
@@ -878,7 +1063,11 @@ export const TagInput = ({
                 const lastTagIndex = nextVisibleTagCount - 1;
                 requestAnimationFrame(() => {
                     requestAnimationFrame(() => {
-                        (removeTagRefs.current[lastTagIndex] ?? tagRefs.current[lastTagIndex])?.focus();
+                        (
+                            nextFocusableElement ??
+                            removeTagRefs.current[lastTagIndex] ??
+                            tagRefs.current[lastTagIndex]
+                        )?.focus();
                     });
                 });
             }
@@ -961,7 +1150,7 @@ export const TagInput = ({
         if (direction === -1) {
             focusRemoveAt(index + direction);
         } else {
-            focusTagAt(index + direction);
+            focusLabelAt(index + direction);
         }
     };
 
@@ -975,6 +1164,102 @@ export const TagInput = ({
         focusTagAt(targetIndex);
     };
 
+    const startEditing = (id: string, label: string, selectText = true) => {
+        setEditingState({id, selectText});
+        setEditDraft(label);
+        setIsInputActive(false);
+    };
+
+    const cancelEditing = (focusIndex?: number) => {
+        setEditingState(null);
+        setEditDraft('');
+        if (focusIndex != null) {
+            focusLabelAt(focusIndex);
+        }
+    };
+
+    const focusDraftInput = () => {
+        setIsInputActive(true);
+        requestAnimationFrame(() => inputRef.current?.focus());
+    };
+
+    const commitEditing = (rawDraft: string, explicit = false, focusTarget?: HTMLInputElement): boolean => {
+        if (editingEntry == null) {
+            return false;
+        }
+
+        const normalized = normalizeTagDraft(rawDraft);
+        if (!hasRenderableTagLabel(normalized)) {
+            onRemove(editingEntry.originalIndex);
+            cancelEditing();
+            if (explicit) {
+                focusDraftInput();
+            }
+            return true;
+        }
+
+        if (hasTagLabel(values, normalized, editingEntry.originalIndex)) {
+            if (!explicit) {
+                cancelEditing();
+                return true;
+            }
+            return false;
+        }
+
+        const editingVisibleIndex = tagEntries.findIndex(entry => entry.id === editingEntry.id);
+        const nextFocusableElement =
+            explicit && isMobile && !canAdd && focusTarget != null ? getNextFocusableElement(focusTarget) : undefined;
+        const currentLabel = normalizeTagDraft(getTagLabel(editingEntry.value));
+        if (normalized !== currentLabel) {
+            onChange(editingEntry.originalIndex, ValueTypes.STRING.newValue(normalized), normalized);
+        }
+        cancelEditing();
+        if (explicit) {
+            if (canAdd) {
+                focusDraftInput();
+            } else {
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        (
+                            nextFocusableElement ??
+                            removeTagRefs.current[editingVisibleIndex] ??
+                            tagRefs.current[editingVisibleIndex]
+                        )?.focus();
+                    });
+                });
+            }
+        }
+        return true;
+    };
+
+    const removeEditingAndEditPrevious = () => {
+        if (editingEntry == null) {
+            return;
+        }
+
+        const visibleIndex = tagEntries.findIndex(entry => entry.id === editingEntry.id);
+        const previousEntry = tagEntries[visibleIndex - 1];
+        onRemove(editingEntry.originalIndex);
+
+        if (previousEntry != null) {
+            startEditing(previousEntry.id, getTagLabel(previousEntry.value));
+        } else {
+            cancelEditing();
+            focusDraftInput();
+        }
+    };
+
+    const editLastTagFromInput = (input: HTMLInputElement) => {
+        const lastEntry = tagEntries[visibleTagCount - 1];
+        if (lastEntry == null) {
+            return;
+        }
+
+        skipBlurCommit.current = true;
+        input.blur();
+        startEditing(lastEntry.id, getTagLabel(lastEntry.value));
+    };
+
     const handleFieldClick: preact.JSX.MouseEventHandler<HTMLElement> = event => {
         if (event.target === event.currentTarget) {
             handleFieldActivate();
@@ -986,6 +1271,10 @@ export const TagInput = ({
         label: getTagLabel(entry.value),
         error: getFirstError(errors[entry.originalIndex]?.validationResults ?? []),
         enabled,
+        editing: editingState?.id === entry.id,
+        editDraft,
+        editInvalid: editingState?.id === entry.id && isEditInvalid,
+        selectEditText: editingState?.selectText ?? true,
         isTabStop: !showInlineInput && !hasFocusWithin && index === visibleTagCount - 1,
         showDrag,
         showRemove: canRemove,
@@ -998,6 +1287,12 @@ export const TagInput = ({
         onNavigate: direction => handleTagNavigate(index, direction),
         onDragMove: direction => handleKeyboardDragMove(index, direction),
         onDeleteKey: () => handleRemove(entry.originalIndex, {focusPreviousTag: true}),
+        onEditStart: (initialDraft = getTagLabel(entry.value), selectText = true) =>
+            startEditing(entry.id, initialDraft, selectText),
+        onEditChange: setEditDraft,
+        onEditCommit: commitEditing,
+        onEditCancel: () => cancelEditing(index),
+        onEditRemovePrevious: removeEditingAndEditPrevious,
         onRemovePointerDown: prepareRemove,
         onRemoveKey: () => handleRemove(entry.originalIndex, {activateInput: true, commitCurrentDraft: true}),
         onRemove: () => handleRemove(entry.originalIndex, {commitCurrentDraft: true}),
@@ -1013,6 +1308,10 @@ export const TagInput = ({
     };
 
     const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLInputElement>) => {
+        if (isMobile && event.key === 'Enter') {
+            event.stopPropagation?.();
+        }
+
         if (suggestionsVisible && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
             event.preventDefault();
             setActiveSuggestionIndex(current => {
@@ -1041,13 +1340,20 @@ export const TagInput = ({
 
         if (visibleTagCount > 0 && isAtStart && (event.key === 'ArrowLeft' || event.key === 'ArrowUp')) {
             event.preventDefault();
-            commitAndLeaveInput(event.currentTarget, focusRemoveAt);
+            commitAndLeaveInput(
+                event.currentTarget,
+                event.key === 'ArrowLeft' && draftRef.current.length === 0 ? focusLabelAt : focusRemoveAt,
+            );
             return;
         }
 
         if (visibleTagCount > 0 && isAtStart && event.key === 'Backspace') {
             event.preventDefault();
-            commitAndLeaveInput(event.currentTarget, focusRemoveAt);
+            if (draftRef.current.length === 0) {
+                editLastTagFromInput(event.currentTarget);
+            } else {
+                commitAndLeaveInput(event.currentTarget, focusRemoveAt);
+            }
             return;
         }
 
@@ -1177,6 +1483,7 @@ export const TagInput = ({
                                 renderTagDraftInput({
                                     draft,
                                     accessibleName: getInputAccessibleName(input),
+                                    enterKeyHint,
                                     enabled,
                                     invalid: isDraftDuplicate,
                                     visible: isDraftInputVisible,

--- a/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
+++ b/src/main/resources/assets/admin/common/js/form2/components/tag-input/TagInput.tsx
@@ -61,6 +61,15 @@ export {
 const TAG_INPUT_NAME = 'TagInput';
 const SUGGESTION_LIST_ID = 'tag-input-suggestions';
 const SUGGESTION_DEBOUNCE_MS = 300;
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button',
+    'input:not([type="hidden"])',
+    'select',
+    'textarea',
+    '[contenteditable]:not([contenteditable="false"])',
+    '[tabindex]',
+].join(',');
 
 //
 // * Types
@@ -291,41 +300,67 @@ function getTagViewState(occurrences: Occurrences, enabled: boolean, valueCount:
     };
 }
 
-function getOrCreateTagId(idsByValue: WeakMap<Value, string>, nextId: RefObject<number>, value: Value): string {
-    let id = idsByValue.get(value);
-    if (id == null) {
-        id = `tag-${nextId.current}`;
-        nextId.current += 1;
-        idsByValue.set(value, id);
-    }
-    return id;
-}
-
 function focusElementNextFrame(element: HTMLElement | null | undefined): void {
     requestAnimationFrame(() => element?.focus());
 }
 
-function getNextFocusableElement(element: HTMLElement): HTMLElement | undefined {
-    const container = element.closest('[data-component="TagInput"]');
-    const focusableElements = Array.from(
-        element.ownerDocument.querySelectorAll<HTMLElement>(
-            'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])',
-        ),
-    );
-    const currentIndex = focusableElements.indexOf(element);
-    if (currentIndex < 0) {
-        return undefined;
+function isTabTarget(element: HTMLElement): boolean {
+    if (!element.isConnected || element.tabIndex < 0 || element.matches(':disabled')) {
+        return false;
     }
 
-    return focusableElements
-        .slice(currentIndex + 1)
-        .find(
-            candidate =>
-                !container?.contains(candidate) &&
-                candidate.tabIndex >= 0 &&
-                !candidate.hidden &&
-                !('disabled' in candidate && candidate.disabled === true),
-        );
+    if (element.closest('[hidden], [inert]') != null) {
+        return false;
+    }
+
+    const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+    if (style?.display === 'none' || style?.visibility === 'hidden' || style?.visibility === 'collapse') {
+        return false;
+    }
+
+    return element.getClientRects().length > 0;
+}
+
+function getNextFocusableElements(element: HTMLElement): HTMLElement[] {
+    const container = element.closest('[data-component="TagInput"]');
+    const focusableElements = Array.from(element.ownerDocument.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+        .map((candidate, domIndex) => ({candidate, domIndex}))
+        .sort((first, second) => {
+            const firstTabIndex = first.candidate.tabIndex;
+            const secondTabIndex = second.candidate.tabIndex;
+            const firstIsPositive = firstTabIndex > 0;
+            const secondIsPositive = secondTabIndex > 0;
+
+            if (firstIsPositive && secondIsPositive && firstTabIndex !== secondTabIndex) {
+                return firstTabIndex - secondTabIndex;
+            }
+            if (firstIsPositive !== secondIsPositive) {
+                return firstIsPositive ? -1 : 1;
+            }
+            return first.domIndex - second.domIndex;
+        })
+        .map(({candidate}) => candidate);
+    const currentIndex = focusableElements.indexOf(element);
+    if (currentIndex < 0) {
+        return [];
+    }
+
+    return focusableElements.slice(currentIndex + 1).filter(candidate => !container?.contains(candidate));
+}
+
+function focusFirstAvailable(candidates: HTMLElement[]): boolean {
+    for (const candidate of candidates) {
+        if (!isTabTarget(candidate)) {
+            continue;
+        }
+
+        candidate.focus();
+        if (candidate.ownerDocument.activeElement === candidate) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 function clearCleanupRef(cleanupRef: RefObject<(() => void) | null>): void {
@@ -737,6 +772,7 @@ const TagItem = ({
                     className={cn('h-5 w-36 bg-transparent font-semibold outline-none', editInvalid && 'text-error')}
                     value={editDraft}
                     disabled={!enabled}
+                    aria-label={`${t('action.edit')}: ${label}`}
                     aria-invalid={editInvalid || undefined}
                     onChange={event => onEditChange(event.currentTarget.value)}
                     onKeyDown={handleEditKeyDown}
@@ -790,6 +826,7 @@ const TagItem = ({
 //
 
 export const TagInput = ({
+    occurrenceIds,
     values,
     onChange,
     onAdd,
@@ -814,8 +851,6 @@ export const TagInput = ({
     const removeTagRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const draftRef = useRef(draft);
     const skipBlurCommit = useRef(false);
-    const idsByValue = useRef(new WeakMap<Value, string>());
-    const nextId = useRef(0);
     const isDraggingRef = useRef(false);
     const dragScrollListener = useDragScrollListener();
     draftRef.current = draft;
@@ -827,7 +862,7 @@ export const TagInput = ({
         entries.push({
             value,
             originalIndex: index,
-            id: getOrCreateTagId(idsByValue.current, nextId, value),
+            id: occurrenceIds[index],
         });
 
         return entries;
@@ -1032,8 +1067,8 @@ export const TagInput = ({
 
         const nextVisibleTagCount = visibleTagCount + labelsToCommit.length;
         const hasRoomForAnother = maximum === 0 || nextVisibleTagCount < maximum;
-        const nextFocusableElement =
-            isMobile && focusTarget != null && !hasRoomForAnother ? getNextFocusableElement(focusTarget) : undefined;
+        const nextFocusableElements =
+            isMobile && focusTarget != null && !hasRoomForAnother ? getNextFocusableElements(focusTarget) : [];
         const usedHiddenSlots = Math.min(Math.max(values.length - visibleTagCount, 0), labelsToCommit.length);
 
         if (usedHiddenSlots > 0) {
@@ -1063,11 +1098,9 @@ export const TagInput = ({
                 const lastTagIndex = nextVisibleTagCount - 1;
                 requestAnimationFrame(() => {
                     requestAnimationFrame(() => {
-                        (
-                            nextFocusableElement ??
-                            removeTagRefs.current[lastTagIndex] ??
-                            tagRefs.current[lastTagIndex]
-                        )?.focus();
+                        if (!focusFirstAvailable(nextFocusableElements)) {
+                            (removeTagRefs.current[lastTagIndex] ?? tagRefs.current[lastTagIndex])?.focus();
+                        }
                     });
                 });
             }
@@ -1150,7 +1183,7 @@ export const TagInput = ({
         if (direction === -1) {
             focusRemoveAt(index + direction);
         } else {
-            focusLabelAt(index + direction);
+            focusTagAt(index + direction);
         }
     };
 
@@ -1207,8 +1240,8 @@ export const TagInput = ({
         }
 
         const editingVisibleIndex = tagEntries.findIndex(entry => entry.id === editingEntry.id);
-        const nextFocusableElement =
-            explicit && isMobile && !canAdd && focusTarget != null ? getNextFocusableElement(focusTarget) : undefined;
+        const nextFocusableElements =
+            explicit && isMobile && !canAdd && focusTarget != null ? getNextFocusableElements(focusTarget) : [];
         const currentLabel = normalizeTagDraft(getTagLabel(editingEntry.value));
         if (normalized !== currentLabel) {
             onChange(editingEntry.originalIndex, ValueTypes.STRING.newValue(normalized), normalized);
@@ -1220,11 +1253,11 @@ export const TagInput = ({
             } else {
                 requestAnimationFrame(() => {
                     requestAnimationFrame(() => {
-                        (
-                            nextFocusableElement ??
-                            removeTagRefs.current[editingVisibleIndex] ??
-                            tagRefs.current[editingVisibleIndex]
-                        )?.focus();
+                        if (!focusFirstAvailable(nextFocusableElements)) {
+                            (
+                                removeTagRefs.current[editingVisibleIndex] ?? tagRefs.current[editingVisibleIndex]
+                            )?.focus();
+                        }
                     });
                 });
             }

--- a/src/main/resources/assets/admin/common/js/form2/types.ts
+++ b/src/main/resources/assets/admin/common/js/form2/types.ts
@@ -42,6 +42,7 @@ export type InputTypeComponent<C extends InputTypeConfig = InputTypeConfig> = Co
 
 /** Props for self-managed input type components (e.g. ComboBox) that handle their own multi-value UI. */
 export type SelfManagedComponentProps<C extends InputTypeConfig = InputTypeConfig> = {
+    occurrenceIds: string[];
     values: Value[];
     onChange: (index: number, value: Value, rawValue?: string) => void;
     onBlur?: (index: number) => void;


### PR DESCRIPTION
### Description

TagInput needs predictable mobile focus behavior and accessible tag editing.

### Required behavior
- Mobile completion adds tag and keeps draft input active while more tags are allowed.
- Mobile completion moves to next focusable field only when committed tag reaches configured maximum.
- Unlimited TagInput never moves automatically.
- Desktop completion behavior stays unchanged.

### Tag editing
- Clicking tag label opens inline editor.
- Empty draft Backspace edits last tag.
- Editor receives focus immediately.
- Existing text selected when editing starts.
- Clearing tag and pressing Backspace removes it, then edits previous tag.
- Clearing tag and leaving editor removes tag without restoring stale value.
- Successful edit returns to draft input when another tag can be added.
- At maximum, mobile Enter moves to next focusable field.
- Escape cancels edit and restores label focus.
- Reopening editor after Enter/Escape must not suppress next blur commit.

### Keyboard accessibility
Keep one Tab stop for whole TagInput:
- Draft input while adding remains possible.
- Last tag label when maximum reached.

Arrow navigation:

**_drag handle → tag label → remove button → next tag_**

Focused label behavior:
- Enter or Space: edit existing value with text selected.
- Printable key: replace value with typed character and place caret after it.
- Arrow keys: continue control navigation.
- ArrowLeft from empty draft: focus last tag label.
- Accessible label: Edit: <tag value>.
Preserve keyboard drag mode and Backspace editing chain.